### PR TITLE
updated the ipfabric example to work with IPF 7+

### DIFF
--- a/examples/ipfabric_to_infrahub/config.yml
+++ b/examples/ipfabric_to_infrahub/config.yml
@@ -70,7 +70,8 @@ schema_mapping:
     filters:
       - field: version
         operation: is_not_empty
-    mapping: tables/management/osver-consistency
+    # mapping: tables/management/osver-consistency # This is for version <7.0 of IPFabric.
+    mapping: tables/inventory/os-version-consistency/platforms # This is for versions >= 7.0 of IPFabric.
     fields:
       - name: version
         mapping: version


### PR DESCRIPTION
fixed the issue in 
https://github.com/opsmill/infrahub-sync/issues/102

Works with IPfabric 7.0+

Tested on IPFabric 7.3.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version data mapping configuration in the IP Fabric to Infrahub integration example. This modifies how NOS version information is sourced and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->