### PR TITLE
ipfabric: Add logic to fetch URL and token from environment variables.

### DIFF
--- a/infrahub_sync/adapters/ipfabricsync.py
+++ b/infrahub_sync/adapters/ipfabricsync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -48,7 +49,14 @@ class IpfabricsyncAdapter(DiffSyncMixin, Adapter):
         settings = adapter.settings or {}
 
         base_url = settings.get("base_url", None)
+        if not base_url:
+            base_url = os.environ.get("IPF_URL", None)
+            settings["base_url"] = base_url
+
         auth = settings.get("auth", None)
+        if not auth:
+            auth = os.environ.get("IPF_TOKEN", None)
+            settings["auth"] = auth
 
         if not base_url or not auth:
             msg = "Both url and auth must be specified!"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback to environment variables for configuration: uses IPF_URL when base URL is missing and IPF_TOKEN when authentication is missing, storing them into settings.
* **Bug Fixes**
  * Improved configuration validation: if required values are still missing after fallback, the system now raises a clear error (“Both url and auth must be specified!”), preventing silent misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->