### PR TITLE
docs: add Infrahub Sync release notes for 1.5.6, 1.6.0, and 2.0.0

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -152,3 +152,5 @@ vscode
 VSCode
 Yaml
 yamllint
+ty
+formatters

--- a/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
@@ -20,4 +20,4 @@ title: Release 1.5.6
 
 ## Fixed
 
-- Fixed Slurp’it interface processing so interface records are loaded one at a time instead of concurrently. This removes a race in interface handling and makes Slurp’it sync runs more predictable. ([#115](https://github.com/opsmill/infrahub-sync/pull/115))
+- Fixed Slurp’it interface processing so interface records load one at a time instead of concurrently. This removes a race in interface handling. Slurp’it sync runs now have deterministic interface processing. ([#115](https://github.com/opsmill/infrahub-sync/pull/115))

--- a/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
@@ -1,0 +1,23 @@
+---
+title: Release 1.5.6
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.5.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>February 18th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[1.5.6](https://github.com/opsmill/infrahub-sync/releases/tag/1.5.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Fixed
+
+- Fixed Slurp’it interface processing so interface records are loaded one at a time instead of concurrently. This removes a race in interface handling and makes Slurp’it sync runs more predictable. ([#115](https://github.com/opsmill/infrahub-sync/pull/115))

--- a/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx
@@ -20,4 +20,4 @@ title: Release 1.5.6
 
 ## Fixed
 
-- Fixed Slurp’it interface processing so interface records load one at a time instead of concurrently. This removes a race in interface handling. Slurp’it sync runs now have deterministic interface processing. ([#115](https://github.com/opsmill/infrahub-sync/pull/115))
+- Fixed a race in the Slurp’it adapter by processing interface records sequentially instead of concurrently. Slurp’it sync runs now produce deterministic interface output. ([#115](https://github.com/opsmill/infrahub-sync/pull/115))

--- a/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
@@ -18,17 +18,17 @@ title: Release 1.6.0
   </tbody>
 </table>
 
-We're excited to announce the release of Infrahub Sync, v1.6.0!
+Infrahub Sync 1.6.0 is available.
 
-This release makes Infrahub Sync cleaner to run from automation. CLI, engine, and adapter messages now use Python logging instead of direct terminal printing. New verbosity and progress controls help keep scheduled runs quiet while preserving useful output for interactive troubleshooting.
+This release updates CLI, engine, and adapter messages to use Python logging instead of direct terminal printing. It also adds verbosity and progress controls for scheduled runs and interactive troubleshooting.
 
 ## Main changes
 
 ### Automation-friendly logging
 
-Infrahub Sync no longer mixes plain printed lines with application logs during a run. Teams embedding Infrahub Sync in Python automation, CI, cron, or workflow schedulers can keep one consistent logging path.
+Infrahub Sync no longer mixes plain printed lines with application logs during a run. If you embed Infrahub Sync in Python automation, CI, cron, or workflow schedulers, use one consistent logging path.
 
-The package CLI, sync engine, and built-in adapters now emit operational messages through Python logging. The default CLI format remains human-readable, while embedded usage can attach custom handlers and formatters.
+The package CLI, sync engine, and built-in adapters now emit operational messages through Python logging. The default CLI format remains human-readable. Embedded usage can attach custom handlers and formatters.
 
 ### Verbosity and progress controls
 

--- a/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
@@ -1,0 +1,64 @@
+---
+title: Release 1.6.0
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.6.0</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>March 26th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[1.6.0](https://github.com/opsmill/infrahub-sync/releases/tag/1.6.0)</td>
+    </tr>
+  </tbody>
+</table>
+
+We're excited to announce the release of Infrahub Sync, v1.6.0!
+
+This release makes Infrahub Sync cleaner to run from automation. CLI, engine, and adapter messages now use Python logging instead of direct terminal printing. New verbosity and progress controls help keep scheduled runs quiet while preserving useful output for interactive troubleshooting.
+
+## Main changes
+
+### Automation-friendly logging
+
+Infrahub Sync no longer mixes plain printed lines with application logs during a run. Teams embedding Infrahub Sync in Python automation, CI, cron, or workflow schedulers can keep one consistent logging path.
+
+The package CLI, sync engine, and built-in adapters now emit operational messages through Python logging. The default CLI format remains human-readable, while embedded usage can attach custom handlers and formatters.
+
+### Verbosity and progress controls
+
+The CLI now includes global verbosity controls:
+
+```bash
+infrahub-sync --verbosity quiet ...
+infrahub-sync --verbosity verbose ...
+infrahub-sync -q ...
+infrahub-sync -v ...
+```
+
+Commands that show progress now support `--show-progress / --no-show-progress`. Progress bars are auto-detected for interactive terminals by default. Use `--no-show-progress` in automation that needs stable, parseable output.
+
+## Upgrade notes
+
+- No configuration changes are required.
+- Review any scripts that parse human-readable output from `list`, `diff`, `sync`, or `generate`. Operational messages now flow through Python logging.
+- Use `--quiet`, `--verbose`, or `--verbosity` to tune log volume for automation and troubleshooting.
+- Use `--no-show-progress` in non-interactive environments that require stable log output.
+
+## Full changelog
+
+### Added
+
+- Added global `--verbosity`, `--verbose`/`-v`, and `--quiet`/`-q` controls. ([#117](https://github.com/opsmill/infrahub-sync/pull/117))
+- Added `--show-progress / --no-show-progress` to `diff` and `sync`, with terminal auto-detection by default. ([#117](https://github.com/opsmill/infrahub-sync/pull/117))
+
+### Changed
+
+- Replaced direct `print()` and Rich console output with Python logging in the package CLI, sync engine, and built-in adapters. ([#117](https://github.com/opsmill/infrahub-sync/pull/117))
+- Updated adapter documentation command examples from Poetry to uv. ([#117](https://github.com/opsmill/infrahub-sync/pull/117))
+- Updated development guidance for the uv-based workflow and Python 3.13 support. ([#117](https://github.com/opsmill/infrahub-sync/pull/117))

--- a/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
@@ -26,9 +26,9 @@ This release updates CLI, engine, and adapter messages to use Python logging ins
 
 ### Automation-friendly logging
 
-Infrahub Sync no longer mixes plain printed lines with application logs during a run. If you embed Infrahub Sync in Python automation, CI, cron, or workflow schedulers, use one consistent logging path.
+The package CLI, sync engine, and built-in adapters now emit operational messages through Python logging instead of writing directly to the terminal. A run produces one consistent log stream rather than a mix of printed lines and application logs.
 
-The package CLI, sync engine, and built-in adapters now emit operational messages through Python logging. The default CLI format remains human-readable. Embedded usage can attach custom handlers and formatters.
+The default CLI format remains human-readable. When you embed Infrahub Sync in Python automation, CI, cron, or workflow schedulers, attach your own handlers and formatters to route logs alongside the rest of your pipeline.
 
 ### Verbosity and progress controls
 

--- a/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx
@@ -41,7 +41,7 @@ infrahub-sync -q ...
 infrahub-sync -v ...
 ```
 
-Commands that show progress now support `--show-progress / --no-show-progress`. Progress bars are auto-detected for interactive terminals by default. Use `--no-show-progress` in automation that needs stable, parseable output.
+Commands that show progress now support `--show-progress / --no-show-progress`. Progress bars are auto-detected for interactive terminals by default. Use `--no-show-progress` in automation that needs stable, machine-readable output.
 
 ## Upgrade notes
 

--- a/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
@@ -20,9 +20,9 @@ title: Release 2.0.0
 
 Infrahub Sync 2.0.0 is available.
 
-This release changes how Infrahub Sync handles large and recurring sync runs. It can derive write order from schema mappings, load source and destination data concurrently, write cache artifacts for each run, and use incremental extraction on warm runs for supported adapters.
+This release changes how Infrahub Sync handles large and recurring sync runs. It derives write order from schema mappings. It loads source and destination data concurrently. It writes cache artifacts for each run. And on supported adapters, warm runs can extract incrementally.
 
-Use these changes to reduce configuration for large dependency graphs, reduce load time for recurring syncs, and catch suspicious source-side changes before they affect the destination.
+Together, these changes reduce configuration for large dependency graphs, cut load time on recurring syncs, and surface suspicious source-side changes before they reach the destination.
 
 ## Main changes
 
@@ -45,7 +45,7 @@ uv run infrahub-sync diff --name from-netbox --directory examples/
 duckdb -c "SELECT action, resource, source_id FROM read_parquet('.infrahub-sync-cache/from-netbox/<run-id>/plan.parquet') LIMIT 20"
 ```
 
-The new `apply` command introduces the foundation for replaying a cached plan without extracting the source again. In 2.0.0, this requires destination adapter support for cached-row application. Use `sync` for built-in adapter workflows until that support is available. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
+The new `apply` command is the first step toward replaying a cached plan directly from cache, with no second extraction from the source. In 2.0.0, this requires destination adapter support for cached-row application. Use `sync` for built-in adapter workflows until that support lands. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
 
 ### Faster recurring syncs
 
@@ -70,7 +70,7 @@ The new `--continue-on-error` flag logs and skips peer relationships whose ident
 
 The development workflow now uses [ty](https://github.com/astral-sh/ty) instead of mypy. The `invoke lint` workflow runs ty alongside ruff, pylint, and yamllint. The repository no longer carries ty override blocks to hide diagnostics.
 
-During the migration, type fixes removed failure paths in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
+Fixing the type errors surfaced by the migration also resolved latent runtime issues in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
 
 ## Upgrade notes
 

--- a/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
@@ -18,36 +18,38 @@ title: Release 2.0.0
   </tbody>
 </table>
 
-We're excited to announce the release of Infrahub Sync, v2.0.0!
+Infrahub Sync 2.0.0 is available.
 
-This release focuses on making large and recurring sync runs easier to operate. Infrahub Sync can now derive write order from schema mappings, load source and destination data concurrently, write inspectable cache artifacts, and use incremental extraction on warm runs for supported adapters.
+This release changes how Infrahub Sync handles large and recurring sync runs. It can derive write order from schema mappings, load source and destination data concurrently, write cache artifacts for each run, and use incremental extraction on warm runs for supported adapters.
 
-Together, these changes reduce manual configuration work for large dependency graphs, reduce load time for recurring syncs, and add guardrails that help operators catch suspicious source-side changes before they affect the destination.
+Use these changes to reduce configuration for large dependency graphs, reduce load time for recurring syncs, and catch suspicious source-side changes before they affect the destination.
 
 ## Main changes
 
 ### Less manual ordering for large syncs
 
-Infrahub Sync can now compute sync order from `reference` relationships in `schema_mapping`, so most projects no longer need a manually maintained `order` list in `config.yml`. The engine builds a dependency graph, groups kinds into tiers, and writes one tier at a time.
+Infrahub Sync can now compute sync order from `reference` relationships in `schema_mapping`. Most projects no longer need a maintained `order` list in `config.yml`. The engine builds a dependency graph, groups kinds into tiers, and writes one tier at a time.
 
-The `sync` command enables `--parallel` by default. When `order` is omitted, Infrahub Sync writes each computed tier before moving to the next tier, so dependent kinds do not start before their referenced kinds are in place. Existing configurations with an explicit `order` list still work; in that case, Infrahub Sync logs a warning and uses the serial order because the user-supplied sequence remains authoritative.
+The `sync` command enables `--parallel` by default. When `order` is omitted, Infrahub Sync writes each computed tier before moving to the next tier. Dependent kinds do not start before their referenced kinds are in place.
+
+Existing configurations with an explicit `order` list still work. In that case, Infrahub Sync logs a warning and uses the configured sequence.
 
 ### Cached snapshots and diff plans
 
 `diff` and `sync` now write run artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`. The cache includes source and destination snapshots, `plan.parquet`, run metadata, cursors, schema sub-hash information, and rowcount baselines. See the [cache layout reference](../../reference/cache-layout.mdx) for the file structure and plan columns.
 
-Operators can inspect the generated plan with tools such as DuckDB before running another sync or investigating an unexpected diff:
+Inspect the generated plan with tools such as DuckDB before running another sync or investigating an unexpected diff:
 
 ```bash
 uv run infrahub-sync diff --name from-netbox --directory examples/
 duckdb -c "SELECT action, resource, source_id FROM read_parquet('.infrahub-sync-cache/from-netbox/<run-id>/plan.parquet') LIMIT 20"
 ```
 
-The new `apply` command introduces the foundation for replaying a cached plan without extracting the source again. In 2.0.0, this requires destination adapter support for cached-row application; use `sync` for built-in adapter workflows until that support is available. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
+The new `apply` command introduces the foundation for replaying a cached plan without extracting the source again. In 2.0.0, this requires destination adapter support for cached-row application. Use `sync` for built-in adapter workflows until that support is available. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
 
 ### Faster recurring syncs
 
-`diff` and `sync` load source and destination data concurrently by default. Built-in adapters load into separate stores and cache directories, so this reduces load-phase wall-clock time without changing the sync result. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
+`diff` and `sync` load source and destination data concurrently by default. Built-in adapters load into separate stores and cache directories. This reduces load-phase wall-clock time without changing the sync result. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
 
 Warm sync runs can also use cursor-based extraction for supported adapters. NetBox, Nautobot, and Infrahub support timestamp-based cursors:
 
@@ -60,19 +62,19 @@ Timestamp-based incremental extraction does not detect deletes immediately, beca
 
 ### Safety guardrails for destructive changes
 
-`sync` records rowcount baselines after successful runs and refuses to proceed when a later run sees a resource drop by more than 50 percent. This helps catch source-side outages, partial restores, or permission changes before they remove valid destination data. Use `--allow-rowcount-drop` only when the source intentionally shrank.
+`sync` records rowcount baselines after successful runs. A later run stops when a resource count drops by more than 50 percent from the previous successful baseline. This check can catch source-side outages, partial restores, or permission changes before they remove valid destination data. Use `--allow-rowcount-drop` only when the source intentionally shrank.
 
-The new `--continue-on-error` flag lets a run log and skip peer relationships whose identifier values are missing instead of aborting the entire run. Use it for partial source data, then review the warnings before relying on the result.
+The new `--continue-on-error` flag logs and skips peer relationships whose identifier values are missing instead of aborting the entire run. Use it for partial source data, then review the warnings before relying on the result.
 
 ### Contributor workflow updates
 
-The development workflow now uses [ty](https://github.com/astral-sh/ty) instead of mypy. The `invoke lint` workflow runs ty alongside ruff, pylint, and yamllint, and the repository no longer carries ty override blocks to hide diagnostics.
+The development workflow now uses [ty](https://github.com/astral-sh/ty) instead of mypy. The `invoke lint` workflow runs ty alongside ruff, pylint, and yamllint. The repository no longer carries ty override blocks to hide diagnostics.
 
-During the migration, type fixes also removed several real failure paths in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
+During the migration, type fixes removed failure paths in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
 
 ## Upgrade notes
 
-- `order` is now optional when `schema_mapping` contains enough `reference` information to derive the dependency graph. Keep `order` when you need a hand-authored sequence.
+- `order` is now optional when `schema_mapping` contains enough `reference` information to derive the dependency graph. Keep `order` when you need a configured sequence.
 - `--parallel`, `--concurrent-load`, and `--full-extract` are enabled by default. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
 - Incremental extraction is opt-in with `--no-full-extract`.
 - `.infrahub-sync-cache/` is now part of normal operation and is ignored by Git.
@@ -86,7 +88,7 @@ During the migration, type fixes also removed several real failure paths in CLI 
 - Added automatic sync ordering from `schema_mapping` reference relationships, making `order` optional for configurations with enough dependency information. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added tier-by-tier sync execution with `--parallel` enabled by default when `order` is omitted. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added per-run cache artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`, including source and destination snapshots, run metadata, cursors, schema-sub-hash data, and rowcount baselines. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
-- Added Parquet diff plans for `diff` and `sync`, making run output easier to inspect with external tools. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added Parquet diff plans for `diff` and `sync`, so run output can be inspected with external tools. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added the `infrahub-sync apply` command as the foundation for replaying cached plans with destination adapters that support cached-row application. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added cursor-based incremental extraction for NetBox, Nautobot, and Infrahub, enabled with `--no-full-extract`. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added rowcount guardrails that stop `sync` when a resource count drops by more than 50 percent from the previous successful baseline. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))

--- a/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
@@ -1,0 +1,105 @@
+---
+title: Release 2.0.0
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>2.0.0</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 8th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[2.0.0](https://github.com/opsmill/infrahub-sync/releases/tag/2.0.0)</td>
+    </tr>
+  </tbody>
+</table>
+
+We're excited to announce the release of Infrahub Sync, v2.0.0!
+
+This release focuses on making large and recurring sync runs easier to operate. Infrahub Sync can now derive write order from schema mappings, load source and destination data concurrently, write inspectable cache artifacts, and use incremental extraction on warm runs for supported adapters.
+
+Together, these changes reduce manual configuration work for large dependency graphs, reduce load time for recurring syncs, and add guardrails that help operators catch suspicious source-side changes before they affect the destination.
+
+## Main changes
+
+### Less manual ordering for large syncs
+
+Infrahub Sync can now compute sync order from `reference` relationships in `schema_mapping`, so most projects no longer need a manually maintained `order` list in `config.yml`. The engine builds a dependency graph, groups kinds into tiers, and writes one tier at a time.
+
+The `sync` command enables `--parallel` by default. When `order` is omitted, Infrahub Sync writes each computed tier before moving to the next tier, so dependent kinds do not start before their referenced kinds are in place. Existing configurations with an explicit `order` list still work; in that case, Infrahub Sync logs a warning and uses the serial order because the user-supplied sequence remains authoritative.
+
+### Cached snapshots and diff plans
+
+`diff` and `sync` now write run artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`. The cache includes source and destination snapshots, `plan.parquet`, run metadata, cursors, schema sub-hash information, and rowcount baselines. See the [cache layout reference](../../reference/cache-layout.mdx) for the file structure and plan columns.
+
+Operators can inspect the generated plan with tools such as DuckDB before running another sync or investigating an unexpected diff:
+
+```bash
+uv run infrahub-sync diff --name from-netbox --directory examples/
+duckdb -c "SELECT action, resource, source_id FROM read_parquet('.infrahub-sync-cache/from-netbox/<run-id>/plan.parquet') LIMIT 20"
+```
+
+The new `apply` command introduces the foundation for replaying a cached plan without extracting the source again. In 2.0.0, this requires destination adapter support for cached-row application; use `sync` for built-in adapter workflows until that support is available. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
+
+### Faster recurring syncs
+
+`diff` and `sync` load source and destination data concurrently by default. Built-in adapters load into separate stores and cache directories, so this reduces load-phase wall-clock time without changing the sync result. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
+
+Warm sync runs can also use cursor-based extraction for supported adapters. NetBox, Nautobot, and Infrahub support timestamp-based cursors:
+
+- NetBox and Nautobot use `last_updated__gte`.
+- Infrahub uses `node_metadata__updated_at__after`.
+
+The default remains `--full-extract`, which re-extracts every resource on each run. Pass `--no-full-extract` to enable the incremental warm path. Infrahub Sync falls back to a full extract when the schema mapping changes, when a prior successful run is unavailable, when the adapter does not support cursors for a resource, or when the configured full-resync cadence is reached. See the [incremental extraction reference](../../reference/incremental-extraction.mdx) for details.
+
+Timestamp-based incremental extraction does not detect deletes immediately, because deleted records have no updated timestamp to query. Infrahub Sync periodically forces a full extract, every 10 runs by default, to reconcile deletes.
+
+### Safety guardrails for destructive changes
+
+`sync` records rowcount baselines after successful runs and refuses to proceed when a later run sees a resource drop by more than 50 percent. This helps catch source-side outages, partial restores, or permission changes before they remove valid destination data. Use `--allow-rowcount-drop` only when the source intentionally shrank.
+
+The new `--continue-on-error` flag lets a run log and skip peer relationships whose identifier values are missing instead of aborting the entire run. Use it for partial source data, then review the warnings before relying on the result.
+
+### Contributor workflow updates
+
+The development workflow now uses [ty](https://github.com/astral-sh/ty) instead of mypy. The `invoke lint` workflow runs ty alongside ruff, pylint, and yamllint, and the repository no longer carries ty override blocks to hide diagnostics.
+
+During the migration, type fixes also removed several real failure paths in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
+
+## Upgrade notes
+
+- `order` is now optional when `schema_mapping` contains enough `reference` information to derive the dependency graph. Keep `order` when you need a hand-authored sequence.
+- `--parallel`, `--concurrent-load`, and `--full-extract` are enabled by default. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
+- Incremental extraction is opt-in with `--no-full-extract`.
+- `.infrahub-sync-cache/` is now part of normal operation and is ignored by Git.
+- Review automation that parses command output. The new cache workflow adds run identifiers and cache paths to successful `diff` and `sync` runs.
+- Review retention and cleanup for `.infrahub-sync-cache/` in scheduled environments, because recurring runs now persist snapshots and plans.
+
+## Full changelog
+
+### Added
+
+- Added automatic sync ordering from `schema_mapping` reference relationships, making `order` optional for configurations with enough dependency information. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added tier-by-tier sync execution with `--parallel` enabled by default when `order` is omitted. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added per-run cache artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`, including source and destination snapshots, run metadata, cursors, schema-sub-hash data, and rowcount baselines. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added Parquet diff plans for `diff` and `sync`, making run output easier to inspect with external tools. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added the `infrahub-sync apply` command as the foundation for replaying cached plans with destination adapters that support cached-row application. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added cursor-based incremental extraction for NetBox, Nautobot, and Infrahub, enabled with `--no-full-extract`. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added rowcount guardrails that stop `sync` when a resource count drops by more than 50 percent from the previous successful baseline. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added `--continue-on-error` to skip peer relationships with missing identifier values while logging warnings. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+
+### Changed
+
+- Enabled concurrent source and destination loading by default for `diff` and `sync`, with `--no-concurrent-load` available for custom adapters that are not thread-safe. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Enabled `--parallel` and `--full-extract` by default for `sync`. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Updated example configurations to omit `order` by default and show how to opt back into a manual sequence. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Replaced mypy with ty in the development and CI linting workflow. ([#126](https://github.com/opsmill/infrahub-sync/pull/126))
+
+### Fixed
+
+- Improved peer identifier handling so missing peer identifier values produce clearer errors, or warnings when `--continue-on-error` is used. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Fixed several type-checker-discovered runtime failure paths in CLI narrowing, resource-name handling, Infrahub peer resolution, and Slurp’it conversion return values. ([#126](https://github.com/opsmill/infrahub-sync/pull/126))

--- a/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
+++ b/docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx
@@ -20,57 +20,85 @@ title: Release 2.0.0
 
 Infrahub Sync 2.0.0 is available.
 
-This release changes how Infrahub Sync handles large and recurring sync runs. It derives write order from schema mappings. It loads source and destination data concurrently. It writes cache artifacts for each run. And on supported adapters, warm runs can extract incrementally.
+This release focuses on recurring synchronization at scale. Run large syncs on a schedule, automate them safely, and inspect exactly what changed on every run.
 
-Together, these changes reduce configuration for large dependency graphs, cut load time on recurring syncs, and surface suspicious source-side changes before they reach the destination.
+The focus of 2.0 is operational reliability: faster incremental syncs, automatic dependency ordering, built-in safety guardrails, and on-disk run artifacts. Together these make it practical to run synchronization as a recurring part of infrastructure operations.
+
+## Release highlights
+
+- **Schedule recurring syncs without re-reading entire datasets.** Recurring syncs used to re-read the full source and destination on every run. After the first run, `--no-full-extract` lets supported adapters extract only changed records, so large sync jobs stay fast enough to run on a schedule. See [Incremental syncs for large datasets](#incremental-syncs-for-large-datasets).
+- **Add and evolve models without maintaining a write order.** Sync ordering used to be maintained manually in `config.yml` and updated on every schema change. It is now derived from your schema mapping automatically. Evolve data models, onboard new systems, and extend integrations without updating sync configuration on every change. See [Write ordering derived from schema mapping](#write-ordering-derived-from-schema-mapping).
+- **Run synchronization safely in unattended environments.** Source system outages, permission issues, or incomplete datasets no longer risk deleting valid destination data. Built-in guardrails detect unexpected source drops and stop the run, or skip the affected records, before writing to the destination. Run scheduled syncs in CI/CD pipelines and cron jobs without risking accidental data loss from source anomalies. See [Row count guardrails for unattended runs](#row-count-guardrails-for-unattended-runs).
+- **Inspect, audit, and troubleshoot every sync run.** Every `diff` and `sync` used to be discarded after execution. Both are now saved to disk. Review exactly what changed, investigate unexpected results, and build repeatable operational workflows around sync. See [Per-run artifacts for diff and sync](#per-run-artifacts-for-diff-and-sync).
+
+:::note What to expect after upgrading
+
+Your existing sync projects keep working without changes, and most run faster, because loading and writing now happen in parallel by default. Three situations need action:
+
+- If you use a custom adapter that is not thread-safe, pass `--no-concurrent-load`.
+- If a sync depends on a specific write order, set an explicit `order` list in `config.yml`.
+- `diff` and `sync` now write a cache under `.infrahub-sync-cache/`. In scheduled environments, plan to clean it up so per-run artifacts do not accumulate.
+
+The [upgrade notes](#upgrade-notes) list every default that changed.
+
+:::
 
 ## Main changes
 
-### Less manual ordering for large syncs
+### Incremental syncs for large datasets
 
-Infrahub Sync can now compute sync order from `reference` relationships in `schema_mapping`. Most projects no longer need a maintained `order` list in `config.yml`. The engine builds a dependency graph, groups kinds into tiers, and writes one tier at a time.
+Large synchronization jobs previously required reading both source and destination systems in full on every run, so execution time grew with the dataset. Infrahub Sync now loads both systems concurrently and, after the first run, can extract only changed records on supported adapters. Run large syncs on a schedule and keep systems in sync as datasets change.
 
-The `sync` command enables `--parallel` by default. When `order` is omitted, Infrahub Sync writes each computed tier before moving to the next tier. Dependent kinds do not start before their referenced kinds are in place.
+The approved benchmark for [#127](https://github.com/opsmill/infrahub-sync/pull/127) used the `nautobot-v2` demo dataset with interfaces omitted and about 14 object kinds:
 
-Existing configurations with an explicit `order` list still work. In that case, Infrahub Sync logs a warning and uses the configured sequence.
+| Scenario | Cold | Warm |
+| --- | ---: | ---: |
+| Baseline, serial, no concurrent load | 463.8s | 154.3s |
+| `--parallel` with `--concurrent-load` | 437.5s | 132.3s |
+| `--no-full-extract`, cursor-driven warm run | 434.5s | 6.3s |
 
-### Cached snapshots and diff plans
+- Pass `--no-concurrent-load` for custom adapters that are not thread-safe. Concurrent loading is on by default and does not change the sync result.
+- Enable incremental extraction with `--no-full-extract` to read only changed records after the first run. The default `--full-extract` re-reads every resource on each run. On supported adapters it uses timestamp cursors: NetBox and Nautobot use `last_updated__gte`, and Infrahub uses `node_metadata__updated_at__after`.
+- Infrahub Sync falls back to a full extract when the schema mapping changes, when no prior successful run exists, when an adapter has no cursor for a resource, or when the full-resync cadence is reached.
+- Timestamp cursors do not detect deletes. Infrahub Sync forces a full extract every 10 runs by default to reconcile them.
 
-`diff` and `sync` now write run artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`. The cache includes source and destination snapshots, `plan.parquet`, run metadata, cursors, schema sub-hash information, and rowcount baselines. See the [cache layout reference](../../reference/cache-layout.mdx) for the file structure and plan columns.
+See the [incremental extraction reference](../../reference/incremental-extraction.mdx) for details.
 
-Inspect the generated plan with tools such as DuckDB before running another sync or investigating an unexpected diff:
+### Write ordering derived from schema mapping
+
+Add and evolve models without updating sync configuration. Synchronization writes objects in dependency order, and that order used to be maintained manually in `config.yml` and updated on every schema change. Infrahub Sync now derives it from the `reference` relationships in your schema mapping.
+
+- Infrahub Sync builds the dependency graph from the `reference` relationships in your `schema_mapping`. It groups object kinds into tiers; objects within a tier have no cross-dependencies.
+- When `order` is omitted, Infrahub Sync writes each tier in full before starting the next, so no object is created before what it references. `--parallel` is on by default and writes objects within a tier concurrently.
+- Set an explicit `order` list when you need a specific sequence; Infrahub Sync logs a warning and uses it.
+
+### Row count guardrails for unattended runs
+
+Schedule syncs in CI jobs or cron without manually reviewing each run for source anomalies. An outage, a partial restore, or a permissions change can make a source return far fewer records than it holds. Previously, a sync would apply that drop as a deletion. Infrahub Sync now checks record counts against a baseline before writing and stops the run, or skips the affected records, when the drop exceeds the configured threshold.
+
+- Pass `--allow-rowcount-drop` only when the source intentionally shrank. By default, the rowcount check stops a run when a resource drops by more than 50 percent from its last successful baseline.
+- Pass `--continue-on-error` to log and skip a record that links to an object it cannot find, such as a peer relationship with a missing identifier, instead of aborting the run. Use it for partial source data, then review the warnings before relying on the result.
+
+### Per-run artifacts for diff and sync
+
+Review, audit, and troubleshoot any run after it completes. `diff` used to print to the terminal and keep nothing. Every `diff` and `sync` now saves its snapshots and change plan to disk, so you can inspect what changed and investigate an unexpected result.
+
+- Find each run's source snapshot, destination snapshot, `plan.parquet`, run metadata, cursors, and schema sub-hash under `.infrahub-sync-cache/<sync-name>/<run-id>/`. The sync-level rowcount baseline is stored at `.infrahub-sync-cache/<sync-name>/last-successful-rowcounts.json`. See the [cache layout reference](../../reference/cache-layout.mdx) for the file structure and plan columns.
+- Query the plan with tools such as DuckDB before the next run, or to investigate an unexpected diff:
 
 ```bash
 uv run infrahub-sync diff --name from-netbox --directory examples/
 duckdb -c "SELECT action, resource, source_id FROM read_parquet('.infrahub-sync-cache/from-netbox/<run-id>/plan.parquet') LIMIT 20"
 ```
 
-The new `apply` command is the first step toward replaying a cached plan directly from cache, with no second extraction from the source. In 2.0.0, this requires destination adapter support for cached-row application. Use `sync` for built-in adapter workflows until that support lands. `apply` refuses to run when the destination schema shape no longer matches the cached schema sub-hash.
+- Use `apply` (preview) to replay a cached plan without re-extracting the source. In 2.0.0 it requires destination adapter support for cached-row application, so use `sync` for built-in adapter workflows until that support is available. `apply` refuses to run when the current schema mapping and destination schema shape no longer match the cached schema sub-hash.
 
-### Faster recurring syncs
+### Type checking uses ty in invoke lint
 
-`diff` and `sync` load source and destination data concurrently by default. Built-in adapters load into separate stores and cache directories. This reduces load-phase wall-clock time without changing the sync result. Use `--no-concurrent-load` for custom adapters that are not thread-safe.
+Run `invoke lint` with stricter type checking and no override blocks. The project used mypy with overrides that hid known type errors. Migrating to ty removed those overrides and fixed several latent runtime bugs in the process.
 
-Warm sync runs can also use cursor-based extraction for supported adapters. NetBox, Nautobot, and Infrahub support timestamp-based cursors:
-
-- NetBox and Nautobot use `last_updated__gte`.
-- Infrahub uses `node_metadata__updated_at__after`.
-
-The default remains `--full-extract`, which re-extracts every resource on each run. Pass `--no-full-extract` to enable the incremental warm path. Infrahub Sync falls back to a full extract when the schema mapping changes, when a prior successful run is unavailable, when the adapter does not support cursors for a resource, or when the configured full-resync cadence is reached. See the [incremental extraction reference](../../reference/incremental-extraction.mdx) for details.
-
-Timestamp-based incremental extraction does not detect deletes immediately, because deleted records have no updated timestamp to query. Infrahub Sync periodically forces a full extract, every 10 runs by default, to reconcile deletes.
-
-### Safety guardrails for destructive changes
-
-`sync` records rowcount baselines after successful runs. A later run stops when a resource count drops by more than 50 percent from the previous successful baseline. This check can catch source-side outages, partial restores, or permission changes before they remove valid destination data. Use `--allow-rowcount-drop` only when the source intentionally shrank.
-
-The new `--continue-on-error` flag logs and skips peer relationships whose identifier values are missing instead of aborting the entire run. Use it for partial source data, then review the warnings before relying on the result.
-
-### Contributor workflow updates
-
-The development workflow now uses [ty](https://github.com/astral-sh/ty) instead of mypy. The `invoke lint` workflow runs ty alongside ruff, pylint, and yamllint. The repository no longer carries ty override blocks to hide diagnostics.
-
-Fixing the type errors surfaced by the migration also resolved latent runtime issues in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp’it conversion return types.
+- [ty](https://github.com/astral-sh/ty) runs alongside ruff, pylint, and yamllint in `invoke lint`.
+- The migration also fixed latent runtime failures in CLI narrowing, adapter peer resolution, resource-name handling, and Slurp'it conversion return types.
 
 ## Upgrade notes
 
@@ -87,9 +115,10 @@ Fixing the type errors surfaced by the migration also resolved latent runtime is
 
 - Added automatic sync ordering from `schema_mapping` reference relationships, making `order` optional for configurations with enough dependency information. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added tier-by-tier sync execution with `--parallel` enabled by default when `order` is omitted. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
-- Added per-run cache artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`, including source and destination snapshots, run metadata, cursors, schema-sub-hash data, and rowcount baselines. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added per-run cache artifacts under `.infrahub-sync-cache/<sync-name>/<run-id>/`, including source and destination snapshots, run metadata, cursors, and schema-sub-hash data. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added sync-level rowcount baselines under `.infrahub-sync-cache/<sync-name>/last-successful-rowcounts.json`. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added Parquet diff plans for `diff` and `sync`, so run output can be inspected with external tools. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
-- Added the `infrahub-sync apply` command as the foundation for replaying cached plans with destination adapters that support cached-row application. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
+- Added the `infrahub-sync apply` command (preview) as the foundation for replaying cached plans with destination adapters that support cached-row application. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added cursor-based incremental extraction for NetBox, Nautobot, and Infrahub, enabled with `--no-full-extract`. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added rowcount guardrails that stop `sync` when a resource count drops by more than 50 percent from the previous successful baseline. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
 - Added `--continue-on-error` to skip peer relationships with missing identifier values while logging warnings. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
@@ -104,4 +133,4 @@ Fixing the type errors surfaced by the migration also resolved latent runtime is
 ### Fixed
 
 - Improved peer identifier handling so missing peer identifier values produce clearer errors, or warnings when `--continue-on-error` is used. ([#127](https://github.com/opsmill/infrahub-sync/pull/127))
-- Fixed several type-checker-discovered runtime failure paths in CLI narrowing, resource-name handling, Infrahub peer resolution, and Slurp’it conversion return values. ([#126](https://github.com/opsmill/infrahub-sync/pull/126))
+- Fixed several type-checker-discovered runtime failure paths in CLI narrowing, resource-name handling, Infrahub peer resolution, and Slurp'it conversion return values. ([#126](https://github.com/opsmill/infrahub-sync/pull/126))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -53,6 +53,31 @@ const sidebars: SidebarsConfig = {
         'reference/incremental-extraction',
       ],
     },
+    {
+      type: 'category',
+      label: 'Release Notes',
+      collapsible: true,
+      collapsed: true,
+      link: {
+        type: 'generated-index',
+        slug: 'release-notes',
+      },
+      items: [
+        {
+          type: 'category',
+          label: 'Infrahub Sync',
+          link: {
+            type: 'generated-index',
+            slug: 'release-notes/infrahub-sync',
+          },
+          items: [
+            'release-notes/infrahub-sync/release-2_0_0',
+            'release-notes/infrahub-sync/release-1_6_0',
+            'release-notes/infrahub-sync/release-1_5_6',
+          ],
+        },
+      ],
+    },
     'contributing',
   ]
 };


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated Infrahub Sync release notes for versions **1.5.6**, **1.6.0**, and **2.0.0**
  * Expanded docs navigation with a new **Release Notes** section and an Infrahub Sync subsection
* **Bug Fixes**
  * Fixed a race condition in the Slurp’it adapter for **deterministic interface output**
* **New Features / Improvements**
  * Introduced global **verbosity/log-volume** controls and **progress display** toggles (with sensible terminal defaults)
  * Added large-run execution improvements (ordered writes, better parallelism defaults, cached run artifacts, and safer rowcount handling)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Adds three release notes under `docs/docs/release-notes/infrahub-sync/` and wires them into the sidebar.

- **1.5.6** — Slurp'it adapter race fix; deterministic interface output.
- **1.6.0** — Python-logging based output across CLI, engine, and adapters; new `--verbosity` / `-v` / `-q` and `--show-progress` / `--no-show-progress` controls.
- **2.0.0** — Schema-derived sync order (`order` now optional), per-run cache artifacts under `.infrahub-sync-cache/`, Parquet diff plans, the new `apply` command, cursor-based incremental extraction for NetBox / Nautobot / Infrahub, rowcount guardrails, and `--continue-on-error`.

## Scope

Documentation only. No Python source, CLI flags, or config keys change in this PR — the release notes describe features that already shipped on `main`.

`git diff --stat upstream/main..HEAD`:

```
 docs/docs/release-notes/infrahub-sync/release-1_5_6.mdx |  23 +++
 docs/docs/release-notes/infrahub-sync/release-1_6_0.mdx |  64 ++++++
 docs/docs/release-notes/infrahub-sync/release-2_0_0.mdx | 107 +++++++++++
 docs/sidebars.ts                                        |  25 +++
 4 files changed, 219 insertions(+)
```

## Verification

- `uv run invoke linter.format` — ruff clean.
- `uv run invoke linter.lint-ty` — exit 0.
- `npx markdownlint-cli2 "docs/docs/release-notes/infrahub-sync/*.mdx"` — 0 errors.
- `uv run invoke docs.generate` — no diff (already current).
- `uv run invoke docs.docusaurus` — site builds successfully.
- OpsMill voice/tone audit applied to all three notes across two passes.

🤖 Drafted with assistance from Claude (Anthropic).
