### PR TITLE
ipfabric: Update auth error message.

### DIFF
--- a/infrahub_sync/adapters/ipfabricsync.py
+++ b/infrahub_sync/adapters/ipfabricsync.py
@@ -59,7 +59,7 @@ class IpfabricsyncAdapter(DiffSyncMixin, Adapter):
             settings["auth"] = auth
 
         if not base_url or not auth:
-            msg = "Both url and auth must be specified!"
+            msg = "Both url and auth must be specified! Please specify in the config or using `IPF_URL` and `IPF_TOKEN` environment variables."
             raise ValueError(msg)
 
         return IPFClient(**settings)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message when IP Fabric connection details are missing. The message now clearly instructs how to provide the base URL and token via configuration or the IPF_URL/IPF_TOKEN environment variables, making setup issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->