### PR TITLE
Slurpit one to many support

### DIFF
--- a/examples/slurpit_to_infrahub/config.yml
+++ b/examples/slurpit_to_infrahub/config.yml
@@ -129,6 +129,9 @@ schema_mapping:
         mapping: Version
       - name: file
         mapping: File
+      - name: devices
+        mapping: hostname
+        reference: InfraDevice
 
   - name: InfraVLAN
     identifiers: ['vlan_id', "name"]

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -57,6 +57,7 @@ def update_node(node: InfrahubNodeSync, attrs: dict) -> InfrahubNodeSync:
                     for existing_id in existing_only:
                         attr.remove(existing_id)
 
+                    attr.fetch()
                     for new_id in new_only:
                         attr.add(new_id)
 
@@ -208,7 +209,8 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
             elif rel_schema.cardinality == "many":
                 values = []
                 rel_manager = getattr(node, rel_schema.name)
-                for peer in rel_manager:
+                rel_manager.fetch()
+                for peer in rel_manager.peers:
                     peer_node = self.client.store.get(key=peer.id, kind=rel_schema.peer)
                     peer_data = self.infrahub_node_to_diffsync(node=peer_node)
                     peer_model = getattr(self, rel_schema.peer)

--- a/infrahub_sync/adapters/slurpitsync.py
+++ b/infrahub_sync/adapters/slurpitsync.py
@@ -259,7 +259,7 @@ class SlurpitsyncAdapter(DiffSyncMixin, Adapter):
                         f" The available models are {self.store.get_all_model_names()}"
                     )
                 if not field_is_list:
-                    if node := obj[field.mapping]:
+                    if node := obj.get(field.mapping):
                         matching_nodes = []
                         node_id = self.build_mapping(reference=field.reference, obj=obj)
                         matching_nodes = [item for item in nodes if str(item) == node_id]

--- a/infrahub_sync/adapters/slurpitsync.py
+++ b/infrahub_sync/adapters/slurpitsync.py
@@ -271,6 +271,17 @@ class SlurpitsyncAdapter(DiffSyncMixin, Adapter):
                             # raise IndexError(f"Unable to locate the node {field.reference} {node_id}")
                         node = matching_nodes[0]
                         data[field.name] = node.get_unique_id()
+                else:
+                    data[field.name] = []
+                    if node := obj.get(field.mapping):
+                        node_id = self.build_mapping(reference=field.reference, obj=obj)
+                        matching_nodes = [item for item in nodes if str(item) == node_id]
+                        if len(matching_nodes) == 0:
+                            self.skipped.append(node)
+                            continue
+                            # raise IndexError(f"Unable to locate the node {field.reference} {node_id}")
+                        data[field.name].append(matching_nodes[0].get_unique_id())
+                    data[field.name] = sorted(data[field.name])
         return data
 
 


### PR DESCRIPTION
Enable one to many schema support in the slurpit adapter. 
Fix issue with infrahub adapter not pulling and syncing peers. 