### PR TITLE
chore: retarget dependency automation to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    target-branch: develop
     labels:
       - "type/housekeeping"
     groups:
@@ -24,7 +23,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    target-branch: develop
     labels:
       - "type/housekeeping"
     groups:

--- a/.github/workflows/update-infrahub-sdk.yml
+++ b/.github/workflows/update-infrahub-sdk.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         branch-name:
-          - develop
+          - main
 
     runs-on: ubuntu-22.04
     concurrency:


### PR DESCRIPTION
## Problem

Dependabot and the SDK release workflow both target `develop`. The repository default branch is `main`, so automated dependency pull requests from either path use a stale base.

## Solution

Remove the Dependabot target overrides and change the SDK workflow target from `develop` to `main`. Dependabot now uses the repository default branch. SDK release events create a `main-infrahub-sdk-<version>` branch and open the pull request against `main`.

## Before and after

```yaml
# Before
target-branch: develop
branch-name:
  - develop

# After
# Dependabot uses the repository default branch.
branch-name:
  - main
```

## Scope

- Preserve the existing schedules, dependency groups, housekeeping labels, and SDK release triggers.
- Leave `trigger-pr-develop.yml` unchanged. Retiring the protected `develop` branch and its remaining CI references requires a separate cleanup.
- Change no Infrahub Sync product, CLI, or configuration behavior.

## Validation

- `uv sync --extra dev`: passed.
- `uv run invoke format`: passed with no generated changes.
- `uv run invoke lint`: passed with the existing Pylint notices.
- Targeted YAML validation: passed; the SDK matrix contains `main` and no `develop` target.
- `uv run infrahub-sync --help`: passed.
- `uv run infrahub-sync list --directory examples/`: passed.
- Targeted generation reached the local Infrahub stack and stopped at the expected schema-availability check.
- The final diff contains the two Dependabot target removals and the SDK workflow target replacement.
- [GitHub Actions run 31761890946](https://github.com/opsmill/infrahub-sync/actions/runs/31761890946): passed for exact head `d28efb7` with no pending or failed checks.

## Follow-up

After this merges:

- Close #154 and #163 because Dependabot generated them from `develop`.
- Allow Dependabot to regenerate equivalent updates from current `main`.
- Retire the protected `develop` branch and remove its remaining workflow references in a separate cleanup.
- Refresh `uv.lock` manually if the regenerated Python update does not include it.

🤖 Generated with OpenAI Codex
