### PR TITLE
feat: Add skip_unmatched_source option 

### DIFF
--- a/docs/docs/reference/config.mdx
+++ b/docs/docs/reference/config.mdx
@@ -23,6 +23,7 @@ Describes the overall synchronization    configuration.
 | destination | SyncAdapter | Configuration for the destination adapter. | Yes |
 | order | List of strings | Specifies the order in which objects should be synchronized. | Yes |
 | schema_mapping | List of SchemaMappingModel | Defines how data is mapped from source to destination. | Yes |
+| skip_unmatched_source | boolean | If set to `true`, Source records will not be compared if they do not exist in the Destination | No |
 
 ### Sync store
 

--- a/docs/docs/reference/config.mdx
+++ b/docs/docs/reference/config.mdx
@@ -17,13 +17,13 @@ Describes the overall synchronization    configuration.
 
 | Property | Type | Description | Mandatory |
 | -------- | ---- | ----------- | --------- |
-| name | string | Unique identifier for the sync instance. | Yes |
-| store | SyncStore | Configuration for the optional storage mechanism. | No |
-| source | SyncAdapter | Configuration for the source adapter. | Yes |
-| destination | SyncAdapter | Configuration for the destination adapter. | Yes |
-| order | List of strings | Specifies the order in which objects should be synchronized. | Yes |
-| schema_mapping | List of SchemaMappingModel | Defines how data is mapped from source to destination. | Yes |
-| skip_unmatched_source | boolean | If set to `true`, Source records will not be compared if they do not exist in the Destination | No |
+| `name` | string | Unique identifier for the sync instance. | Yes |
+| `store` | SyncStore | Configuration for the optional storage mechanism. | No |
+| `source` | SyncAdapter | Configuration for the source adapter. | Yes |
+| `destination` | SyncAdapter | Configuration for the destination adapter. | Yes |
+| `order` | List of strings | Specifies the order in which objects should be synchronized. | Yes |
+| `schema_mapping` | List of SchemaMappingModel | Defines how data is mapped from source to destination. | Yes |
+| `skip_unmatched_source` | boolean | If set to `true`, Source records will not be compared if they do not exist in the Destination | No |
 
 ### Sync store
 

--- a/infrahub_sync/__init__.py
+++ b/infrahub_sync/__init__.py
@@ -55,6 +55,7 @@ class SyncConfig(pydantic.BaseModel):
     destination: SyncAdapter
     order: list[str] = pydantic.Field(default_factory=list)
     schema_mapping: list[SchemaMappingModel] = []
+    skip_unmatched_source: bool = pydantic.Field(default=False)
 
 
 class SyncInstance(SyncConfig):

--- a/infrahub_sync/potenda/__init__.py
+++ b/infrahub_sync/potenda/__init__.py
@@ -37,7 +37,11 @@ class Potenda:
         self.progress_bar = None
         self.show_progress = show_progress
         enable_console_logging(verbosity=1)
-        self.flags = DiffSyncFlags.SKIP_UNMATCHED_DST
+        self.flags = (
+            DiffSyncFlags.SKIP_UNMATCHED_BOTH
+            if self.config.skip_unmatched_destination
+            else DiffSyncFlags.SKIP_UNMATCHED_DST
+        )
 
     def _print_callback(self, stage: str, elements_processed: int, total_models: int):
         """Callback for DiffSync using tqdm"""


### PR DESCRIPTION
This feature allows the infrahub-sync to ignore source records that do not already exist in the destination, allowing for more granular behavior. 

This is useful when the source has a large number of records that do not need to be in the destination, but has records with updated or different information to by compared and synced. 

This fulfills https://github.com/opsmill/infrahub-sync/issues/64