### PR TITLE
Run develop PR checks for the v3 branch

### DIFF
--- a/.github/workflows/trigger-pr-develop.yml
+++ b/.github/workflows/trigger-pr-develop.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - develop
+      - feature/v3-develop
 
 jobs:
   linter:


### PR DESCRIPTION
## Problem

The temporary v3 development branch uses the repository's normal PR workflow,
but the workflow currently dispatches only when the exact base branch is
`develop`. As a result, saved-plan draft PR #157 receives no repository lint,
dependency, or test checks.

## Solution

Add `feature/v3-develop` to the existing develop pull-request trigger. This
reuses the same lint, uv-check, and test jobs without changing their behavior or
the release workflows for `main` and `stable`.

## Impact

Pull requests targeting either `develop` or the temporary
`feature/v3-develop` branch receive the same repository checks. This is
bootstrap infrastructure only; it changes no Infrahub Sync product behavior.

## Validation

- `uv sync --extra dev`
- `uv run yamllint .github/workflows/trigger-pr-develop.yml`
- `git diff --check`

The local base does not define the later `prefect` optional dependency, so the
bootstrap used its applicable `dev` extra. `actionlint` is not installed
locally; once this trigger lands, the repository's workflow-lint job will
exercise the workflow through the normal GitHub path.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull request automation now runs for changes targeting `feature/v3-develop`, in addition to `develop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->