### PR TITLE
fix: restore the from-netbox example sync name

### DIFF
--- a/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
+++ b/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
@@ -193,7 +193,7 @@ curl -L \
   -o sync-projects/netbox-demo/config.yml
 ```
 
-The downloaded configuration is named `netbox-demo-to-infrahub`. It maps selected NetBox objects onto the Infrahub schema.
+The downloaded configuration is named `from-netbox`. It maps selected NetBox objects onto the Infrahub schema.
 
 Open `sync-projects/netbox-demo/config.yml` in an editor and scan the top-level keys:
 
@@ -213,7 +213,7 @@ For a fuller explanation of this file, see [Create a sync project](../creating-a
 Generate the Python models and adapter code for this sync project.
 
 ```bash
-uv run infrahub-sync generate --name netbox-demo-to-infrahub --directory sync-projects
+uv run infrahub-sync generate --name from-netbox --directory sync-projects
 ```
 
 The `generate` command reads the sync configuration and the destination schema, then writes the Python code used at runtime. Run `generate` again any time you edit `config.yml`.
@@ -235,10 +235,10 @@ The rest of this tutorial runs `diff` and `sync` against this branch with `--bra
 Run a dry-run diff against the `netbox-import` branch before writing any data to Infrahub.
 
 ```bash
-uv run infrahub-sync diff --name netbox-demo-to-infrahub --directory sync-projects --branch netbox-import
+uv run infrahub-sync diff --name from-netbox --directory sync-projects --branch netbox-import
 ```
 
-The `diff` command loads data from NetBox and Infrahub, compares both sides, and prints the planned changes. It also writes a cached plan under `.infrahub-sync-cache/netbox-demo-to-infrahub/<run-id>/plan.parquet`.
+The `diff` command loads data from NetBox and Infrahub, compares both sides, and prints the planned changes. It also writes a cached plan under `.infrahub-sync-cache/from-netbox/<run-id>/plan.parquet`.
 
 Review the output before continuing. On a first run against an empty branch, most planned changes should be creates. Exact counts depend on the current public NetBox demo data.
 
@@ -247,7 +247,7 @@ Review the output before continuing. On a first run against an empty branch, mos
 After reviewing the diff, run the sync against the same branch.
 
 ```bash
-uv run infrahub-sync sync --name netbox-demo-to-infrahub --directory sync-projects --branch netbox-import --diff
+uv run infrahub-sync sync --name from-netbox --directory sync-projects --branch netbox-import --diff
 ```
 
 The `--diff` option prints the diff before applying the changes. The first sync can take a few minutes because it writes the imported objects and relationships into the `netbox-import` branch — `main` is untouched until you merge the resulting proposed change. Because this configuration omits `order:`, Infrahub Sync derives the write order from the mapping references.

--- a/examples/netbox_to_infrahub/config.yml
+++ b/examples/netbox_to_infrahub/config.yml
@@ -1,5 +1,5 @@
 ---
-# netbox-demo-to-infrahub — demonstrates the two newest features of infrahub-sync:
+# from-netbox — demonstrates the two newest features of infrahub-sync:
 #
 #   1. Auto-tiered write order. The `order:` list has been removed; the engine
 #      derives tiers from `schema_mapping[].fields[].reference` and groups
@@ -7,18 +7,18 @@
 #      enforce a hard barrier between tiers.
 #
 #   2. Parquet sidecar cache. Every `diff` writes per-resource snapshots and
-#      a `plan.parquet` under `.infrahub-sync-cache/netbox-demo-to-infrahub/<run_id>/`.
+#      a `plan.parquet` under `.infrahub-sync-cache/from-netbox/<run_id>/`.
 #      The run_id is logged at INFO; pass it to `apply` to re-dispatch the
 #      cached plan without re-extracting the source.
 #
 # Usage:
-#   uv run infrahub-sync diff --name netbox-demo-to-infrahub --directory sync-projects
-#   uv run infrahub-sync apply --name netbox-demo-to-infrahub --run-id <run_id> --directory sync-projects
-#   uv run infrahub-sync sync --name netbox-demo-to-infrahub --directory sync-projects --parallel
+#   uv run infrahub-sync diff --name from-netbox --directory sync-projects
+#   uv run infrahub-sync apply --name from-netbox --run-id <run_id> --directory sync-projects
+#   uv run infrahub-sync sync --name from-netbox --directory sync-projects --parallel
 #
 # ---------------------------------------------------------------------------
 
-name: netbox-demo-to-infrahub
+name: from-netbox
 
 source:
   name: netbox


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the NetBox-to-Infrahub tutorial to use the `from-netbox` project name consistently.
  * Updated the example configuration and cache path references to match the renamed project identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

PR #140's tutorial work renamed the shipped NetBox example sync project from `from-netbox` to `netbox-demo-to-infrahub`. The original name is referenced in 19 places across 11 files (README, docs, release notes, bench task), and 8 unit tests on `main` fail because they resolve the example by name. This PR restores the original name instead of updating every reference: a 2-file, 11-line change, and the test suite passes again with no test changes.

## Key Changes

- The example is named `from-netbox` again, so every existing doc, command, and external reference is correct as written.
- The tutorial — the only page that used the new name; it downloads the config directly from `main` — now uses `from-netbox` in its five references.
- The 8 failing tests on `main` pass again with no changes to any test file.

## Related Context

- #140 introduced the rename as part of the NetBox demo tutorial. Everything else in #140 (the tutorial, the schema-library config rewrite, the float-weight and VLAN fixes) is unchanged.
- CI did not run the unit tests on #140: the test job's paths filter excludes changes under `examples/`. The same filter will skip the tests on this PR; results from a local run are in the test plan below. Fixing the filter is left to a follow-up PR to keep this one minimal.
- @BaptisteGi — comment if further changes are needed, or if you would prefer to standardize on the new name and update the remaining references instead.

## Documentation Updates

- `docs/docs/tutorials/netbox-demo-to-infrahub.mdx` — five sync-name references updated to match the restored config name. The page's own name and slug are unchanged.

## Test Plan

- `uv run pytest -q` — 110 passed, 3 skipped (8 failed on current `main`).
- `uv run infrahub-sync list --directory examples/` shows `from-netbox | netbox >> infrahub`.
- `yamllint`, `rumdl`, and `vale` pass on the changed files; the full Docusaurus build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
