### PR TITLE
Fix invalid reference logic.

### DIFF
--- a/infrahub_sync/adapters/ipfabricsync.py
+++ b/infrahub_sync/adapters/ipfabricsync.py
@@ -21,6 +21,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
+from infrahub_sync.adapters.utils import build_mapping
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -55,31 +56,6 @@ class IpfabricsyncAdapter(DiffSyncMixin, Adapter):
             raise ValueError(msg)
 
         return IPFClient(base_url=base_url, auth=auth, timeout=timeout, verify=verify_ssl)
-
-    def build_mapping(self, reference, obj) -> str:
-        # Get object class and model name from the store
-        object_class, modelname = self.store._get_object_class_and_model(model=reference)
-
-        # Find the schema element matching the model name
-        schema_element = next(
-            (element for element in self.config.schema_mapping if element.name == modelname),
-            None,
-        )
-
-        # Collect all relevant field mappings for identifiers
-        new_identifiers = []
-
-        # Convert schema_element.fields to a dictionary for fast lookup
-        field_dict = {field.name: field.mapping for field in schema_element.fields}
-
-        # Loop through object_class._identifiers to find corresponding field mappings
-        for identifier in object_class._identifiers:
-            if identifier in field_dict:
-                new_identifiers.append(field_dict[identifier])
-
-        # Construct the unique identifier, using a fallback if a key isn't found
-        unique_id = "__".join(str(obj.get(key, "")) for key in new_identifiers)
-        return unique_id
 
     def model_loader(self, model_name: str, model: IpfabricsyncModel) -> None:
         """
@@ -143,7 +119,7 @@ class IpfabricsyncAdapter(DiffSyncMixin, Adapter):
                     raise IndexError(msg)
                 if not field_is_list and (node := obj[field.mapping]):
                     matching_nodes = []
-                    node_id = self.build_mapping(reference=field.reference, obj=obj)
+                    node_id = build_mapping(adapter=self, reference=field.reference, obj=obj, field=field)
                     matching_nodes = [item for item in nodes if str(item) == node_id]
                     if len(matching_nodes) == 0:
                         data[field.name] = None

--- a/infrahub_sync/adapters/slurpitsync.py
+++ b/infrahub_sync/adapters/slurpitsync.py
@@ -18,8 +18,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
-
-from .utils import get_value
+from infrahub_sync.adapters.utils import build_mapping
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -220,32 +219,6 @@ class SlurpitsyncAdapter(DiffSyncMixin, Adapter):
         if self.skipped:
             print(f"{self.type}: skipped syncing {len(self.skipped)} models")
 
-    # Reuse mapping from another adapter
-    def build_mapping(self, reference, obj):
-        # Get object class and model name from the store
-        object_class, modelname = self.store._get_object_class_and_model(model=reference)
-
-        # Find the schema element matching the model name
-        schema_element = next(
-            (element for element in self.config.schema_mapping if element.name == modelname),
-            None,
-        )
-
-        # Collect all relevant field mappings for identifiers
-        new_identifiers = []
-
-        # Convert schema_element.fields to a dictionary for fast lookup
-        field_dict = {field.name: field.mapping for field in schema_element.fields}
-
-        # Loop through object_class._identifiers to find corresponding field mappings
-        for identifier in object_class._identifiers:
-            if identifier in field_dict:
-                new_identifiers.append(field_dict[identifier])
-
-        # Construct the unique identifier, using a fallback if a key isn't found
-        unique_id = "__".join(str(obj.get(key, "")) for key in new_identifiers)
-        return unique_id
-
     def slurpit_obj_to_diffsync(
         self, obj: dict[str, Any], mapping: SchemaMappingModel, model: SlurpitsyncModel
     ) -> dict:
@@ -276,7 +249,7 @@ class SlurpitsyncAdapter(DiffSyncMixin, Adapter):
                 if not field_is_list:
                     if node := obj.get(field.mapping):
                         matching_nodes = []
-                        node_id = self.build_mapping(reference=field.reference, obj=obj)
+                        node_id = build_mapping(adapter=self, reference=field.reference, obj=obj)
                         matching_nodes = [item for item in nodes if str(item) == node_id]
                         if len(matching_nodes) == 0:
                             self.skipped.append(node)

--- a/infrahub_sync/adapters/slurpitsync.py
+++ b/infrahub_sync/adapters/slurpitsync.py
@@ -18,7 +18,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
-from infrahub_sync.adapters.utils import build_mapping
+from infrahub_sync.adapters.utils import build_mapping, get_value
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/infrahub_sync/adapters/utils.py
+++ b/infrahub_sync/adapters/utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from diffsync import Adapter
+if TYPE_CHECKING:
+    from diffsync import Adapter
 
 
 def build_mapping(adapter: Adapter, reference: str, obj, field) -> str:
@@ -16,9 +17,11 @@ def build_mapping(adapter: Adapter, reference: str, obj, field) -> str:
         None,
     )
     if not schema_element:
-        raise ValueError(
-            f"Schema mapping for model '{reference}' not found when attempting to resolve reference for {field.name}. The reference must be an existing schema mapping."
+        msg = (
+            f"Schema mapping for model '{reference}' not found when attempting to resolve "
+            f"reference for {field.name}. The reference must be an existing schema mapping."
         )
+        raise ValueError(msg)
 
     # Collect all relevant field mappings for identifiers
     new_identifiers = []

--- a/infrahub_sync/adapters/utils.py
+++ b/infrahub_sync/adapters/utils.py
@@ -2,6 +2,39 @@ from __future__ import annotations
 
 from typing import Any
 
+from diffsync import Adapter
+
+
+def build_mapping(adapter: Adapter, reference: str, obj, field) -> str:
+    """This is used when references are encountered to attempt to resolve them for mapping."""
+    # Get object class and model name from the store
+    object_class, modelname = adapter.store._get_object_class_and_model(model=reference)
+
+    # Find the schema element matching the model name
+    schema_element = next(
+        (element for element in adapter.config.schema_mapping if element.name == modelname),
+        None,
+    )
+    if not schema_element:
+        raise ValueError(
+            f"Schema mapping for model '{reference}' not found when attempting to resolve reference for {field.name}. The reference must be an existing schema mapping."
+        )
+
+    # Collect all relevant field mappings for identifiers
+    new_identifiers = []
+
+    # Convert schema_element.fields to a dictionary for fast lookup
+    field_dict = {field.name: field.mapping for field in schema_element.fields}
+
+    # Loop through object_class._identifiers to find corresponding field mappings
+    for identifier in object_class._identifiers:
+        if identifier in field_dict:
+            new_identifiers.append(field_dict[identifier])
+
+    # Construct the unique identifier, using a fallback if a key isn't found
+    unique_id = "__".join(str(obj.get(key, "")) for key in new_identifiers)
+    return unique_id
+
 
 def get_value(obj: Any, name: str) -> Any | None:
     """Query a value in dot notation recursively"""


### PR DESCRIPTION
- Moved 'build_mapping' to utils.py since it's used in two different spots.
- Added exception raising if no schema_element is found and properly report it.

The newly returned error message looks like:

`Error: An error occurred while loading IPFabricsync: Schema mapping for model 'InfraNOSVersion' not found when attempting to resolve reference for os_version.`