### PR TITLE
Update __init__.py

### DIFF
--- a/infrahub_sync/__init__.py
+++ b/infrahub_sync/__init__.py
@@ -140,8 +140,9 @@ class DiffSyncModelMixin:
             # Render the template using the item's context
             transformed_value = template.render(**item)
 
-            # Assign the result back to the item
-            item[field] = transformed_value
+            # Assign the result back to the item if not empty
+            if transformed_value != "":
+                item[field] = transformed_value
         except Exception as exc:
             raise ValueError(f"Failed to transform '{field}' with '{transform_expr}': {exc}") from exc
 


### PR DESCRIPTION
Assign the result of a transform only if the result is not empty to avoid import errors on list or regex fields

Exemple of this issue with a transform of a Time Zone value named time_zone:
- The transform in the sync configuration file
![sync_file](https://github.com/user-attachments/assets/51f42572-7f9f-42bf-a38d-48240946e716)
- The error raised by GraphSQL because the Jinja transform sends back "" and not a "None type" object
![image](https://github.com/user-attachments/assets/b75b1358-ce97-46bf-8246-59b6db28f370)
