### PR TITLE
Add managed Sync HTTP API over Prefect

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -61,6 +61,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -77,9 +78,13 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         run: uv python install ${{ matrix.python-version }}
 
-      # Optional orchestration imports must resolve in the ty gate. The managed
-      # profile also carries Prefect Extras, FastAPI, and the ASGI server.
-      - name: "Install dependencies"
+      - name: "Install Developer Preview dependencies on Python 3.10"
+        if: matrix.python-version == '3.10'
+        run: uv sync --python 3.10 --frozen --extra dev --extra prefect
+
+      # Optional managed imports resolve only on their supported Python range.
+      - name: "Install managed dependencies on Python 3.11+"
+        if: matrix.python-version != '3.10'
         run: uv sync --python ${{ matrix.python-version }} --frozen --extra dev --extra prefect --extra managed
 
       - name: "Linting: ruff check"
@@ -88,7 +93,12 @@ jobs:
       - name: "Linting: ruff format"
         run: "uv run ruff format --check --diff ."
 
+      - name: "Linting: ty check (Developer Preview Python 3.10)"
+        if: matrix.python-version == '3.10'
+        run: "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
+
       - name: "Linting: ty check (managed Python 3.11+)"
+        if: matrix.python-version != '3.10'
         run: "uv run ty check ."
 
       # TODO: Need to cleanup code

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -61,7 +61,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -81,7 +80,7 @@ jobs:
       # Optional orchestration imports must resolve in the ty gate. The managed
       # profile also carries Prefect Extras, FastAPI, and the ASGI server.
       - name: "Install dependencies"
-        run: uv sync --frozen --extra dev --extra prefect --extra managed
+        run: uv sync --python ${{ matrix.python-version }} --frozen --extra dev --extra prefect --extra managed
 
       - name: "Linting: ruff check"
         run: "uv run ruff check ."
@@ -89,12 +88,7 @@ jobs:
       - name: "Linting: ruff format"
         run: "uv run ruff format --check --diff ."
 
-      - name: "Linting: ty check (base Python 3.10)"
-        if: matrix.python-version == '3.10'
-        run: "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
-
       - name: "Linting: ty check (managed Python 3.11+)"
-        if: matrix.python-version != '3.10'
         run: "uv run ty check ."
 
       # TODO: Need to cleanup code

--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -78,13 +78,10 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         run: uv python install ${{ matrix.python-version }}
 
-      # The `prefect` extra is required by the ty gate: with Prefect absent, ty
-      # reports `unresolved-import` for every `prefect` import in
-      # `infrahub_sync/orchestration/` and `tests/orchestration/` (measured: 13
-      # diagnostics instead of 4), so the type gate would fail on code it cannot
-      # see. Ruff needs no extra, but it runs in this same job.
+      # Optional orchestration imports must resolve in the ty gate. The managed
+      # profile also carries Prefect Extras, FastAPI, and the ASGI server.
       - name: "Install dependencies"
-        run: uv sync --frozen --extra dev --extra prefect
+        run: uv sync --frozen --extra dev --extra prefect --extra managed
 
       - name: "Linting: ruff check"
         run: "uv run ruff check ."
@@ -92,7 +89,12 @@ jobs:
       - name: "Linting: ruff format"
         run: "uv run ruff format --check --diff ."
 
-      - name: "Linting: ty check"
+      - name: "Linting: ty check (base Python 3.10)"
+        if: matrix.python-version == '3.10'
+        run: "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
+
+      - name: "Linting: ty check (managed Python 3.11+)"
+        if: matrix.python-version != '3.10'
         run: "uv run ty check ."
 
       # TODO: Need to cleanup code

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -59,11 +59,11 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         run: uv python install ${{ matrix.python-version }}
 
-      # The `prefect` extra is required: without it `tests/orchestration/test_flow.py`
-      # is skipped whole by its `pytest.importorskip("prefect")`, so the flow, log
-      # bridge, parameter-contract and canary-redaction suites would never run here.
+      # The optional orchestration profiles are required here: their suites use
+      # collection-time skips so the separate base-install leg can remain free of
+      # Prefect and managed-service dependencies.
       - name: "Install dependencies"
-        run: uv sync --frozen --extra dev --extra prefect
+        run: uv sync --frozen --extra dev --extra prefect --extra managed
 
       # Runs only `-m "not integration"`. Integration tests need a live
       # Infrahub instance and are opted into via `invoke tests-integration`
@@ -97,12 +97,14 @@ jobs:
       - name: "Install dependencies"
         run: uv sync --frozen --extra dev
 
-      - name: "Assert prefect is absent from this environment"
+      - name: "Assert managed runtime dependencies are absent from this environment"
         run: |
-          if uv run --no-sync python -c "import prefect" 2>/dev/null; then
-            echo "prefect is importable — this leg must be a base install"
-            exit 1
-          fi
+          for module in prefect fastapi uvicorn opsmill_prefect_extras; do
+            if uv run --no-sync python -c "import ${module}" 2>/dev/null; then
+              echo "${module} is importable — this leg must be a base install"
+              exit 1
+            fi
+          done
 
       - name: "pytest: unit tests"
         run: uv run --no-sync invoke tests.tests-unit

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -43,6 +43,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -58,10 +59,14 @@ jobs:
       - name: "Set up Python ${{ matrix.python-version }}"
         run: uv python install ${{ matrix.python-version }}
 
-      # The optional orchestration profiles are required here: their suites use
-      # collection-time skips so the separate base-install leg can remain free of
-      # Prefect and managed-service dependencies.
-      - name: "Install dependencies"
+      - name: "Install Developer Preview dependencies on Python 3.10"
+        if: matrix.python-version == '3.10'
+        run: uv sync --python 3.10 --frozen --extra dev --extra prefect
+
+      # Managed HTTP support is Python 3.11+; the separate 3.10 leg still proves
+      # the preserved Developer Preview orchestration profile.
+      - name: "Install managed dependencies on Python 3.11+"
+        if: matrix.python-version != '3.10'
         run: uv sync --python ${{ matrix.python-version }} --frozen --extra dev --extra prefect --extra managed
 
       # Runs only `-m "not integration"`. Integration tests need a live

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -63,7 +62,7 @@ jobs:
       # collection-time skips so the separate base-install leg can remain free of
       # Prefect and managed-service dependencies.
       - name: "Install dependencies"
-        run: uv sync --frozen --extra dev --extra prefect --extra managed
+        run: uv sync --python ${{ matrix.python-version }} --frozen --extra dev --extra prefect --extra managed
 
       # Runs only `-m "not integration"`. Integration tests need a live
       # Infrahub instance and are opted into via `invoke tests-integration`
@@ -77,7 +76,7 @@ jobs:
     # the base package neither imports nor needs Prefect; only an install where
     # Prefect is genuinely absent proves the base install still imports and the CLI
     # still runs. The flow suite skips here, by design.
-    name: "Unit Tests (base install, no prefect extra)"
+    name: "Unit Tests (base install, Python 3.10, no managed runtimes)"
     needs: ["files-changed"]
     if: needs.files-changed.outputs.sync == 'true'
     runs-on: "ubuntu-22.04"
@@ -91,11 +90,14 @@ jobs:
         with:
           version: "latest"
 
-      - name: "Set up Python 3.12"
-        run: uv python install 3.12
+      - name: "Set up Python 3.10"
+        run: uv python install 3.10
 
       - name: "Install dependencies"
-        run: uv sync --frozen --extra dev
+        run: uv sync --python 3.10 --frozen --extra dev
+
+      - name: "Assert Python 3.10 is active"
+        run: uv run --no-sync python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version"
 
       - name: "Assert managed runtime dependencies are absent from this environment"
         run: |

--- a/changelog/+managed-sync-http-api.added.md
+++ b/changelog/+managed-sync-http-api.added.md
@@ -1,0 +1,7 @@
+Added an authenticated managed Sync HTTP API for creating and inspecting durable runs,
+reviewing retained plans, running read-only verification, applying an exact approved
+checksum, retrieving results and artifacts, and requesting cancellation through Prefect.
+Actor-scoped durable mutation receipts make exact retries converge on one Sync run and
+Prefect flow run without storing the raw client key. Install the `managed` extra to run the
+separate Prefect deployment and API; the base CLI and existing four-parameter Developer
+Preview deployment remain unchanged.

--- a/dev/knowledge/orchestration-prefect.md
+++ b/dev/knowledge/orchestration-prefect.md
@@ -4,7 +4,7 @@
 
 <!-- Extracted from dev/specs/archive/001-prefect-managed-remote-run on 2026-07-31 -->
 
-`infrahub_sync/orchestration/` is a packaged Prefect integration: a flow that runs one plan
+`infrahub_sync/orchestration/` is the Developer Preview Prefect integration: a flow that runs one plan
 or one confirmed sync, and a serve entrypoint that exposes it as a locally served
 deployment. It is the only package in the repository that imports `prefect`, it is installed
 by the optional `prefect` extra, and nothing in the base package imports it — see
@@ -12,6 +12,13 @@ by the optional `prefect` extra, and nothing in the base package imports it — 
 
 The flow calls [the shared execution surface](execution-surface.md) in-process. It never
 spawns the CLI.
+
+`infrahub_sync/managed/` is a separate, optional operational profile. Its managed flow
+consumes the API-created product run ID and delegates deployment catalogue validation,
+deployment convergence, and native submission idempotency to OpsMill Prefect Extras pinned
+at commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The managed HTTP service owns the
+public contract; Prefect remains authoritative for live execution, logs, retries, workers,
+and cancellation.
 
 ## The flow
 
@@ -28,6 +35,16 @@ def infrahub_sync_run(
 Exactly those four parameters. None of them accepts a path, a CLI fragment, a credential, or
 an environment override. Everything else the run needs comes from the serving process's own
 environment.
+
+The separate `infrahub-sync-managed/run` deployment accepts exactly seven parameters:
+`run_id`, `sync_name`, `stage`, `configuration_reference`, `branch`, `expected_checksum`,
+and `confirm_writes`. It does not replace or extend the four-parameter Developer Preview
+flow. Credentials, endpoints, adapter instances, product-cache locations, and saved-plan
+cache locations stay in the managed worker environment.
+
+When the managed flow runs outside Prefect context in offline executor tests,
+`get_run_logger()` raises `MissingContextError`. The flow catches only that exception and
+uses its module logger. It does not construct `RunLoggerBridge` in the fallback path.
 
 `FLOW_NAME` is `infrahub-sync` and `DEPLOYMENT_NAME` is `run`, so the deployment lookup path
 is `/api/deployments/name/infrahub-sync/run` rather than a stuttering repeat of the flow

--- a/docs/docs/reference/durable-product-records.mdx
+++ b/docs/docs/reference/durable-product-records.mdx
@@ -8,8 +8,9 @@ artifacts. It is independent of Prefect: a standalone run has no Prefect links, 
 managed run can retain any number of purpose-labelled execution links after Prefect no
 longer has the corresponding flow-run detail.
 
-This is a Python provider surface. The CLI, public run API, and managed execution paths do
-not use it yet; their shared integration is a separate compatibility step.
+This is a Python provider surface. The managed Sync HTTP API and its worker use the local
+profile for durable run, plan, result, artifact, execution-link, mutation-receipt, and audit
+integration. The CLI and local public run API retain their existing cache contracts.
 
 ## Provider profiles
 
@@ -90,6 +91,17 @@ results, phase, and Prefect-link metadata. It rejects records that already have 
 timestamp, outcome, or artifact reference; those completion fields must be added through
 the publication and finish operations so their integrity checks cannot be bypassed.
 
+Managed mutations reserve a `MutationReceipt` unique by actor and SHA-256 digest of the
+client idempotency key. A receipt binds the operation, target, request fingerprint, reason,
+Sync run, opaque Prefect key, state, and exact accepted response. The raw client key is not
+stored. Run creation commits its receipt and unfinished product run in one relational
+transaction. `AuditEvent` records secret-safe actor, reason, operation, and outcome evidence
+for accepted mutations and refusals.
+
+`record_results` updates retained result evidence without changing product phase, outcome,
+or finish time. Managed verification uses this operation because verification is read-only
+for both the destination and product lifecycle.
+
 ## Artifact publication and lookup
 
 Artifact keys contain their SHA-256 digest and never change. Publication first reserves a
@@ -131,11 +143,11 @@ retention is independent.
 
 ## Secret boundary
 
-Pass the credential values collected by `collect_secret_values` to `create_run`,
-`add_prefect_execution`, `publish_artifact`, and `finish_run`. Values are redacted from
-nested record data and raw artifact bytes before either provider is called. Do not put
-secrets into identifiers; credentials should continue to come from environment variables
-or a secret manager.
+Pass the credential values collected by `collect_secret_values` to mutation, audit, run,
+execution-link, result, artifact, and finish operations. Values are redacted from nested
+record data and raw artifact bytes before either provider is called. Do not put secrets into
+identifiers; credentials should continue to come from environment variables or a secret
+manager.
 
 ## Reproducible sizing evidence
 

--- a/docs/docs/reference/managed-http-api.mdx
+++ b/docs/docs/reference/managed-http-api.mdx
@@ -1,0 +1,253 @@
+---
+title: Managed Sync HTTP API
+sidebar_position: 7
+---
+
+The managed Sync HTTP API accepts authenticated run requests, records a stable Sync run
+identity, and delegates execution to a separate Prefect deployment. Sync owns the HTTP,
+authorization, plan, result, artifact, audit, and idempotency contracts. Prefect owns live
+execution state, workers, retries, logs, and cancellation.
+
+The existing [Prefect remote run developer preview](./prefect-remote-run.mdx) remains a
+separate four-parameter deployment. Use the managed API when a trusted automation client
+needs reviewed-plan apply, durable results, artifact retrieval, or actor-scoped mutation
+control.
+
+## Install the managed profile
+
+The managed profile requires Python 3.11 or later. Install it on the API host and every
+worker that can run its deployment:
+
+```bash
+pip install 'infrahub-sync[managed]'
+```
+
+The profile directly installs FastAPI, Uvicorn, Prefect 3.8.1, and OpsMill Prefect Extras
+from commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does not
+import these packages. Ordinary CLI and Python API imports remain Prefect-free.
+
+You also need:
+
+- a Prefect API and an existing process work pool;
+- a worker with access to the allowed Sync configuration directory;
+- an absolute saved-plan cache path shared by worker processes; and
+- one absolute durable product-cache path visible to both the API and workers.
+
+The MVP product-cache profile uses SQLite and the local filesystem. Run the API and workers
+on infrastructure where they can use the same filesystem paths. The API does not copy
+worker-local paths through Prefect.
+
+## Configure principals
+
+`INFRAHUB_SYNC_MANAGED_BEARER_TOKENS` contains a non-empty JSON object keyed by actor. Each
+entry has a bearer token of at least 16 characters and an optional administrator flag:
+
+```bash
+export INFRAHUB_SYNC_MANAGED_BEARER_TOKENS='{
+  "automation@example.com": {
+    "token": "replace-with-a-secret-token",
+    "administrator": false
+  },
+  "sync-admin@example.com": {
+    "token": "replace-with-another-secret-token",
+    "administrator": true
+  }
+}'
+```
+
+Inject this value through your deployment's secret mechanism. Do not put a real token in a
+shell history, Sync configuration, request body, idempotency key, or Prefect parameter.
+Tokens must be unique. The resolver compares them with a timing-safe operation and never
+persists, returns, or submits them to Prefect.
+
+Any authenticated principal can create and inspect a run. Only the initiating actor or an
+administrator can verify, apply, or cancel it. Every accepted mutation and authorization
+refusal records secret-safe actor, reason, and outcome evidence.
+
+## Deploy the managed flow
+
+Set the work pool name, then apply the managed deployment:
+
+```bash
+export PREFECT_API_URL="http://127.0.0.1:4200/api"
+export INFRAHUB_SYNC_MANAGED_WORK_POOL="sync-process-pool"
+python -m infrahub_sync.managed.deploy
+```
+
+The command validates and applies `infrahub-sync-managed/run` through OpsMill Prefect
+Extras. It does not create a work pool or start a worker.
+
+Configure the worker environment before it starts:
+
+| Variable | Requirement |
+| --- | --- |
+| `PREFECT_API_URL` | Prefect API used by the deployment and worker. |
+| `INFRAHUB_SYNC_CONFIG_DIRECTORY` | Existing directory containing the Sync configurations allowed on this worker. |
+| `INFRAHUB_SYNC_CACHE_DIR` | Absolute shared cache root for saved plans and run artifacts. |
+| `INFRAHUB_SYNC_MANAGED_CACHE_LOCATION` | Absolute durable product-cache root shared with the API. |
+| Adapter credential variables | Credentials required by the selected Sync configuration. Keep them in the worker environment or its secret provider. |
+
+The managed flow accepts exactly seven bounded parameters:
+
+| Parameter | Type | Purpose |
+| --- | --- | --- |
+| `run_id` | `str` | API-created Sync run identity. |
+| `sync_name` | `str` | Configuration selected from the worker's configured directory. |
+| `stage` | `plan`, `verify`, `apply`, or `sync` | Execution stage accepted by the API. |
+| `configuration_reference` | `str` | Immutable, non-secret configuration revision recorded on the product run. |
+| `branch` | `str` or `null` | Optional Infrahub branch. |
+| `expected_checksum` | SHA-256 string or `null` | Reviewed checksum required by `apply`. |
+| `confirm_writes` | `bool` | Required for `apply` and composed `sync`. |
+
+The API rejects configured secret values in flow-bound request fields. Credentials,
+endpoints, adapter instances, and filesystem paths are never flow parameters.
+
+## Start the API
+
+Set the same product-cache path used by the worker and start Uvicorn through the packaged
+entry point:
+
+```bash
+export PREFECT_API_URL="http://127.0.0.1:4200/api"
+export INFRAHUB_SYNC_MANAGED_CACHE_LOCATION="/var/lib/infrahub-sync/product-cache"
+export INFRAHUB_SYNC_MANAGED_HOST="127.0.0.1"
+python -m infrahub_sync.managed.serve
+```
+
+The server listens on port `8000`. Its host defaults to `127.0.0.1`. Put TLS and any
+network access controls at your ingress boundary. The bearer-token provider is the MVP
+application authentication boundary, not a replacement for transport security.
+
+## Routes
+
+Every route requires `Authorization: Bearer <token>`. Every `POST` route also requires a
+non-empty `Idempotency-Key` header and a non-empty `reason` in its JSON body.
+
+| Route | Behavior |
+| --- | --- |
+| `POST /runs` | Create one Sync run and accept `plan` or confirmed composed `sync`. |
+| `GET /runs/{run_id}` | Return the durable product record with current linked Prefect detail when available. |
+| `GET /runs/{run_id}/plan` | Return retained saved-plan review data. |
+| `GET /runs/{run_id}/results` | Return retained results independently of Prefect result retention. |
+| `GET /runs/{run_id}/artifacts` | List immutable run-owned artifact references. |
+| `GET /runs/{run_id}/artifacts/{artifact_id}` | Return verified artifact bytes with their media type and `Digest` header. |
+| `POST /runs/{run_id}/verify` | Accept read-only saved-plan verification without changing product lifecycle state. |
+| `POST /runs/{run_id}/apply` | Accept a confirmed apply for the exact retained reviewed checksum. |
+| `POST /runs/{run_id}/cancel` | Ask Prefect to cancel only the latest active linked execution. |
+
+### Create a plan
+
+Supply a stable non-secret reference for the exact configuration revision you intend the
+worker to resolve:
+
+```bash
+curl --request POST http://127.0.0.1:8000/runs \
+  --header "Authorization: Bearer $SYNC_API_TOKEN" \
+  --header "Idempotency-Key: plan-inventory-2026-08-10" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "sync_name": "inventory",
+    "operation": "plan",
+    "configuration_reference": "sha256:7a15c1e2",
+    "reason": "review inventory changes"
+  }'
+```
+
+Acceptance returns `202` with the durable `ProductRun` and its first orchestration link.
+The `run_id` in that response is the identity for every later stage, result, artifact, and
+Prefect execution link.
+
+Read the plan after the worker publishes it:
+
+```bash
+curl --header "Authorization: Bearer $SYNC_API_TOKEN" \
+  http://127.0.0.1:8000/runs/20260810T1500-0123abcd/plan
+```
+
+The plan response includes its checksum, checksum verification state, summary, verification
+notes, and per-object operations.
+
+### Verify and apply the reviewed plan
+
+Verification is read-only and retains verification evidence without finishing or otherwise
+advancing the product run:
+
+```bash
+curl --request POST \
+  http://127.0.0.1:8000/runs/20260810T1500-0123abcd/verify \
+  --header "Authorization: Bearer $SYNC_API_TOKEN" \
+  --header "Idempotency-Key: verify-20260810T1500-0123abcd" \
+  --header "Content-Type: application/json" \
+  --data '{"reason":"verify the reviewed plan"}'
+```
+
+Apply requires the exact retained checksum and explicit write confirmation:
+
+```bash
+curl --request POST \
+  http://127.0.0.1:8000/runs/20260810T1500-0123abcd/apply \
+  --header "Authorization: Bearer $SYNC_API_TOKEN" \
+  --header "Idempotency-Key: apply-20260810T1500-0123abcd" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "expected_checksum": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "confirm_writes": true,
+    "reason": "change approved"
+  }'
+```
+
+The worker verifies the saved plan again before its first destination write. Destination
+deletes remain disabled.
+
+## Idempotency and retries
+
+An exact retry by the same actor with the same `Idempotency-Key`, target, and JSON body
+returns the stored status and body. A different request using that actor and key returns
+`409 idempotency-conflict`.
+
+Sync stores a SHA-256 digest of the client key, never the raw key. Before dispatch, it
+atomically reserves a durable mutation receipt; run creation reserves the receipt and
+product run in one transaction. The receipt owns a separate opaque key passed to Prefect's
+native idempotency field. If an HTTP or Prefect response is lost after submission, retry the
+exact request. The retry reuses the receipt, opaque Prefect key, Sync run ID, and Prefect
+flow-run ID.
+
+Do not change the request body, including `reason`, while retrying. Use a new idempotency key
+for a new intent.
+
+## Errors and retained state
+
+Every error uses the same envelope:
+
+```json
+{
+  "error": {
+    "code": "checksum-conflict",
+    "message": "expected_checksum does not match the retained reviewed plan",
+    "status": 409,
+    "run_id": "20260810T1500-0123abcd",
+    "mutation_id": null
+  }
+}
+```
+
+| Status | Meaning |
+| --- | --- |
+| `401` | Missing or invalid authentication. |
+| `403` | The actor does not own the mutation and is not an administrator. |
+| `404` | The Sync run or run-owned artifact does not exist. |
+| `409` | Idempotency conflict, missing confirmation, stale checksum, or non-cancellable execution. |
+| `410` | The retained plan or artifact has expired. |
+| `422` | Invalid request schema, missing idempotency key, or a secret-bearing flow parameter. |
+| `503` | Submission, live orchestration detail, or retained data cannot be confirmed or retrieved. |
+
+Prefect detail can expire or become unavailable while the durable Sync record, results,
+and published artifacts remain readable. Cancellation never deletes the product record or
+its execution history. The API does not add a Sync-owned queue, retry policy, scheduler,
+recovery state machine, or overlap policy.
+
+## Related
+
+- [Durable product records](./durable-product-records.mdx)
+- [Saved-plan review and apply](../running-a-sync.mdx)
+- [Prefect remote run developer preview](./prefect-remote-run.mdx)

--- a/docs/docs/reference/managed-http-api.mdx
+++ b/docs/docs/reference/managed-http-api.mdx
@@ -22,9 +22,9 @@ worker that can run its deployment:
 pip install 'infrahub-sync[managed]'
 ```
 
-The profile directly installs FastAPI, Uvicorn, Prefect 3.8.1, and OpsMill Prefect Extras
-from commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does not
-import these packages. Ordinary CLI and Python API imports remain Prefect-free.
+The profile directly installs FastAPI, HTTPX, Uvicorn, Prefect 3.8.1, and OpsMill Prefect
+Extras from commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does
+not import these packages. Ordinary CLI and Python API imports remain Prefect-free.
 
 You also need:
 
@@ -214,6 +214,12 @@ flow-run ID.
 
 Do not change the request body, including `reason`, while retrying. Use a new idempotency key
 for a new intent.
+
+The first confirmed composed `sync` or reviewed `apply` permanently consumes that run's
+single write admission, including when the execution later fails, crashes, or is cancelled.
+Retry an uncertain request with its original idempotency key. To make another write attempt
+after a terminal failure or cancellation, create and review a new plan run; a new key on the
+old run returns `409 apply-already-admitted`.
 
 ## Errors and retained state
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
         'reference/incremental-extraction',
         'reference/prefect-remote-run',
         'reference/durable-product-records',
+        'reference/managed-http-api',
       ],
     },
     {

--- a/infrahub_sync/managed/__init__.py
+++ b/infrahub_sync/managed/__init__.py
@@ -1,0 +1,5 @@
+"""Optional managed HTTP and Prefect integration.
+
+This package is intentionally not imported by :mod:`infrahub_sync`; install the
+``managed`` extra before importing its modules.
+"""

--- a/infrahub_sync/managed/_settings.py
+++ b/infrahub_sync/managed/_settings.py
@@ -1,0 +1,3 @@
+"""Environment names shared by managed API and worker composition roots."""
+
+PRODUCT_CACHE_ENV = "INFRAHUB_SYNC_MANAGED_CACHE_LOCATION"

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -1,0 +1,150 @@
+"""FastAPI routing for the stable managed Sync HTTP contract."""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import Depends, FastAPI, Header, Request, Response
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .auth import Principal, PrincipalResolver
+from .models import (
+    ApplyRunRequest,
+    ArtifactListResource,
+    CancelRunRequest,
+    CreateRunRequest,
+    ErrorDetail,
+    ErrorEnvelope,
+    PlanResource,
+    ResultsResource,
+    RunResource,
+    VerifyRunRequest,
+)
+from .service import ManagedAPIError, ManagedRunService
+
+logger = logging.getLogger(__name__)
+
+ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    status: {"model": ErrorEnvelope} for status in (401, 403, 404, 409, 410, 422, 503)
+}
+
+
+def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastAPI:
+    """Create the managed application from explicit providers."""
+    application = FastAPI(title="Infrahub Sync managed API", version="1.0.0")
+
+    def authenticate(request: Request, authorization: Annotated[str | None, Header()] = None) -> Principal:
+        if authorization is None or not authorization.startswith("Bearer "):
+            service.record_authentication_refusal(request.url.path, "missing-or-invalid-authorization")
+            raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
+        token = authorization.removeprefix("Bearer ")
+        principal = resolver.resolve(token)
+        if principal is None:
+            service.record_authentication_refusal(request.url.path, "invalid-bearer-token")
+            raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
+        return principal
+
+    def idempotency_key(value: Annotated[str | None, Header(alias="Idempotency-Key")] = None) -> str:
+        if value is None or not value.strip():
+            raise ManagedAPIError(422, "idempotency-key-required", "a non-empty Idempotency-Key header is required")
+        return value
+
+    @application.exception_handler(ManagedAPIError)
+    async def managed_error(_request: Request, exc: ManagedAPIError) -> JSONResponse:  # noqa: RUF029
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(
+                code=exc.code,
+                message=exc.message,
+                status=exc.status,
+                run_id=exc.run_id,
+                mutation_id=exc.mutation_id,
+            )
+        )
+        headers = {"WWW-Authenticate": "Bearer"} if exc.status == 401 else None
+        return JSONResponse(status_code=exc.status, content=envelope.model_dump(mode="json"), headers=headers)
+
+    @application.exception_handler(RequestValidationError)
+    async def validation_error(_request: Request, _exc: RequestValidationError) -> JSONResponse:  # noqa: RUF029
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(code="request-invalid", message="the request does not match the API schema", status=422)
+        )
+        return JSONResponse(status_code=422, content=envelope.model_dump(mode="json"))
+
+    @application.exception_handler(Exception)
+    async def unavailable_error(_request: Request, exc: Exception) -> JSONResponse:  # noqa: RUF029
+        logger.error("managed API request failed: %s", type(exc).__name__)
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(
+                code="service-unavailable",
+                message="the managed Sync service is temporarily unavailable",
+                status=503,
+            )
+        )
+        return JSONResponse(status_code=503, content=envelope.model_dump(mode="json"))
+
+    @application.post("/runs", status_code=202, response_model=RunResource, responses=ERROR_RESPONSES)
+    async def create_run(
+        body: CreateRunRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
+    ) -> JSONResponse:
+        status, content = await service.create_run(body, principal, key)
+        return JSONResponse(status_code=status, content=content)
+
+    @application.get("/runs/{run_id}", responses=ERROR_RESPONSES)
+    async def get_run(run_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> RunResource:
+        return await service.get_run(run_id)
+
+    @application.get("/runs/{run_id}/plan", responses=ERROR_RESPONSES)
+    def get_plan(run_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> PlanResource:
+        return service.get_plan(run_id)
+
+    @application.get("/runs/{run_id}/results", responses=ERROR_RESPONSES)
+    def get_results(run_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> ResultsResource:
+        return service.get_results(run_id)
+
+    @application.get(
+        "/runs/{run_id}/artifacts",
+        responses=ERROR_RESPONSES,
+    )
+    def list_artifacts(run_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> ArtifactListResource:
+        return service.list_artifacts(run_id)
+
+    @application.get("/runs/{run_id}/artifacts/{artifact_id}", responses=ERROR_RESPONSES)
+    def get_artifact(
+        run_id: str, artifact_id: str, _principal: Annotated[Principal, Depends(authenticate)]
+    ) -> Response:
+        data, media_type, digest = service.get_artifact(run_id, artifact_id)
+        return Response(content=data, media_type=media_type, headers={"Digest": f"sha-256={digest}"})
+
+    @application.post("/runs/{run_id}/verify", status_code=202, response_model=RunResource, responses=ERROR_RESPONSES)
+    async def verify_run(
+        run_id: str,
+        body: VerifyRunRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
+    ) -> JSONResponse:
+        status, content = await service.verify_run(run_id, body, principal, key)
+        return JSONResponse(status_code=status, content=content)
+
+    @application.post("/runs/{run_id}/apply", status_code=202, response_model=RunResource, responses=ERROR_RESPONSES)
+    async def apply_run(
+        run_id: str,
+        body: ApplyRunRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
+    ) -> JSONResponse:
+        status, content = await service.apply_run(run_id, body, principal, key)
+        return JSONResponse(status_code=status, content=content)
+
+    @application.post("/runs/{run_id}/cancel", status_code=202, response_model=RunResource, responses=ERROR_RESPONSES)
+    async def cancel_run(
+        run_id: str,
+        body: CancelRunRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
+    ) -> JSONResponse:
+        status, content = await service.cancel_run(run_id, body, principal, key)
+        return JSONResponse(status_code=status, content=content)
+
+    return application

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -1,6 +1,7 @@
 """FastAPI routing for the stable managed Sync HTTP contract."""
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, Header, Request, Response
@@ -34,10 +35,11 @@ def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastA
     application = FastAPI(title="Infrahub Sync managed API", version="1.0.0")
 
     def authenticate(request: Request, authorization: Annotated[str | None, Header()] = None) -> Principal:
-        if authorization is None or not authorization.startswith("Bearer "):
+        parts = [] if authorization is None else authorization.split(None, 1)
+        if len(parts) != 2 or parts[0].casefold() != "bearer" or not parts[1]:
             service.record_authentication_refusal(request.url.path, "missing-or-invalid-authorization")
             raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
-        token = authorization.removeprefix("Bearer ")
+        token = parts[1]
         principal = resolver.resolve(token)
         if principal is None:
             service.record_authentication_refusal(request.url.path, "invalid-bearer-token")
@@ -70,9 +72,17 @@ def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastA
         )
         return JSONResponse(status_code=422, content=envelope.model_dump(mode="json"))
 
-    @application.exception_handler(Exception)
-    async def unavailable_error(_request: Request, exc: Exception) -> JSONResponse:  # noqa: RUF029
-        logger.error("managed API request failed: %s", type(exc).__name__)
+    @application.middleware("http")
+    async def contain_unhandled_error(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        try:
+            return await call_next(request)
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            logger.error(  # noqa: TRY400 - raw traceback text must not cross this log boundary.
+                "managed API request failed: %s", type(exc).__name__
+            )
         envelope = ErrorEnvelope(
             error=ErrorDetail(
                 code="service-unavailable",

--- a/infrahub_sync/managed/auth.py
+++ b/infrahub_sync/managed/auth.py
@@ -1,0 +1,88 @@
+"""Application-owned principal resolution for the managed API."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+PRINCIPALS_ENV = "INFRAHUB_SYNC_MANAGED_BEARER_TOKENS"
+
+
+class Principal(BaseModel):
+    """Authenticated managed-API actor."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    actor: str = Field(min_length=1)
+    administrator: bool = False
+
+
+class PrincipalResolver(Protocol):
+    """Narrow authentication provider replaced without changing HTTP routes."""
+
+    @property
+    def secret_values(self) -> tuple[str, ...]: ...
+
+    def resolve(self, token: str) -> Principal | None: ...
+
+
+class _ConfiguredPrincipal(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    token: str = Field(min_length=16)
+    administrator: bool = False
+
+
+class EnvironmentPrincipalResolver:
+    """Resolve bearer tokens from one environment-configured JSON mapping."""
+
+    def __init__(self, entries: tuple[tuple[str, _ConfiguredPrincipal], ...]) -> None:
+        self._entries = entries
+
+    @classmethod
+    def from_environment(cls) -> EnvironmentPrincipalResolver:
+        """Load ``{actor: {token, administrator}}`` without retaining raw JSON."""
+        raw = os.environ.get(PRINCIPALS_ENV)
+        if not raw:
+            msg = f"{PRINCIPALS_ENV} must contain a JSON object of managed API principals"
+            raise ValueError(msg)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            msg = f"{PRINCIPALS_ENV} must contain valid JSON"
+            raise ValueError(msg) from None
+        if not isinstance(payload, dict) or not payload:
+            msg = f"{PRINCIPALS_ENV} must contain a non-empty JSON object"
+            raise ValueError(msg)
+        try:
+            entries = tuple(
+                (str(actor).strip(), _ConfiguredPrincipal.model_validate(value)) for actor, value in payload.items()
+            )
+        except ValidationError:
+            msg = f"{PRINCIPALS_ENV} contains an invalid principal definition"
+            raise ValueError(msg) from None
+        if any(not actor for actor, _ in entries):
+            msg = f"{PRINCIPALS_ENV} contains an empty actor name"
+            raise ValueError(msg)
+        tokens = [entry.token for _, entry in entries]
+        if len(tokens) != len(set(tokens)):
+            msg = f"{PRINCIPALS_ENV} assigns one bearer token to multiple actors"
+            raise ValueError(msg)
+        return cls(entries)
+
+    @property
+    def secret_values(self) -> tuple[str, ...]:
+        """Return token values for boundary redaction, never persistence."""
+        return tuple(entry.token for _, entry in self._entries)
+
+    def resolve(self, token: str) -> Principal | None:
+        """Compare every configured token with a timing-safe operation."""
+        matched: Principal | None = None
+        for actor, entry in self._entries:
+            if hmac.compare_digest(token.encode(), entry.token.encode()):
+                matched = Principal(actor=actor, administrator=entry.administrator)
+        return matched

--- a/infrahub_sync/managed/deploy.py
+++ b/infrahub_sync/managed/deploy.py
@@ -1,0 +1,33 @@
+"""Converge the separate managed deployment onto an existing Prefect work pool."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from opsmill_prefect_extras.deployments import apply_deployments
+from opsmill_prefect_extras.workflows import WorkflowCatalogue, assert_valid_definitions
+
+from .orchestration import MANAGED_DEFINITION
+
+WORK_POOL_ENV = "INFRAHUB_SYNC_MANAGED_WORK_POOL"
+CATALOGUE = WorkflowCatalogue(MANAGED_DEFINITION)
+
+
+async def _deploy() -> int:
+    assert_valid_definitions(CATALOGUE)
+    work_pool = os.environ.get(WORK_POOL_ENV)
+    if not work_pool:
+        msg = f"{WORK_POOL_ENV} must name an existing Prefect work pool"
+        raise ValueError(msg)
+    report = await apply_deployments(CATALOGUE, work_pool_name=work_pool)
+    return 0 if report.is_successful else 1
+
+
+def main() -> int:
+    """Validate the catalogue and apply its one managed deployment."""
+    return asyncio.run(_deploy())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -6,7 +6,7 @@
 
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
@@ -20,7 +20,9 @@ from infrahub_sync.execution import (
     bounded_run_lock,
     collect_secret_values,
     execute_run,
+    redact,
     resolve_sync_instance,
+    sanitize_exception_chain,
 )
 from infrahub_sync.orchestration.flow import BRIDGED_LEVEL, SOURCE_LOGGER_NAME, RunLogger, RunLoggerBridge
 from infrahub_sync.plan.review import SavedPlan
@@ -45,21 +47,29 @@ def _run_logger() -> tuple[RunLogger, bool]:
 
 
 @contextmanager
-def _remote_log_bridge(run_logger: RunLogger, *, prefect_context: bool) -> Iterator[None]:
+def _remote_log_bridge(
+    run_logger: RunLogger,
+    *,
+    prefect_context: bool,
+    secrets: Sequence[str] = (),
+) -> Iterator[None]:
     """Bridge shared logs only when a real Prefect run context owns the logger."""
     if not prefect_context:
         yield
         return
     source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
-    bridge = RunLoggerBridge(run_logger)
+    bridge = RunLoggerBridge(run_logger, secrets=secrets)
     previous_level = source_logger.level
+    previous_propagate = source_logger.propagate
     source_logger.addHandler(bridge)
     source_logger.setLevel(BRIDGED_LEVEL)
+    source_logger.propagate = False
     try:
         yield
     finally:
         source_logger.removeHandler(bridge)
         source_logger.setLevel(previous_level)
+        source_logger.propagate = previous_propagate
 
 
 def _runtime() -> tuple[str, ProductProjection]:
@@ -90,7 +100,7 @@ def _review_document(run_id: str, saved: SavedPlan) -> PlanResource:
     )
 
 
-def _publish_plan(projection: ProductProjection, run_id: str, saved: SavedPlan, secrets: tuple[str, ...]) -> None:
+def _publish_plan(projection: ProductProjection, run_id: str, saved: SavedPlan, secrets: Sequence[str]) -> None:
     document = _review_document(run_id, saved)
     projection.publish_artifact(
         run_id,
@@ -134,8 +144,128 @@ def _plan(
     return saved
 
 
+def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
+    run_id: str,
+    sync_name: str,
+    stage: Literal["plan", "verify", "apply", "sync"],
+    configuration_reference: str,
+    branch: str | None,
+    expected_checksum: str | None,
+    confirm_writes: bool,
+    run_logger: RunLogger,
+    secrets: list[str],
+) -> dict[str, Any]:
+    """Resolve and execute one managed stage within the sanitized worker boundary."""
+    config_directory, projection = _runtime()
+    stored = projection.lookup_run(run_id)
+    if stored.value is None:
+        msg = f"API-created Sync run {run_id!r} is unavailable"
+        raise RuntimeError(msg)
+    if stored.value.configuration_reference != configuration_reference:
+        msg = f"configuration_reference does not match Sync run {run_id!r}"
+        raise ValueError(msg)
+    recorded_sync_name = stored.value.summary.get("sync_name")
+    if recorded_sync_name is not None and recorded_sync_name != sync_name:
+        msg = f"sync_name does not match Sync run {run_id!r}"
+        raise ValueError(msg)
+    if stage in ("apply", "sync") and not confirm_writes:
+        msg = f"confirm_writes=true is required for managed stage={stage}"
+        raise ValueError(msg)
+    if stage == "apply" and expected_checksum is None:
+        msg = "expected_checksum is required for managed stage=apply"
+        raise ValueError(msg)
+
+    instance = resolve_sync_instance(sync_name, directory=config_directory)
+    secrets[:] = collect_secret_values(instance)
+    result: dict[str, Any]
+    if stage == "plan":
+        saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=False)
+        _publish_plan(projection, run_id, saved, secrets)
+        summary = saved.summary()
+        outcome = "no-change" if summary.total == 0 else "planned"
+        result = {"run_id": run_id, "stage": stage, "outcome": outcome, "summary": summary.model_dump(mode="json")}
+        projection.finish_run(
+            run_id,
+            phase="planned",
+            outcome=outcome,
+            summary={"sync_name": sync_name, **summary.model_dump(mode="json")},
+            results=result,
+            secrets=secrets,
+        )
+    elif stage == "verify":
+        saved = execute_run(instance, operation="verify", run_id=run_id, _require_verified=True)
+        assert isinstance(saved, SavedPlan)
+        result = {
+            "run_id": run_id,
+            "stage": stage,
+            "outcome": "verified",
+            "checksum": saved.manifest.plan_checksum,
+            "checksum_ok": saved.checksum_ok,
+            "verification_notes": list(saved.verification_notes),
+        }
+        projection.record_results(
+            run_id,
+            {**stored.value.results, "verification": result},
+            secrets=secrets,
+        )
+    elif stage == "apply":
+        applied = execute_run(
+            instance,
+            operation="apply",
+            run_id=run_id,
+            branch=branch,
+            expected_checksum=expected_checksum,
+            confirm_writes=True,
+        )
+        assert isinstance(applied, RunResult)
+        result = _result_data(applied)
+        projection.finish_run(
+            run_id,
+            phase="applied",
+            outcome=applied.status,
+            summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
+            results=result,
+            secrets=secrets,
+        )
+    else:
+        with bounded_run_lock(instance.name, timeout=60.0):
+            saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=True)
+            _publish_plan(projection, run_id, saved, secrets)
+            verified = execute_run(
+                instance,
+                operation="verify",
+                run_id=run_id,
+                _lock_already_held=True,
+                _run_file_mode="sync",
+                _require_verified=True,
+            )
+            assert isinstance(verified, SavedPlan)
+            applied = execute_run(
+                instance,
+                operation="apply",
+                run_id=run_id,
+                branch=branch,
+                expected_checksum=verified.manifest.plan_checksum,
+                confirm_writes=True,
+                _lock_already_held=True,
+                _run_file_mode="sync",
+            )
+            assert isinstance(applied, RunResult)
+        result = _result_data(applied)
+        projection.finish_run(
+            run_id,
+            phase="applied",
+            outcome=applied.status,
+            summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
+            results=result,
+            secrets=secrets,
+        )
+    run_logger.info(redact(f"managed Sync run {run_id} stage={stage} outcome={result['outcome']}", secrets))
+    return result
+
+
 @flow(name=MANAGED_FLOW_NAME)
-def managed_sync_run(  # pylint: disable=too-many-positional-arguments,too-many-statements
+def managed_sync_run(  # pylint: disable=too-many-positional-arguments
     run_id: str,
     sync_name: str,
     stage: Literal["plan", "verify", "apply", "sync"],
@@ -146,110 +276,24 @@ def managed_sync_run(  # pylint: disable=too-many-positional-arguments,too-many-
 ) -> dict[str, Any]:
     """Execute one API-reserved stage and publish its durable product data."""
     run_logger, prefect_context = _run_logger()
-    with _remote_log_bridge(run_logger, prefect_context=prefect_context):
-        config_directory, projection = _runtime()
-        stored = projection.lookup_run(run_id)
-        if stored.value is None:
-            msg = f"API-created Sync run {run_id!r} is unavailable"
-            raise RuntimeError(msg)
-        if stored.value.configuration_reference != configuration_reference:
-            msg = f"configuration_reference does not match Sync run {run_id!r}"
-            raise ValueError(msg)
-        recorded_sync_name = stored.value.summary.get("sync_name")
-        if recorded_sync_name is not None and recorded_sync_name != sync_name:
-            msg = f"sync_name does not match Sync run {run_id!r}"
-            raise ValueError(msg)
-        if stage in ("apply", "sync") and not confirm_writes:
-            msg = f"confirm_writes=true is required for managed stage={stage}"
-            raise ValueError(msg)
-        if stage == "apply" and expected_checksum is None:
-            msg = "expected_checksum is required for managed stage=apply"
-            raise ValueError(msg)
-
-        instance = resolve_sync_instance(sync_name, directory=config_directory)
-        secrets = collect_secret_values(instance)
-        result: dict[str, Any]
-        if stage == "plan":
-            saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=False)
-            _publish_plan(projection, run_id, saved, secrets)
-            summary = saved.summary()
-            outcome = "no-change" if summary.total == 0 else "planned"
-            result = {"run_id": run_id, "stage": stage, "outcome": outcome, "summary": summary.model_dump(mode="json")}
-            projection.finish_run(
+    secrets = list(collect_secret_values())
+    failure: Exception | None = None
+    try:
+        with _remote_log_bridge(run_logger, prefect_context=prefect_context, secrets=secrets):
+            return _execute_stage(
                 run_id,
-                phase="planned",
-                outcome=outcome,
-                summary={"sync_name": sync_name, **summary.model_dump(mode="json")},
-                results=result,
-                secrets=secrets,
+                sync_name,
+                stage,
+                configuration_reference,
+                branch,
+                expected_checksum,
+                confirm_writes,
+                run_logger,
+                secrets,
             )
-        elif stage == "verify":
-            saved = execute_run(instance, operation="verify", run_id=run_id, _require_verified=True)
-            assert isinstance(saved, SavedPlan)
-            result = {
-                "run_id": run_id,
-                "stage": stage,
-                "outcome": "verified",
-                "checksum": saved.manifest.plan_checksum,
-                "checksum_ok": saved.checksum_ok,
-                "verification_notes": list(saved.verification_notes),
-            }
-            projection.record_results(
-                run_id,
-                {**stored.value.results, "verification": result},
-                secrets=secrets,
-            )
-        elif stage == "apply":
-            applied = execute_run(
-                instance,
-                operation="apply",
-                run_id=run_id,
-                branch=branch,
-                expected_checksum=expected_checksum,
-                confirm_writes=True,
-            )
-            assert isinstance(applied, RunResult)
-            result = _result_data(applied)
-            projection.finish_run(
-                run_id,
-                phase="applied",
-                outcome=applied.status,
-                summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
-                results=result,
-                secrets=secrets,
-            )
-        else:
-            with bounded_run_lock(instance.name, timeout=60.0):
-                saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=True)
-                _publish_plan(projection, run_id, saved, secrets)
-                verified = execute_run(
-                    instance,
-                    operation="verify",
-                    run_id=run_id,
-                    _lock_already_held=True,
-                    _run_file_mode="sync",
-                    _require_verified=True,
-                )
-                assert isinstance(verified, SavedPlan)
-                applied = execute_run(
-                    instance,
-                    operation="apply",
-                    run_id=run_id,
-                    branch=branch,
-                    expected_checksum=verified.manifest.plan_checksum,
-                    confirm_writes=True,
-                    _lock_already_held=True,
-                    _run_file_mode="sync",
-                )
-                assert isinstance(applied, RunResult)
-            result = _result_data(applied)
-            projection.finish_run(
-                run_id,
-                phase="applied",
-                outcome=applied.status,
-                summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
-                results=result,
-                secrets=secrets,
-            )
-        run_logger.info("managed Sync run %s stage=%s outcome=%s", run_id, stage, result["outcome"])
-        return result
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # Rebuilt after the original exception context exits.
+        failure = sanitize_exception_chain(exc, secrets)
+    assert failure is not None
+    secrets.clear()
+    raise failure

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -25,6 +25,7 @@ from infrahub_sync.execution import (
     sanitize_exception_chain,
 )
 from infrahub_sync.orchestration.flow import BRIDGED_LEVEL, SOURCE_LOGGER_NAME, RunLogger, RunLoggerBridge
+from infrahub_sync.plan.models import ApplyRecord
 from infrahub_sync.plan.review import SavedPlan
 from infrahub_sync.product_store import ProductProjection, local_product_projection
 
@@ -203,9 +204,9 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
             "checksum_ok": saved.checksum_ok,
             "verification_notes": list(saved.verification_notes),
         }
-        projection.record_results(
+        projection.merge_results(
             run_id,
-            {**stored.value.results, "verification": result},
+            {"verification": result},
             secrets=secrets,
         )
     elif stage == "apply":
@@ -264,6 +265,68 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
     return result
 
 
+def _failure_evidence(
+    stage: Literal["plan", "verify", "apply", "sync"],
+    exc: Exception,
+) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "stage": stage,
+        "outcome": "failed",
+        "error_type": type(exc).__name__,
+    }
+    apply_record = getattr(exc, "apply_record", None)
+    if isinstance(apply_record, ApplyRecord):
+        evidence.update(apply_record.as_summary_keys())
+    return evidence
+
+
+def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    run_id: str,
+    stage: Literal["plan", "verify", "apply", "sync"],
+    exc: Exception,
+    run_logger: RunLogger,
+    secrets: Sequence[str],
+) -> None:
+    """Best-effort durable product evidence without masking the worker failure."""
+    try:
+        _config_directory, projection = _runtime()
+        stored = projection.lookup_run(run_id).value
+        if stored is None:
+            return
+        evidence = _failure_evidence(stage, exc)
+        projection.merge_results(run_id, {f"{stage}_failure": evidence}, secrets=secrets)
+        if stage == "verify":
+            return
+        refreshed = projection.lookup_run(run_id).value
+        if refreshed is None:
+            return
+        partial = {
+            key: evidence[key]
+            for key in (
+                "applied_operations",
+                "skipped_delete_operations",
+                "skipped_delete_count",
+                "failed_operation",
+                "may_have_partially_written",
+            )
+            if key in evidence
+        }
+        projection.finish_run(
+            run_id,
+            phase=f"{stage}-failed",
+            outcome="failed",
+            summary={**refreshed.summary, "failed_stage": stage, **partial},
+            results=refreshed.results,
+            secrets=secrets,
+        )
+    except Exception as persistence_error:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        run_logger.log(
+            logging.WARNING,
+            "managed Sync failure evidence could not be persisted (%s)",
+            type(persistence_error).__name__,
+        )
+
+
 @flow(name=MANAGED_FLOW_NAME)
 def managed_sync_run(  # pylint: disable=too-many-positional-arguments
     run_id: str,
@@ -293,6 +356,7 @@ def managed_sync_run(  # pylint: disable=too-many-positional-arguments
             )
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Rebuilt after the original exception context exits.
+        _record_failure(run_id, stage, exc, run_logger, secrets)
         failure = sanitize_exception_chain(exc, secrets)
     assert failure is not None
     secrets.clear()

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -1,0 +1,255 @@
+"""Separate Prefect flow for API-created durable Sync runs."""
+
+# Deliberately no ``from __future__ import annotations``. Prefect parameter
+# validation must receive the concrete Literal at runtime; the preserved
+# Developer Preview flow documents the affected Prefect/Pydantic versions.
+
+import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Literal
+
+from prefect import flow, get_run_logger
+from prefect.exceptions import MissingContextError
+
+from infrahub_sync.execution import (
+    ACTION_KEYS,
+    RunResult,
+    bounded_run_lock,
+    collect_secret_values,
+    execute_run,
+    resolve_sync_instance,
+)
+from infrahub_sync.orchestration.flow import BRIDGED_LEVEL, SOURCE_LOGGER_NAME, RunLogger, RunLoggerBridge
+from infrahub_sync.plan.review import SavedPlan
+from infrahub_sync.product_store import ProductProjection, local_product_projection
+
+from ._settings import PRODUCT_CACHE_ENV
+from .models import PlanResource
+from .orchestration import MANAGED_FLOW_NAME
+from .service import PLAN_ARTIFACT_ID
+
+CONFIG_DIR_ENV = "INFRAHUB_SYNC_CONFIG_DIRECTORY"
+RUN_CACHE_ENV = "INFRAHUB_SYNC_CACHE_DIR"
+logger = logging.getLogger(__name__)
+
+
+def _run_logger() -> tuple[RunLogger, bool]:
+    """Use Prefect logging in a run and a local logger in executor-only tests."""
+    try:
+        return get_run_logger(), True
+    except MissingContextError:
+        return logger, False
+
+
+@contextmanager
+def _remote_log_bridge(run_logger: RunLogger, *, prefect_context: bool) -> Iterator[None]:
+    """Bridge shared logs only when a real Prefect run context owns the logger."""
+    if not prefect_context:
+        yield
+        return
+    source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
+    bridge = RunLoggerBridge(run_logger)
+    previous_level = source_logger.level
+    source_logger.addHandler(bridge)
+    source_logger.setLevel(BRIDGED_LEVEL)
+    try:
+        yield
+    finally:
+        source_logger.removeHandler(bridge)
+        source_logger.setLevel(previous_level)
+
+
+def _runtime() -> tuple[str, ProductProjection]:
+    config_directory = os.environ.get(CONFIG_DIR_ENV)
+    product_cache = os.environ.get(PRODUCT_CACHE_ENV)
+    run_cache = os.environ.get(RUN_CACHE_ENV)
+    if not config_directory or not Path(config_directory).is_dir():
+        msg = f"{CONFIG_DIR_ENV} must name the worker's configuration directory"
+        raise RuntimeError(msg)
+    if not product_cache:
+        msg = f"{PRODUCT_CACHE_ENV} must name the worker's durable product cache"
+        raise RuntimeError(msg)
+    if not run_cache or not Path(run_cache).expanduser().is_absolute():
+        msg = f"{RUN_CACHE_ENV} must name an absolute shared saved-plan cache"
+        raise RuntimeError(msg)
+    return config_directory, local_product_projection(Path(product_cache).expanduser())
+
+
+def _review_document(run_id: str, saved: SavedPlan) -> PlanResource:
+    summary = saved.summary()
+    return PlanResource(
+        run_id=run_id,
+        checksum=saved.manifest.plan_checksum,
+        checksum_ok=saved.checksum_ok,
+        verification_notes=tuple(saved.verification_notes),
+        summary=summary.model_dump(mode="json"),
+        operations=tuple(operation.model_dump(mode="json") for operation in saved.operations()),
+    )
+
+
+def _publish_plan(projection: ProductProjection, run_id: str, saved: SavedPlan, secrets: tuple[str, ...]) -> None:
+    document = _review_document(run_id, saved)
+    projection.publish_artifact(
+        run_id,
+        artifact_id=PLAN_ARTIFACT_ID,
+        kind="saved-plan-review",
+        media_type="application/json",
+        data=document.model_dump_json().encode(),
+        secrets=secrets,
+    )
+
+
+def _result_data(result: RunResult) -> dict[str, Any]:
+    return {
+        "run_id": result.run_id,
+        "operation": result.operation,
+        "outcome": result.status,
+        "changed": result.changed,
+        "summary": {key: result.summary[key] for key in ACTION_KEYS},
+    }
+
+
+def _plan(
+    instance: Any,
+    *,
+    run_id: str,
+    branch: str | None,
+    composed_sync: bool,
+) -> SavedPlan:
+    saved = execute_run(
+        instance,
+        operation="plan",
+        branch=branch,
+        run_id=run_id,
+        show_progress=False,
+        print_diff=False,
+        _lock_already_held=composed_sync,
+        _run_file_mode="sync" if composed_sync else None,
+        _return_saved_plan=True,
+    )
+    assert isinstance(saved, SavedPlan)
+    return saved
+
+
+@flow(name=MANAGED_FLOW_NAME)
+def managed_sync_run(  # pylint: disable=too-many-positional-arguments,too-many-statements
+    run_id: str,
+    sync_name: str,
+    stage: Literal["plan", "verify", "apply", "sync"],
+    configuration_reference: str,
+    branch: str | None = None,
+    expected_checksum: str | None = None,
+    confirm_writes: bool = False,
+) -> dict[str, Any]:
+    """Execute one API-reserved stage and publish its durable product data."""
+    run_logger, prefect_context = _run_logger()
+    with _remote_log_bridge(run_logger, prefect_context=prefect_context):
+        config_directory, projection = _runtime()
+        stored = projection.lookup_run(run_id)
+        if stored.value is None:
+            msg = f"API-created Sync run {run_id!r} is unavailable"
+            raise RuntimeError(msg)
+        if stored.value.configuration_reference != configuration_reference:
+            msg = f"configuration_reference does not match Sync run {run_id!r}"
+            raise ValueError(msg)
+        recorded_sync_name = stored.value.summary.get("sync_name")
+        if recorded_sync_name is not None and recorded_sync_name != sync_name:
+            msg = f"sync_name does not match Sync run {run_id!r}"
+            raise ValueError(msg)
+        if stage in ("apply", "sync") and not confirm_writes:
+            msg = f"confirm_writes=true is required for managed stage={stage}"
+            raise ValueError(msg)
+        if stage == "apply" and expected_checksum is None:
+            msg = "expected_checksum is required for managed stage=apply"
+            raise ValueError(msg)
+
+        instance = resolve_sync_instance(sync_name, directory=config_directory)
+        secrets = collect_secret_values(instance)
+        result: dict[str, Any]
+        if stage == "plan":
+            saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=False)
+            _publish_plan(projection, run_id, saved, secrets)
+            summary = saved.summary()
+            outcome = "no-change" if summary.total == 0 else "planned"
+            result = {"run_id": run_id, "stage": stage, "outcome": outcome, "summary": summary.model_dump(mode="json")}
+            projection.finish_run(
+                run_id,
+                phase="planned",
+                outcome=outcome,
+                summary={"sync_name": sync_name, **summary.model_dump(mode="json")},
+                results=result,
+                secrets=secrets,
+            )
+        elif stage == "verify":
+            saved = execute_run(instance, operation="verify", run_id=run_id, _require_verified=True)
+            assert isinstance(saved, SavedPlan)
+            result = {
+                "run_id": run_id,
+                "stage": stage,
+                "outcome": "verified",
+                "checksum": saved.manifest.plan_checksum,
+                "checksum_ok": saved.checksum_ok,
+                "verification_notes": list(saved.verification_notes),
+            }
+            projection.record_results(
+                run_id,
+                {**stored.value.results, "verification": result},
+                secrets=secrets,
+            )
+        elif stage == "apply":
+            applied = execute_run(
+                instance,
+                operation="apply",
+                run_id=run_id,
+                branch=branch,
+                expected_checksum=expected_checksum,
+                confirm_writes=True,
+            )
+            assert isinstance(applied, RunResult)
+            result = _result_data(applied)
+            projection.finish_run(
+                run_id,
+                phase="applied",
+                outcome=applied.status,
+                summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
+                results=result,
+                secrets=secrets,
+            )
+        else:
+            with bounded_run_lock(instance.name, timeout=60.0):
+                saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=True)
+                _publish_plan(projection, run_id, saved, secrets)
+                verified = execute_run(
+                    instance,
+                    operation="verify",
+                    run_id=run_id,
+                    _lock_already_held=True,
+                    _run_file_mode="sync",
+                    _require_verified=True,
+                )
+                assert isinstance(verified, SavedPlan)
+                applied = execute_run(
+                    instance,
+                    operation="apply",
+                    run_id=run_id,
+                    branch=branch,
+                    expected_checksum=verified.manifest.plan_checksum,
+                    confirm_writes=True,
+                    _lock_already_held=True,
+                    _run_file_mode="sync",
+                )
+                assert isinstance(applied, RunResult)
+            result = _result_data(applied)
+            projection.finish_run(
+                run_id,
+                phase="applied",
+                outcome=applied.status,
+                summary={"sync_name": sync_name, **{key: applied.summary[key] for key in ACTION_KEYS}},
+                results=result,
+                secrets=secrets,
+            )
+        run_logger.info("managed Sync run %s stage=%s outcome=%s", run_id, stage, result["outcome"])
+        return result

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -1,0 +1,106 @@
+"""Stable request and response records for the managed HTTP surface."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from infrahub_sync.product_store import ArtifactReference, ProductRun  # noqa: TC001 - Pydantic resolves at runtime.
+
+ManagedStage = Literal["plan", "verify", "apply", "sync"]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class CreateRunRequest(_StrictModel):
+    """Create one managed plan or confirmed composed sync."""
+
+    sync_name: str = Field(min_length=1)
+    operation: Literal["plan", "sync"] = "plan"
+    configuration_reference: str = Field(min_length=1)
+    branch: str | None = None
+    confirm_writes: bool = False
+    reason: str = Field(min_length=1)
+
+
+class VerifyRunRequest(_StrictModel):
+    """Request a read-only verification stage."""
+
+    reason: str = Field(min_length=1)
+
+
+class ApplyRunRequest(_StrictModel):
+    """Request confirmed apply of one reviewed checksum."""
+
+    expected_checksum: str = Field(pattern=r"^[0-9a-f]{64}$")
+    confirm_writes: bool = False
+    branch: str | None = None
+    reason: str = Field(min_length=1)
+
+
+class CancelRunRequest(_StrictModel):
+    """Request cancellation of the current managed Prefect execution."""
+
+    reason: str = Field(min_length=1)
+
+
+class OrchestrationSummary(_StrictModel):
+    """Current Prefect detail layered over one durable execution link."""
+
+    flow_run_id: str
+    purpose: str
+    attempt: int
+    state: str | None
+    detail_available: bool
+    unavailable_reason: str | None = None
+
+
+class RunResource(_StrictModel):
+    """Stable Sync record plus non-authoritative live orchestration detail."""
+
+    run: ProductRun
+    orchestration: tuple[OrchestrationSummary, ...]
+
+
+class PlanResource(_StrictModel):
+    """Retained saved-plan review data."""
+
+    run_id: str
+    checksum: str
+    checksum_ok: bool
+    verification_notes: tuple[str, ...]
+    summary: dict[str, Any]
+    operations: tuple[dict[str, Any], ...]
+
+
+class ResultsResource(_StrictModel):
+    """Retained product results independent of Prefect result storage."""
+
+    run_id: str
+    results: dict[str, Any]
+
+
+class ArtifactListResource(_StrictModel):
+    """Immutable artifact references owned by one Sync run."""
+
+    run_id: str
+    artifacts: tuple[ArtifactReference, ...]
+
+
+class ErrorDetail(_StrictModel):
+    """Typed secret-safe HTTP error detail."""
+
+    code: str
+    message: str
+    status: int
+    run_id: str | None = None
+    mutation_id: str | None = None
+
+
+class ErrorEnvelope(_StrictModel):
+    """Stable envelope used by every managed API error."""
+
+    error: ErrorDetail

--- a/infrahub_sync/managed/orchestration.py
+++ b/infrahub_sync/managed/orchestration.py
@@ -1,0 +1,83 @@
+"""Prefect Extras translation and live-state access for the managed API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import UUID
+
+from opsmill_prefect_extras.executors import (
+    IdempotentWorkflowExecutor,
+    RemoteExecutionClient,
+    RemoteWorkflowExecutor,
+)
+from opsmill_prefect_extras.workflows import WorkflowDefinition
+from prefect.exceptions import ObjectNotFound
+from prefect.states import Cancelling
+
+MANAGED_FLOW_NAME = "infrahub-sync-managed"
+MANAGED_DEPLOYMENT_NAME = "run"
+MANAGED_DEFINITION = WorkflowDefinition(
+    flow_name=MANAGED_FLOW_NAME,
+    deployment_name=MANAGED_DEPLOYMENT_NAME,
+    module="infrahub_sync.managed.flow",
+    function="managed_sync_run",
+    tags=("infrahub-sync", "managed"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Submission:
+    """One Prefect-accepted managed execution."""
+
+    flow_run_id: str
+    state: str
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """Available Prefect state or explicit missing detail."""
+
+    available: bool
+    state: str | None
+    reason: str | None = None
+
+
+class ManagedOrchestration(Protocol):
+    """Small orchestration boundary consumed by the HTTP service."""
+
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission: ...
+
+    async def observe(self, flow_run_id: str) -> Observation: ...
+
+    async def cancel(self, flow_run_id: str) -> Observation: ...
+
+
+class PrefectOrchestration:
+    """Use Prefect Extras for submission and Prefect as live-state authority."""
+
+    def __init__(self, client: RemoteExecutionClient, executor: IdempotentWorkflowExecutor | None = None) -> None:
+        self._client = client
+        self._executor = executor or RemoteWorkflowExecutor(client)
+
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:
+        handle = await self._executor.submit(MANAGED_DEFINITION, parameters, idempotency_key=idempotency_key)
+        return Submission(flow_run_id=handle.id, state=await handle.status())
+
+    async def observe(self, flow_run_id: str) -> Observation:
+        try:
+            run = await self._client.read_flow_run(UUID(flow_run_id))
+        except ObjectNotFound:
+            return Observation(available=False, state=None, reason="prefect-execution-unavailable")
+        state = run.state
+        if state is None:
+            return Observation(available=True, state="pending")
+        state_name = state.name or state.type.value
+        return Observation(available=True, state=state_name.lower())
+
+    async def cancel(self, flow_run_id: str) -> Observation:
+        observed = await self.observe(flow_run_id)
+        if not observed.available or observed.state in {"completed", "failed", "crashed", "cancelled"}:
+            return observed
+        await self._client.set_flow_run_state(UUID(flow_run_id), Cancelling())
+        return await self.observe(flow_run_id)

--- a/infrahub_sync/managed/orchestration.py
+++ b/infrahub_sync/managed/orchestration.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
+import httpx
 from opsmill_prefect_extras.executors import (
     IdempotentWorkflowExecutor,
     RemoteExecutionClient,
@@ -69,6 +70,8 @@ class PrefectOrchestration:
             run = await self._client.read_flow_run(UUID(flow_run_id))
         except ObjectNotFound:
             return Observation(available=False, state=None, reason="prefect-execution-unavailable")
+        except httpx.HTTPError:
+            return Observation(available=False, state=None, reason="prefect-read-unavailable")
         state = run.state
         if state is None:
             return Observation(available=True, state="pending")
@@ -79,5 +82,8 @@ class PrefectOrchestration:
         observed = await self.observe(flow_run_id)
         if not observed.available or observed.state in {"completed", "failed", "crashed", "cancelled"}:
             return observed
-        await self._client.set_flow_run_state(UUID(flow_run_id), Cancelling())
+        try:
+            await self._client.set_flow_run_state(UUID(flow_run_id), Cancelling())
+        except httpx.HTTPError:
+            return Observation(available=False, state=observed.state, reason="prefect-cancellation-unavailable")
         return await self.observe(flow_run_id)

--- a/infrahub_sync/managed/orchestration.py
+++ b/infrahub_sync/managed/orchestration.py
@@ -84,6 +84,6 @@ class PrefectOrchestration:
             return observed
         try:
             await self._client.set_flow_run_state(UUID(flow_run_id), Cancelling())
-        except httpx.HTTPError:
+        except (ObjectNotFound, httpx.HTTPError):
             return Observation(available=False, state=observed.state, reason="prefect-cancellation-unavailable")
         return await self.observe(flow_run_id)

--- a/infrahub_sync/managed/serve.py
+++ b/infrahub_sync/managed/serve.py
@@ -1,0 +1,59 @@
+"""Run the optional managed HTTP service with environment-owned providers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import uvicorn
+from prefect.client.orchestration import get_client
+
+from infrahub_sync.product_store import local_product_projection
+
+from ._settings import PRODUCT_CACHE_ENV
+from .app import create_app
+from .auth import EnvironmentPrincipalResolver
+from .orchestration import Observation, PrefectOrchestration, Submission
+from .service import ManagedRunService
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+class _ClientPerCallOrchestration:
+    """Keep Prefect client ownership inside each asynchronous API operation."""
+
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:
+        async with get_client() as client:
+            return await PrefectOrchestration(client).submit(parameters, idempotency_key=idempotency_key)
+
+    async def observe(self, flow_run_id: str) -> Observation:
+        async with get_client() as client:
+            return await PrefectOrchestration(client).observe(flow_run_id)
+
+    async def cancel(self, flow_run_id: str) -> Observation:
+        async with get_client() as client:
+            return await PrefectOrchestration(client).cancel(flow_run_id)
+
+
+def build_app() -> FastAPI:
+    """Construct the managed app from its explicit runtime environment."""
+    value = os.environ.get(PRODUCT_CACHE_ENV)
+    if not value:
+        msg = f"{PRODUCT_CACHE_ENV} must name an absolute durable product-cache directory"
+        raise ValueError(msg)
+    cache_location = Path(value).expanduser()
+    projection = local_product_projection(cache_location)
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    service = ManagedRunService(projection, _ClientPerCallOrchestration(), secrets=resolver.secret_values)
+    return create_app(service, resolver)
+
+
+def main() -> None:
+    """Serve the managed API; Prefect workers and deployments are separate."""
+    uvicorn.run(build_app(), host=os.environ.get("INFRAHUB_SYNC_MANAGED_HOST", "127.0.0.1"), port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 from uuid import uuid4
 
 from pydantic import ValidationError
@@ -152,6 +152,18 @@ class ManagedRunService:
     ) -> tuple[int, dict[str, Any]]:
         """Accept an independently auditable, read-only verification."""
         run = self._owned_run(run_id, principal, "verify", request.reason)
+        body = request.model_dump(mode="json")
+        parameters = self._stage_parameters(run, "verify", confirm_writes=False)
+        existing = self._lookup_existing_receipt(
+            run,
+            principal,
+            idempotency_key,
+            operation="verify",
+            reason=request.reason,
+            body=body,
+        )
+        if existing is not None:
+            return await self._resume_or_replay(existing, parameters, principal, request.reason)
         self._plan(run_id)
         receipt = self._reserve_existing(
             run,
@@ -159,19 +171,33 @@ class ManagedRunService:
             idempotency_key,
             operation="verify",
             reason=request.reason,
-            body=request.model_dump(mode="json"),
+            body=body,
         )
-        if receipt.state == "accepted":
-            self._audit(run_id, actor=principal.actor, operation="verify", reason=request.reason, outcome="replayed")
-            return self._stored_response(receipt)
-        parameters = self._stage_parameters(run, "verify", confirm_writes=False)
-        return await self._submit(receipt, parameters, principal, request.reason)
+        return await self._resume_or_replay(receipt, parameters, principal, request.reason)
 
     async def apply_run(
         self, run_id: str, request: ApplyRunRequest, principal: Principal, idempotency_key: str
     ) -> tuple[int, dict[str, Any]]:
         """Accept apply only for the exact reviewed retained plan."""
         run = self._owned_run(run_id, principal, "apply", request.reason)
+        body = request.model_dump(mode="json")
+        parameters = self._stage_parameters(
+            run,
+            "apply",
+            branch=request.branch,
+            expected_checksum=request.expected_checksum,
+            confirm_writes=True,
+        )
+        existing = self._lookup_existing_receipt(
+            run,
+            principal,
+            idempotency_key,
+            operation="apply",
+            reason=request.reason,
+            body=body,
+        )
+        if existing is not None:
+            return await self._resume_or_replay(existing, parameters, principal, request.reason)
         self._require_non_secret_parameters(
             principal.actor,
             "apply",
@@ -210,7 +236,7 @@ class ManagedRunService:
                 idempotency_key,
                 operation="apply",
                 reason=request.reason,
-                body=request.model_dump(mode="json"),
+                body=body,
                 admit_write=True,
             )
         except WriteAdmissionConflictError:
@@ -227,17 +253,7 @@ class ManagedRunService:
                 "a write-capable apply stage is already admitted for this Sync run",
                 run_id=run_id,
             ) from None
-        if receipt.state == "accepted":
-            self._audit(run_id, actor=principal.actor, operation="apply", reason=request.reason, outcome="replayed")
-            return self._stored_response(receipt)
-        parameters = self._stage_parameters(
-            run,
-            "apply",
-            branch=request.branch,
-            expected_checksum=request.expected_checksum,
-            confirm_writes=True,
-        )
-        return await self._submit(receipt, parameters, principal, request.reason)
+        return await self._resume_or_replay(receipt, parameters, principal, request.reason)
 
     async def cancel_run(
         self, run_id: str, request: CancelRunRequest, principal: Principal, idempotency_key: str
@@ -264,35 +280,61 @@ class ManagedRunService:
                 outcome="refused-no-execution",
             )
             raise self._error(409, "no-active-execution", "the run has no managed execution to cancel", run_id=run_id)
-        link = run.prefect_executions[-1]
-        observed = await self._orchestration.observe(link.flow_run_id)
-        if not observed.available:
-            self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="unavailable")
-            raise self._error(
-                503,
-                "orchestration-unavailable",
+        link: PrefectExecutionLink | None = None
+        unavailable_detail = False
+        for candidate in reversed(run.prefect_executions):
+            try:
+                observed = await self._orchestration.observe(candidate.flow_run_id)
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+                self._raise_cancel_unavailable(
+                    receipt,
+                    principal,
+                    request.reason,
+                    "the active managed execution cannot be confirmed",
+                    exc=exc,
+                )
+            if not observed.available:
+                if observed.reason == "prefect-execution-unavailable":
+                    unavailable_detail = True
+                    continue
+                self._raise_cancel_unavailable(
+                    receipt,
+                    principal,
+                    request.reason,
+                    "the active managed execution cannot be confirmed",
+                )
+            if observed.state in TERMINAL_STATES:
+                continue
+            link = candidate
+            break
+        if link is None and unavailable_detail:
+            self._raise_cancel_unavailable(
+                receipt,
+                principal,
+                request.reason,
                 "the active managed execution cannot be confirmed",
-                run_id=run_id,
-                mutation_id=receipt.receipt_id,
             )
-        if observed.state in TERMINAL_STATES:
+        if link is None:
             self._audit(
-                run_id,
-                actor=principal.actor,
-                operation="cancel",
-                reason=request.reason,
-                outcome="refused-terminal",
+                run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="refused-terminal"
             )
             raise self._error(409, "execution-terminal", "the managed execution is already terminal", run_id=run_id)
-        cancelled = await self._orchestration.cancel(link.flow_run_id)
-        if not cancelled.available:
-            self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="unavailable")
-            raise self._error(
-                503,
-                "orchestration-unavailable",
+        try:
+            cancelled = await self._orchestration.cancel(link.flow_run_id)
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            self._raise_cancel_unavailable(
+                receipt,
+                principal,
+                request.reason,
                 "Prefect could not confirm the cancellation request",
-                run_id=run_id,
-                mutation_id=receipt.receipt_id,
+                exc=exc,
+            )
+        if not cancelled.available:
+            self._raise_cancel_unavailable(
+                receipt,
+                principal,
+                request.reason,
+                "Prefect could not confirm the cancellation request",
             )
         self._projection.observe_prefect_execution(
             run_id,
@@ -314,6 +356,29 @@ class ManagedRunService:
         )
         self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="accepted")
         return self._stored_response(completed)
+
+    def _raise_cancel_unavailable(
+        self,
+        receipt: MutationReceipt,
+        principal: Principal,
+        reason: str,
+        message: str,
+        *,
+        exc: Exception | None = None,
+    ) -> NoReturn:
+        self._audit(receipt.run_id, actor=principal.actor, operation="cancel", reason=reason, outcome="unavailable")
+        error = self._error(
+            503,
+            "orchestration-unavailable",
+            message,
+            run_id=receipt.run_id,
+            mutation_id=receipt.receipt_id,
+        )
+        if exc is None:
+            raise error
+        error.__cause__ = sanitize_exception_chain(exc, self._secrets)
+        error.__suppress_context__ = True
+        raise error from error.__cause__
 
     async def get_run(self, run_id: str) -> RunResource:
         """Return retained product state even when Prefect detail expired."""
@@ -456,6 +521,50 @@ class ManagedRunService:
         )
         self._require_matching_receipt(reserved, receipt)
         return reserved
+
+    def _lookup_existing_receipt(
+        self,
+        run: ProductRun,
+        principal: Principal,
+        idempotency_key: str,
+        *,
+        operation: str,
+        reason: str,
+        body: dict[str, Any],
+    ) -> MutationReceipt | None:
+        requested = self._new_receipt(
+            actor=principal.actor,
+            idempotency_key=idempotency_key,
+            operation=operation,
+            target_run_id=run.run_id,
+            run_id=run.run_id,
+            body=body,
+            reason=reason,
+            now=datetime.now(timezone.utc),
+        )
+        existing = self._projection.lookup_mutation(requested.actor, requested.key_digest).value
+        if existing is None:
+            return None
+        self._require_matching_receipt(existing, requested)
+        return existing
+
+    async def _resume_or_replay(
+        self,
+        receipt: MutationReceipt,
+        parameters: dict[str, object],
+        principal: Principal,
+        reason: str,
+    ) -> tuple[int, dict[str, Any]]:
+        if receipt.state == "accepted":
+            self._audit(
+                receipt.run_id,
+                actor=principal.actor,
+                operation=receipt.operation,
+                reason=reason,
+                outcome="replayed",
+            )
+            return self._stored_response(receipt)
+        return await self._submit(receipt, parameters, principal, reason)
 
     @staticmethod
     def _new_receipt(

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -281,7 +281,6 @@ class ManagedRunService:
             )
             raise self._error(409, "no-active-execution", "the run has no managed execution to cancel", run_id=run_id)
         link: PrefectExecutionLink | None = None
-        unavailable_detail = False
         for candidate in reversed(run.prefect_executions):
             try:
                 observed = await self._orchestration.observe(candidate.flow_run_id)
@@ -295,7 +294,6 @@ class ManagedRunService:
                 )
             if not observed.available:
                 if observed.reason == "prefect-execution-unavailable":
-                    unavailable_detail = True
                     continue
                 self._raise_cancel_unavailable(
                     receipt,
@@ -307,13 +305,6 @@ class ManagedRunService:
                 continue
             link = candidate
             break
-        if link is None and unavailable_detail:
-            self._raise_cancel_unavailable(
-                receipt,
-                principal,
-                request.reason,
-                "the active managed execution cannot be confirmed",
-            )
         if link is None:
             self._audit(
                 run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="refused-terminal"

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -1,0 +1,643 @@
+"""Run-oriented managed API behavior over durable Sync product records."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from pydantic import ValidationError
+
+from infrahub_sync.cache.paths import generate_run_id
+from infrahub_sync.execution import collect_secret_values, redact, sanitize_exception_chain
+from infrahub_sync.plan.canonical import canonical_json_bytes
+from infrahub_sync.product_store import (
+    AuditEvent,
+    DuplicatePrefectExecutionError,
+    MutationReceipt,
+    PrefectExecutionLink,
+    ProductProjection,
+    ProductRun,
+)
+
+from .models import (
+    ApplyRunRequest,
+    ArtifactListResource,
+    CancelRunRequest,
+    CreateRunRequest,
+    OrchestrationSummary,
+    PlanResource,
+    ResultsResource,
+    RunResource,
+    VerifyRunRequest,
+)
+from .orchestration import ManagedOrchestration, Observation
+
+if TYPE_CHECKING:
+    from .auth import Principal
+
+PLAN_ARTIFACT_ID = "plan-review"
+TERMINAL_STATES = frozenset({"completed", "failed", "crashed", "cancelled"})
+
+
+class ManagedAPIError(Exception):
+    """Stable HTTP classification raised by the service boundary."""
+
+    def __init__(
+        self,
+        status: int,
+        code: str,
+        message: str,
+        *,
+        run_id: str | None = None,
+        mutation_id: str | None = None,
+        secrets: tuple[str, ...] = (),
+    ) -> None:
+        self.status = status
+        self.code = code
+        self.run_id = run_id
+        self.mutation_id = mutation_id
+        self.message = redact(message, secrets)
+        super().__init__(self.message)
+
+
+class ManagedRunService:
+    """Direct application service; Prefect owns all execution mechanics."""
+
+    def __init__(
+        self,
+        projection: ProductProjection,
+        orchestration: ManagedOrchestration,
+        *,
+        secrets: tuple[str, ...] = (),
+    ) -> None:
+        self._projection = projection
+        self._orchestration = orchestration
+        self._secrets = tuple(dict.fromkeys((*collect_secret_values(), *secrets)))
+
+    async def create_run(
+        self, request: CreateRunRequest, principal: Principal, idempotency_key: str
+    ) -> tuple[int, dict[str, Any]]:
+        """Reserve one product identity and accept its first managed execution."""
+        self._require_non_secret_parameters(
+            principal.actor,
+            request.operation,
+            request.reason,
+            sync_name=request.sync_name,
+            configuration_reference=request.configuration_reference,
+            branch=request.branch,
+        )
+        if request.operation == "sync" and not request.confirm_writes:
+            self._audit(
+                None,
+                actor=principal.actor,
+                operation="sync",
+                reason=request.reason,
+                outcome="refused-confirmation",
+            )
+            raise self._error(409, "confirmation-required", "confirm_writes=true is required for sync")
+
+        run_id = generate_run_id()
+        now = datetime.now(timezone.utc)
+        receipt = self._new_receipt(
+            actor=principal.actor,
+            idempotency_key=idempotency_key,
+            operation=request.operation,
+            target_run_id=None,
+            run_id=run_id,
+            body=request.model_dump(mode="json"),
+            reason=request.reason,
+            now=now,
+        )
+        run = ProductRun(
+            run_id=run_id,
+            operation=request.operation,
+            configuration_reference=request.configuration_reference,
+            actor=principal.actor,
+            started_at=now,
+            phase="accepted",
+            summary={"sync_name": request.sync_name},
+        )
+        reserved, _ = self._projection.reserve_mutation(receipt, run=run, secrets=self._secrets)
+        self._require_matching_receipt(reserved, receipt)
+        if reserved.state == "accepted":
+            self._audit(
+                reserved.run_id,
+                actor=principal.actor,
+                operation=request.operation,
+                reason=request.reason,
+                outcome="replayed",
+            )
+            return self._stored_response(reserved)
+        parameters: dict[str, object] = {
+            "run_id": reserved.run_id,
+            "sync_name": request.sync_name,
+            "stage": request.operation,
+            "configuration_reference": request.configuration_reference,
+            "branch": request.branch,
+            "expected_checksum": None,
+            "confirm_writes": request.confirm_writes,
+        }
+        return await self._submit(reserved, parameters, principal, request.reason)
+
+    async def verify_run(
+        self, run_id: str, request: VerifyRunRequest, principal: Principal, idempotency_key: str
+    ) -> tuple[int, dict[str, Any]]:
+        """Accept an independently auditable, read-only verification."""
+        run = self._owned_run(run_id, principal, "verify", request.reason)
+        self._plan(run_id)
+        receipt = self._reserve_existing(
+            run,
+            principal,
+            idempotency_key,
+            operation="verify",
+            reason=request.reason,
+            body=request.model_dump(mode="json"),
+        )
+        if receipt.state == "accepted":
+            self._audit(run_id, actor=principal.actor, operation="verify", reason=request.reason, outcome="replayed")
+            return self._stored_response(receipt)
+        parameters = self._stage_parameters(run, "verify", confirm_writes=False)
+        return await self._submit(receipt, parameters, principal, request.reason)
+
+    async def apply_run(
+        self, run_id: str, request: ApplyRunRequest, principal: Principal, idempotency_key: str
+    ) -> tuple[int, dict[str, Any]]:
+        """Accept apply only for the exact reviewed retained plan."""
+        run = self._owned_run(run_id, principal, "apply", request.reason)
+        self._require_non_secret_parameters(
+            principal.actor,
+            "apply",
+            request.reason,
+            run_id=run_id,
+            branch=request.branch,
+        )
+        if not request.confirm_writes:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation="apply",
+                reason=request.reason,
+                outcome="refused-confirmation",
+            )
+            raise self._error(409, "confirmation-required", "confirm_writes=true is required for apply", run_id=run_id)
+        plan = self._plan(run_id)
+        if not plan.checksum_ok or plan.checksum != request.expected_checksum:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation="apply",
+                reason=request.reason,
+                outcome="refused-checksum",
+            )
+            raise self._error(
+                409,
+                "checksum-conflict",
+                "expected_checksum does not match the retained reviewed plan",
+                run_id=run_id,
+            )
+        receipt = self._reserve_existing(
+            run,
+            principal,
+            idempotency_key,
+            operation="apply",
+            reason=request.reason,
+            body=request.model_dump(mode="json"),
+        )
+        if receipt.state == "accepted":
+            self._audit(run_id, actor=principal.actor, operation="apply", reason=request.reason, outcome="replayed")
+            return self._stored_response(receipt)
+        parameters = self._stage_parameters(
+            run,
+            "apply",
+            branch=request.branch,
+            expected_checksum=request.expected_checksum,
+            confirm_writes=True,
+        )
+        return await self._submit(receipt, parameters, principal, request.reason)
+
+    async def cancel_run(
+        self, run_id: str, request: CancelRunRequest, principal: Principal, idempotency_key: str
+    ) -> tuple[int, dict[str, Any]]:
+        """Request cancellation of only the latest active managed execution."""
+        run = self._owned_run(run_id, principal, "cancel", request.reason)
+        receipt = self._reserve_existing(
+            run,
+            principal,
+            idempotency_key,
+            operation="cancel",
+            reason=request.reason,
+            body=request.model_dump(mode="json"),
+        )
+        if receipt.state == "accepted":
+            self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="replayed")
+            return self._stored_response(receipt)
+        if not run.prefect_executions:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation="cancel",
+                reason=request.reason,
+                outcome="refused-no-execution",
+            )
+            raise self._error(409, "no-active-execution", "the run has no managed execution to cancel", run_id=run_id)
+        link = run.prefect_executions[-1]
+        observed = await self._orchestration.observe(link.flow_run_id)
+        if not observed.available:
+            self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="unavailable")
+            raise self._error(
+                503,
+                "orchestration-unavailable",
+                "the active managed execution cannot be confirmed",
+                run_id=run_id,
+                mutation_id=receipt.receipt_id,
+            )
+        if observed.state in TERMINAL_STATES:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation="cancel",
+                reason=request.reason,
+                outcome="refused-terminal",
+            )
+            raise self._error(409, "execution-terminal", "the managed execution is already terminal", run_id=run_id)
+        cancelled = await self._orchestration.cancel(link.flow_run_id)
+        if not cancelled.available:
+            self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="unavailable")
+            raise self._error(
+                503,
+                "orchestration-unavailable",
+                "Prefect could not confirm the cancellation request",
+                run_id=run_id,
+                mutation_id=receipt.receipt_id,
+            )
+        self._projection.observe_prefect_execution(
+            run_id,
+            link.flow_run_id,
+            state=cancelled.state,
+            secrets=self._secrets,
+        )
+        resource = self._resource_with_observations(
+            self._required_run(run_id),
+            {link.flow_run_id: cancelled},
+        )
+        body = resource.model_dump(mode="json")
+        completed = self._projection.complete_mutation(
+            receipt.receipt_id,
+            response_status=202,
+            response_body=body,
+            flow_run_id=link.flow_run_id,
+            secrets=self._secrets,
+        )
+        self._audit(run_id, actor=principal.actor, operation="cancel", reason=request.reason, outcome="accepted")
+        return self._stored_response(completed)
+
+    async def get_run(self, run_id: str) -> RunResource:
+        """Return retained product state even when Prefect detail expired."""
+        run = self._required_run(run_id)
+        observations: dict[str, Observation] = {}
+        for link in run.prefect_executions:
+            observed = await self._orchestration.observe(link.flow_run_id)
+            observations[link.flow_run_id] = observed
+            if observed.available:
+                self._projection.observe_prefect_execution(
+                    run_id,
+                    link.flow_run_id,
+                    state=observed.state,
+                    secrets=self._secrets,
+                )
+        return self._resource_with_observations(self._required_run(run_id), observations)
+
+    def get_plan(self, run_id: str) -> PlanResource:
+        """Return the retained review document."""
+        self._required_run(run_id)
+        return self._plan(run_id)
+
+    def get_results(self, run_id: str) -> ResultsResource:
+        """Return retained product results without consulting Prefect."""
+        run = self._required_run(run_id)
+        return ResultsResource(run_id=run_id, results=run.results)
+
+    def list_artifacts(self, run_id: str) -> ArtifactListResource:
+        """List immutable references without reading artifact bodies."""
+        run = self._required_run(run_id)
+        return ArtifactListResource(run_id=run_id, artifacts=run.artifact_refs)
+
+    def get_artifact(self, run_id: str, artifact_id: str) -> tuple[bytes, str, str]:
+        """Return verified artifact bytes, media type, and recorded digest."""
+        run = self._required_run(run_id)
+        reference = next((item for item in run.artifact_refs if item.artifact_id == artifact_id), None)
+        if reference is None:
+            raise self._error(404, "artifact-not-found", "the requested artifact is not retained", run_id=run_id)
+        result = self._projection.lookup_artifact(run_id, artifact_id)
+        if result.value is not None:
+            return result.value, reference.media_type, reference.digest
+        if result.reason == "artifact-expired":
+            raise self._error(410, "artifact-expired", "the requested artifact has expired", run_id=run_id)
+        raise self._error(503, "artifact-unavailable", "the retained artifact cannot be retrieved", run_id=run_id)
+
+    async def _submit(
+        self,
+        receipt: MutationReceipt,
+        parameters: dict[str, object],
+        principal: Principal,
+        reason: str,
+    ) -> tuple[int, dict[str, Any]]:
+        try:
+            submission = await self._orchestration.submit(parameters, idempotency_key=receipt.prefect_key)
+        except Exception as exc:  # noqa: BLE001 - remote boundary is translated and cause-sanitized
+            self._audit(
+                receipt.run_id,
+                actor=principal.actor,
+                operation=receipt.operation,
+                reason=reason,
+                outcome="unavailable",
+            )
+            error = self._error(
+                503,
+                "orchestration-unavailable",
+                f"Prefect could not confirm managed submission ({type(exc).__name__})",
+                run_id=receipt.run_id,
+                mutation_id=receipt.receipt_id,
+            )
+            error.__cause__ = sanitize_exception_chain(exc, self._secrets)
+            error.__suppress_context__ = True
+            raise error from error.__cause__
+        run = self._required_run(receipt.run_id)
+        attempt = 1 + sum(link.purpose == receipt.operation for link in run.prefect_executions)
+        link = PrefectExecutionLink(
+            flow_run_id=submission.flow_run_id,
+            purpose=receipt.operation,
+            attempt=attempt,
+            last_observed_state=submission.state,
+            last_observed_at=datetime.now(timezone.utc),
+        )
+        try:
+            self._projection.add_prefect_execution(receipt.run_id, link, secrets=self._secrets)
+        except DuplicatePrefectExecutionError:
+            self._projection.observe_prefect_execution(
+                receipt.run_id,
+                submission.flow_run_id,
+                state=submission.state,
+                secrets=self._secrets,
+            )
+        resource = self._resource_with_observations(
+            self._required_run(receipt.run_id),
+            {submission.flow_run_id: Observation(available=True, state=submission.state)},
+        )
+        body = resource.model_dump(mode="json")
+        completed = self._projection.complete_mutation(
+            receipt.receipt_id,
+            response_status=202,
+            response_body=body,
+            flow_run_id=submission.flow_run_id,
+            secrets=self._secrets,
+        )
+        self._audit(
+            receipt.run_id,
+            actor=principal.actor,
+            operation=receipt.operation,
+            reason=reason,
+            outcome="accepted",
+        )
+        return self._stored_response(completed)
+
+    def _reserve_existing(
+        self,
+        run: ProductRun,
+        principal: Principal,
+        idempotency_key: str,
+        *,
+        operation: str,
+        reason: str,
+        body: dict[str, Any],
+    ) -> MutationReceipt:
+        receipt = self._new_receipt(
+            actor=principal.actor,
+            idempotency_key=idempotency_key,
+            operation=operation,
+            target_run_id=run.run_id,
+            run_id=run.run_id,
+            body=body,
+            reason=reason,
+            now=datetime.now(timezone.utc),
+        )
+        reserved, _ = self._projection.reserve_mutation(receipt, secrets=self._secrets)
+        self._require_matching_receipt(reserved, receipt)
+        return reserved
+
+    @staticmethod
+    def _new_receipt(
+        *,
+        actor: str,
+        idempotency_key: str,
+        operation: str,
+        target_run_id: str | None,
+        run_id: str,
+        body: dict[str, Any],
+        reason: str,
+        now: datetime,
+    ) -> MutationReceipt:
+        key_digest = sha256(idempotency_key.encode()).hexdigest()
+        fingerprint = sha256(
+            canonical_json_bytes({"operation": operation, "target_run_id": target_run_id, "body": body})
+        ).hexdigest()
+        receipt_id = f"m-{uuid4().hex}"
+        prefect_key = sha256(f"infrahub-sync:{receipt_id}".encode()).hexdigest()
+        return MutationReceipt(
+            receipt_id=receipt_id,
+            actor=actor,
+            key_digest=key_digest,
+            operation=operation,
+            target_run_id=target_run_id,
+            request_fingerprint=fingerprint,
+            reason=reason,
+            run_id=run_id,
+            prefect_key=prefect_key,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def _require_matching_receipt(self, stored: MutationReceipt, requested: MutationReceipt) -> None:
+        binding = (
+            "operation",
+            "target_run_id",
+            "request_fingerprint",
+        )
+        if any(getattr(stored, field) != getattr(requested, field) for field in binding):
+            self._audit(
+                stored.run_id,
+                actor=requested.actor,
+                operation=requested.operation,
+                reason=requested.reason,
+                outcome="refused-idempotency",
+            )
+            raise self._error(
+                409,
+                "idempotency-conflict",
+                "Idempotency-Key was already used by this actor for different content",
+                run_id=stored.run_id,
+                mutation_id=stored.receipt_id,
+            )
+
+    def _owned_run(self, run_id: str, principal: Principal, operation: str, reason: str) -> ProductRun:
+        run = self._required_run(run_id)
+        if not principal.administrator and run.actor != principal.actor:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation=operation,
+                reason=reason,
+                outcome="refused-authorization",
+            )
+            raise self._error(
+                403, "forbidden", "only the initiating actor or an administrator may mutate this run", run_id=run_id
+            )
+        return run
+
+    def _required_run(self, run_id: str) -> ProductRun:
+        result = self._projection.lookup_run(run_id)
+        if result.value is None:
+            raise self._error(404, "run-not-found", "the requested Sync run does not exist", run_id=run_id)
+        return result.value
+
+    def _plan(self, run_id: str) -> PlanResource:
+        result = self._projection.lookup_artifact(run_id, PLAN_ARTIFACT_ID)
+        if result.value is None:
+            if result.reason == "run-not-found":
+                raise self._error(404, "run-not-found", "the requested Sync run does not exist", run_id=run_id)
+            if result.reason == "artifact-expired":
+                raise self._error(410, "artifact-expired", "the retained plan has expired", run_id=run_id)
+            raise self._error(503, "plan-unavailable", "the retained plan cannot be retrieved", run_id=run_id)
+        try:
+            return PlanResource.model_validate_json(result.value)
+        except (ValidationError, ValueError):
+            raise self._error(503, "plan-unavailable", "the retained plan is invalid", run_id=run_id) from None
+
+    @staticmethod
+    def _stage_parameters(
+        run: ProductRun,
+        stage: str,
+        *,
+        branch: str | None = None,
+        expected_checksum: str | None = None,
+        confirm_writes: bool = False,
+    ) -> dict[str, object]:
+        return {
+            "run_id": run.run_id,
+            "sync_name": str(run.summary.get("sync_name", run.configuration_reference)),
+            "stage": stage,
+            "configuration_reference": run.configuration_reference,
+            "branch": branch,
+            "expected_checksum": expected_checksum,
+            "confirm_writes": confirm_writes,
+        }
+
+    @staticmethod
+    def _stored_response(receipt: MutationReceipt) -> tuple[int, dict[str, Any]]:
+        assert receipt.response_status is not None
+        assert receipt.response_body is not None
+        return receipt.response_status, receipt.response_body
+
+    @staticmethod
+    def _resource_with_observations(run: ProductRun, observations: dict[str, Observation]) -> RunResource:
+        orchestration = []
+        for link in run.prefect_executions:
+            observed = observations.get(link.flow_run_id)
+            if observed is None:
+                orchestration.append(
+                    OrchestrationSummary(
+                        flow_run_id=link.flow_run_id,
+                        purpose=link.purpose,
+                        attempt=link.attempt,
+                        state=link.last_observed_state,
+                        detail_available=False,
+                        unavailable_reason="live-detail-not-requested",
+                    )
+                )
+                continue
+            orchestration.append(
+                OrchestrationSummary(
+                    flow_run_id=link.flow_run_id,
+                    purpose=link.purpose,
+                    attempt=link.attempt,
+                    state=observed.state if observed.available else link.last_observed_state,
+                    detail_available=observed.available,
+                    unavailable_reason=observed.reason,
+                )
+            )
+        return RunResource(run=run, orchestration=tuple(orchestration))
+
+    def _audit(
+        self,
+        run_id: str | None,
+        *,
+        actor: str,
+        operation: str,
+        reason: str,
+        outcome: str,
+    ) -> None:
+        event = AuditEvent(
+            event_id=f"a-{uuid4().hex}",
+            run_id=run_id,
+            actor=actor,
+            operation=operation,
+            reason=reason,
+            outcome=outcome,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._projection.record_audit(event, secrets=self._secrets)
+
+    def record_authentication_refusal(self, operation: str, reason: str) -> None:
+        """Persist anonymous authentication refusal evidence without token material."""
+        self._audit(
+            None,
+            actor="unauthenticated",
+            operation=operation,
+            reason=reason or "not-provided",
+            outcome="refused-authentication",
+        )
+
+    def _require_non_secret_parameters(
+        self,
+        actor: str,
+        operation: str,
+        reason: str,
+        *,
+        run_id: str | None = None,
+        **parameters: str | None,
+    ) -> None:
+        for name, value in parameters.items():
+            if value is not None and redact(value, self._secrets) != value:
+                self._audit(
+                    run_id,
+                    actor=actor,
+                    operation=operation,
+                    reason=reason,
+                    outcome="refused-secret-parameter",
+                )
+                raise self._error(
+                    422,
+                    "secret-parameter-refused",
+                    f"{name} must be a non-secret reference",
+                    run_id=run_id,
+                )
+
+    def _error(
+        self,
+        status: int,
+        code: str,
+        message: str,
+        *,
+        run_id: str | None = None,
+        mutation_id: str | None = None,
+    ) -> ManagedAPIError:
+        return ManagedAPIError(
+            status,
+            code,
+            message,
+            run_id=run_id,
+            mutation_id=mutation_id,
+            secrets=self._secrets,
+        )

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -19,6 +19,7 @@ from infrahub_sync.product_store import (
     PrefectExecutionLink,
     ProductProjection,
     ProductRun,
+    WriteAdmissionConflictError,
 )
 
 from .models import (
@@ -119,7 +120,12 @@ class ManagedRunService:
             phase="accepted",
             summary={"sync_name": request.sync_name},
         )
-        reserved, _ = self._projection.reserve_mutation(receipt, run=run, secrets=self._secrets)
+        reserved, _ = self._projection.reserve_mutation(
+            receipt,
+            run=run,
+            admit_write=request.operation == "sync",
+            secrets=self._secrets,
+        )
         self._require_matching_receipt(reserved, receipt)
         if reserved.state == "accepted":
             self._audit(
@@ -197,14 +203,30 @@ class ManagedRunService:
                 "expected_checksum does not match the retained reviewed plan",
                 run_id=run_id,
             )
-        receipt = self._reserve_existing(
-            run,
-            principal,
-            idempotency_key,
-            operation="apply",
-            reason=request.reason,
-            body=request.model_dump(mode="json"),
-        )
+        try:
+            receipt = self._reserve_existing(
+                run,
+                principal,
+                idempotency_key,
+                operation="apply",
+                reason=request.reason,
+                body=request.model_dump(mode="json"),
+                admit_write=True,
+            )
+        except WriteAdmissionConflictError:
+            self._audit(
+                run_id,
+                actor=principal.actor,
+                operation="apply",
+                reason=request.reason,
+                outcome="refused-apply-admission",
+            )
+            raise self._error(
+                409,
+                "apply-already-admitted",
+                "a write-capable apply stage is already admitted for this Sync run",
+                run_id=run_id,
+            ) from None
         if receipt.state == "accepted":
             self._audit(run_id, actor=principal.actor, operation="apply", reason=request.reason, outcome="replayed")
             return self._stored_response(receipt)
@@ -364,17 +386,20 @@ class ManagedRunService:
             error.__cause__ = sanitize_exception_chain(exc, self._secrets)
             error.__suppress_context__ = True
             raise error from error.__cause__
-        run = self._required_run(receipt.run_id)
-        attempt = 1 + sum(link.purpose == receipt.operation for link in run.prefect_executions)
         link = PrefectExecutionLink(
             flow_run_id=submission.flow_run_id,
             purpose=receipt.operation,
-            attempt=attempt,
+            attempt=1,
             last_observed_state=submission.state,
             last_observed_at=datetime.now(timezone.utc),
         )
         try:
-            self._projection.add_prefect_execution(receipt.run_id, link, secrets=self._secrets)
+            self._projection.add_prefect_execution(
+                receipt.run_id,
+                link,
+                allocate_attempt=True,
+                secrets=self._secrets,
+            )
         except DuplicatePrefectExecutionError:
             self._projection.observe_prefect_execution(
                 receipt.run_id,
@@ -412,6 +437,7 @@ class ManagedRunService:
         operation: str,
         reason: str,
         body: dict[str, Any],
+        admit_write: bool = False,
     ) -> MutationReceipt:
         receipt = self._new_receipt(
             actor=principal.actor,
@@ -423,7 +449,11 @@ class ManagedRunService:
             reason=reason,
             now=datetime.now(timezone.utc),
         )
-        reserved, _ = self._projection.reserve_mutation(receipt, secrets=self._secrets)
+        reserved, _ = self._projection.reserve_mutation(
+            receipt,
+            admit_write=admit_write,
+            secrets=self._secrets,
+        )
         self._require_matching_receipt(reserved, receipt)
         return reserved
 

--- a/infrahub_sync/orchestration/flow.py
+++ b/infrahub_sync/orchestration/flow.py
@@ -26,12 +26,13 @@ The flow calls the shared execution surface IN-PROCESS; it never spawns the CLI.
 import dataclasses
 import logging
 import os
+from collections.abc import Sequence
 from typing import Any, Literal, Protocol
 
 from prefect import flow
 from prefect.logging import get_run_logger
 
-from infrahub_sync.execution import RunExecutionError, run_remote_request
+from infrahub_sync.execution import RunExecutionError, redact, run_remote_request
 
 logger = logging.getLogger(__name__)
 
@@ -77,14 +78,15 @@ class RunLoggerBridge(logging.Handler):
     observable without any change to the engine.
     """
 
-    def __init__(self, run_logger: RunLogger) -> None:
+    def __init__(self, run_logger: RunLogger, *, secrets: Sequence[str] = ()) -> None:
         super().__init__(level=BRIDGED_LEVEL)
         self._run_logger = run_logger
+        self._secrets = secrets
 
     def emit(self, record: logging.LogRecord) -> None:
         """Re-log the record through the run logger, preserving level and origin name."""
         try:
-            self._run_logger.log(record.levelno, "%s | %s", record.name, record.getMessage())
+            self._run_logger.log(record.levelno, "%s | %s", record.name, redact(record.getMessage(), self._secrets))
         except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             # `logging.Handler.emit` must never propagate: `Handler.handle` does not
             # shield it, so anything raised here escapes at the unrelated logging

--- a/infrahub_sync/product_store/__init__.py
+++ b/infrahub_sync/product_store/__init__.py
@@ -1,6 +1,13 @@
 """Durable Sync product records and immutable artifacts."""
 
-from infrahub_sync.product_store.models import ArtifactReference, LookupResult, PrefectExecutionLink, ProductRun
+from infrahub_sync.product_store.models import (
+    ArtifactReference,
+    AuditEvent,
+    LookupResult,
+    MutationReceipt,
+    PrefectExecutionLink,
+    ProductRun,
+)
 from infrahub_sync.product_store.store import (
     ArtifactUnavailableError,
     DBAPIConnection,
@@ -17,11 +24,13 @@ from infrahub_sync.product_store.store import (
 __all__ = (
     "ArtifactReference",
     "ArtifactUnavailableError",
+    "AuditEvent",
     "DBAPIConnection",
     "DuplicateArtifactError",
     "DuplicatePrefectExecutionError",
     "DuplicateRunError",
     "LookupResult",
+    "MutationReceipt",
     "PrefectExecutionLink",
     "ProductProjection",
     "ProductRun",

--- a/infrahub_sync/product_store/__init__.py
+++ b/infrahub_sync/product_store/__init__.py
@@ -17,6 +17,7 @@ from infrahub_sync.product_store.store import (
     ProductProjection,
     RunNotFoundError,
     S3Client,
+    WriteAdmissionConflictError,
     local_product_projection,
     production_product_projection,
 )
@@ -36,6 +37,7 @@ __all__ = (
     "ProductRun",
     "RunNotFoundError",
     "S3Client",
+    "WriteAdmissionConflictError",
     "local_product_projection",
     "production_product_projection",
 )

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime  # noqa: TC003 - pydantic resolves this annotation at runtime.
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -115,6 +115,69 @@ class ProductRun(BaseModel):
             msg = "Prefect flow-run IDs must be unique within a product record"
             raise ValueError(msg)
         return self
+
+
+class MutationReceipt(BaseModel):
+    """Durable actor/key reservation for one managed HTTP mutation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    receipt_id: str = Field(pattern=_IDENTIFIER_PATTERN)
+    actor: str = Field(min_length=1)
+    key_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    operation: str = Field(min_length=1)
+    target_run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
+    request_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    reason: str = Field(min_length=1)
+    run_id: str = Field(pattern=_IDENTIFIER_PATTERN)
+    prefect_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    state: Literal["reserved", "accepted"] = "reserved"
+    response_status: int | None = Field(default=None, ge=100, le=599)
+    response_body: dict[str, Any] | None = None
+    flow_run_id: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @field_validator("created_at", "updated_at")
+    @classmethod
+    def _require_receipt_timezone(cls, value: datetime) -> datetime:
+        if value.utcoffset() is None:
+            msg = "mutation-receipt timestamps must include a timezone"
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _require_accepted_response(self) -> MutationReceipt:
+        accepted_values = (self.response_status, self.response_body, self.flow_run_id)
+        if self.state == "accepted" and any(value is None for value in accepted_values):
+            msg = "an accepted mutation receipt requires its status, response, and Prefect flow-run ID"
+            raise ValueError(msg)
+        if self.state == "reserved" and any(value is not None for value in accepted_values):
+            msg = "a reserved mutation receipt cannot carry an accepted response"
+            raise ValueError(msg)
+        return self
+
+
+class AuditEvent(BaseModel):
+    """Secret-safe durable evidence for one managed API decision."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    event_id: str = Field(pattern=_IDENTIFIER_PATTERN)
+    run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
+    actor: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    reason: str = Field(min_length=1)
+    outcome: str = Field(min_length=1)
+    created_at: datetime
+
+    @field_validator("created_at")
+    @classmethod
+    def _require_audit_timezone(cls, value: datetime) -> datetime:
+        if value.utcoffset() is None:
+            msg = "audit-event timestamps must include a timezone"
+            raise ValueError(msg)
+        return value
 
 
 T = TypeVar("T")

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path, PurePosixPath
 from tempfile import mkdtemp
+from time import sleep
 from typing import Any, Protocol, cast
 
 from pydantic import TypeAdapter
@@ -73,6 +74,7 @@ CREATE INDEX IF NOT EXISTS audit_events_run_created
 _SQLITE_UNIQUE_CONSTRAINT_CODES = frozenset({1555, 2067})
 _POSTGRESQL_SCHEMA_CONFLICT_CODES = frozenset({"23505", "42P07", "42710"})
 _PREFECT_POSITION_ATTEMPTS = 3
+_RESULT_MERGE_ATTEMPTS = 5
 _SCHEMA_INITIALIZATION_ATTEMPTS = 2
 _JSON_MAPPING_ADAPTER = TypeAdapter(dict[str, Any])
 
@@ -197,6 +199,8 @@ class _RunStore(Protocol):
     def audit_events(self, run_id: str | None = None) -> tuple[AuditEvent, ...]: ...
 
     def record_results(self, run_id: str, results: Mapping[str, Any]) -> None: ...
+
+    def merge_results(self, run_id: str, results: Mapping[str, Any]) -> None: ...
 
     def finish(
         self,
@@ -737,6 +741,44 @@ class _RelationalRunStore:
         finally:
             connection.close()
 
+    def merge_results(self, run_id: str, results: Mapping[str, Any]) -> None:
+        """Merge result fields with optimistic concurrency across DB-API providers."""
+        last_conflict: BaseException | None = None
+        for attempt in range(_RESULT_MERGE_ATTEMPTS):
+            connection = self._connect()
+            retry = False
+            try:
+                cursor = connection.cursor()
+                try:
+                    cursor.execute(self._sql("SELECT results FROM product_runs WHERE run_id = ?"), (run_id,))
+                    row = _require_result_row(cursor.fetchone(), run_id)
+                    current_text = str(row[0])
+                    current = _JSON_MAPPING_ADAPTER.validate_json(current_text)
+                    merged = {**current, **results}
+                    cursor.execute(
+                        self._sql("UPDATE product_runs SET results = ? WHERE run_id = ? AND results = ?"),
+                        (_json(merged), run_id, current_text),
+                    )
+                    if cursor.rowcount == 1:
+                        connection.commit()
+                        return
+                    connection.rollback()
+                    retry = True
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    connection.rollback()
+                    if not _is_retryable_write_conflict(exc):
+                        raise
+                    last_conflict = exc
+                    retry = True
+                finally:
+                    cursor.close()
+            finally:
+                connection.close()
+            if retry and attempt + 1 < _RESULT_MERGE_ATTEMPTS:
+                sleep(0.01)
+        msg = f"Could not merge concurrent results for Sync run ID {run_id!r}"
+        raise RuntimeError(msg) from last_conflict
+
     def _insert_reference(self, cursor: _Cursor, reference: ArtifactReference, *, published: bool) -> None:
         cursor.execute(
             self._sql(_INSERT_ARTIFACT_REFERENCE),
@@ -1076,6 +1118,17 @@ class ProductProjection:
         sanitized = cast("Mapping[str, Any]", _redact_value(_normalize_mapping(results), secrets))
         self._records.record_results(redact(run_id, secrets), sanitized)
 
+    def merge_results(
+        self,
+        run_id: str,
+        results: Mapping[str, Any],
+        *,
+        secrets: Sequence[str] = (),
+    ) -> None:
+        """Atomically merge retained result fields without a stale read/replace race."""
+        sanitized = cast("Mapping[str, Any]", _redact_value(_normalize_mapping(results), secrets))
+        self._records.merge_results(redact(run_id, secrets), sanitized)
+
     def publish_artifact(
         self,
         run_id: str,
@@ -1344,6 +1397,12 @@ def _is_unique_violation(exc: BaseException) -> bool:
     return getattr(diagnostic, "sqlstate", None) == "23505"
 
 
+def _is_retryable_write_conflict(exc: BaseException) -> bool:
+    if isinstance(exc, sqlite3.OperationalError):
+        return "database is locked" in str(exc).lower()
+    return _sqlstate(exc) in {"40001", "40P01"}
+
+
 def _sqlstate(exc: BaseException) -> str | None:
     direct = getattr(exc, "sqlstate", None) or getattr(exc, "pgcode", None)
     if isinstance(direct, str):
@@ -1375,6 +1434,13 @@ def _require_run_results_recorded(cursor: _Cursor, run_id: str) -> None:
     if cursor.rowcount != 1:
         msg = f"Cannot record results for unavailable Sync run ID {run_id!r}"
         raise RunNotFoundError(msg)
+
+
+def _require_result_row(row: Sequence[Any] | None, run_id: str) -> Sequence[Any]:
+    if row is None:
+        msg = f"Cannot merge results for unavailable Sync run ID {run_id!r}"
+        raise RunNotFoundError(msg)
+    return row
 
 
 def _redact_value(value: Any, secrets: Sequence[str]) -> Any:

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -17,7 +17,14 @@ from pydantic import TypeAdapter
 
 from infrahub_sync.execution import REDACTED, redact
 from infrahub_sync.plan.canonical import canonical_json_bytes
-from infrahub_sync.product_store.models import ArtifactReference, LookupResult, PrefectExecutionLink, ProductRun
+from infrahub_sync.product_store.models import (
+    ArtifactReference,
+    AuditEvent,
+    LookupResult,
+    MutationReceipt,
+    PrefectExecutionLink,
+    ProductRun,
+)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS product_runs (
@@ -38,6 +45,20 @@ CREATE TABLE IF NOT EXISTS prefect_executions (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_position
     ON prefect_executions (run_id, position);
+CREATE TABLE IF NOT EXISTS mutation_receipts (
+    receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL,
+    operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL,
+    reason TEXT NOT NULL, run_id TEXT NOT NULL, prefect_key TEXT NOT NULL,
+    state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+    UNIQUE (actor, key_digest)
+);
+CREATE TABLE IF NOT EXISTS audit_events (
+    event_id TEXT PRIMARY KEY, run_id TEXT, actor TEXT NOT NULL, operation TEXT NOT NULL,
+    reason TEXT NOT NULL, outcome TEXT NOT NULL, created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS audit_events_run_created
+    ON audit_events (run_id, created_at);
 """
 
 # Stable SQLite extended result codes. Python 3.10's sqlite3 module does not expose
@@ -62,6 +83,17 @@ _SELECT_PREFECT_EXECUTIONS = """SELECT run_id, flow_run_id, deployment_id, purpo
 last_observed_at, position FROM prefect_executions WHERE run_id = ? ORDER BY position"""
 _INSERT_PREFECT_EXECUTION = """INSERT INTO prefect_executions (run_id, flow_run_id, deployment_id, purpose, attempt,
 last_observed_state, last_observed_at, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
+_INSERT_MUTATION_RECEIPT = """INSERT INTO mutation_receipts (receipt_id, actor, key_digest, operation,
+target_run_id, request_fingerprint, reason, run_id, prefect_key, state, response_status, response_body,
+flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+_SELECT_MUTATION_RECEIPT = """SELECT receipt_id, actor, key_digest, operation, target_run_id,
+request_fingerprint, reason, run_id, prefect_key, state, response_status, response_body, flow_run_id,
+created_at, updated_at FROM mutation_receipts WHERE actor = ? AND key_digest = ?"""
+_INSERT_AUDIT_EVENT = """INSERT INTO audit_events (event_id, run_id, actor, operation, reason, outcome, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)"""
+_SELECT_AUDIT_EVENTS = """SELECT event_id, run_id, actor, operation, reason, outcome, created_at
+FROM audit_events WHERE run_id = ? ORDER BY created_at, event_id"""
+_SELECT_AUDIT_LINKS = "SELECT event_id FROM audit_events WHERE run_id = ? ORDER BY created_at, event_id"
 
 
 class DuplicateRunError(ValueError):
@@ -127,6 +159,30 @@ class _RunStore(Protocol):
 
     def add_prefect_execution(self, run_id: str, link: PrefectExecutionLink) -> None: ...
 
+    def observe_prefect_execution(
+        self, run_id: str, flow_run_id: str, *, state: str | None, observed_at: datetime
+    ) -> None: ...
+
+    def reserve_mutation(self, receipt: MutationReceipt, run: ProductRun | None) -> tuple[MutationReceipt, bool]: ...
+
+    def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]: ...
+
+    def complete_mutation(
+        self,
+        receipt_id: str,
+        *,
+        response_status: int,
+        response_body: Mapping[str, Any],
+        flow_run_id: str,
+        updated_at: datetime,
+    ) -> MutationReceipt: ...
+
+    def record_audit(self, event: AuditEvent) -> None: ...
+
+    def audit_events(self, run_id: str | None = None) -> tuple[AuditEvent, ...]: ...
+
+    def record_results(self, run_id: str, results: Mapping[str, Any]) -> None: ...
+
     def finish(
         self,
         run_id: str,
@@ -189,22 +245,7 @@ class _RelationalRunStore:
             cursor = connection.cursor()
             try:
                 try:
-                    cursor.execute(
-                        self._sql(_INSERT_PRODUCT_RUN),
-                        (
-                            run.run_id,
-                            run.operation,
-                            run.configuration_reference,
-                            run.actor,
-                            _json(run.audit_links),
-                            run.started_at.isoformat(),
-                            _iso(run.finished_at),
-                            run.phase,
-                            run.outcome,
-                            _json(run.summary),
-                            _json(run.results),
-                        ),
-                    )
+                    self._insert_product_run_row(cursor, run)
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     # Synchronous DB-API drivers do not share an integrity-error
                     # base class; inspect uniqueness only for the stable run ID.
@@ -222,6 +263,29 @@ class _RelationalRunStore:
                 cursor.close()
         finally:
             connection.close()
+
+    def _insert_product_run(self, cursor: _Cursor, run: ProductRun) -> None:
+        self._insert_product_run_row(cursor, run)
+        for position, link in enumerate(run.prefect_executions):
+            self._insert_prefect_execution(cursor, run.run_id, link, position)
+
+    def _insert_product_run_row(self, cursor: _Cursor, run: ProductRun) -> None:
+        cursor.execute(
+            self._sql(_INSERT_PRODUCT_RUN),
+            (
+                run.run_id,
+                run.operation,
+                run.configuration_reference,
+                run.actor,
+                _json(run.audit_links),
+                run.started_at.isoformat(),
+                _iso(run.finished_at),
+                run.phase,
+                run.outcome,
+                _json(run.summary),
+                _json(run.results),
+            ),
+        )
 
     def lookup(self, run_id: str) -> LookupResult[ProductRun]:
         connection = self._connect()
@@ -245,11 +309,13 @@ class _RelationalRunStore:
                     (run_id,),
                 )
                 links = cursor.fetchall()
+                cursor.execute(self._sql(_SELECT_AUDIT_LINKS), (run_id,))
+                audit_links = cursor.fetchall()
             finally:
                 cursor.close()
         finally:
             connection.close()
-        return LookupResult(value=_run_from_rows(row, references, links))
+        return LookupResult(value=_run_from_rows(row, references, links, audit_links))
 
     def exists(self, run_id: str) -> bool:
         """Return run existence without hydrating child records."""
@@ -410,6 +476,201 @@ class _RelationalRunStore:
                     (run_id, flow_run_id),
                 )
                 return cursor.fetchone() is not None
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+
+    def observe_prefect_execution(
+        self, run_id: str, flow_run_id: str, *, state: str | None, observed_at: datetime
+    ) -> None:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(
+                        "UPDATE prefect_executions SET last_observed_state = ?, last_observed_at = ? "
+                        "WHERE run_id = ? AND flow_run_id = ?"
+                    ),
+                    (state, observed_at.isoformat(), run_id, flow_run_id),
+                )
+                _require_execution_observed(cursor, run_id, flow_run_id)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+
+    def reserve_mutation(self, receipt: MutationReceipt, run: ProductRun | None) -> tuple[MutationReceipt, bool]:
+        """Atomically reserve actor/key and optionally create its product run."""
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                try:
+                    cursor.execute(self._sql(_INSERT_MUTATION_RECEIPT), _receipt_values(receipt))
+                    if run is not None:
+                        self._insert_product_run(cursor, run)
+                    connection.commit()
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    connection.rollback()
+                    if not _is_unique_violation(exc):
+                        raise
+                    existing = self.lookup_mutation(receipt.actor, receipt.key_digest)
+                    if existing.value is not None:
+                        return existing.value, False
+                    if run is not None and self.exists(run.run_id):
+                        msg = f"Sync run ID {run.run_id!r} already exists"
+                        raise DuplicateRunError(msg) from exc
+                    raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        return receipt, True
+
+    def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(self._sql(_SELECT_MUTATION_RECEIPT), (actor, key_digest))
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        if row is None:
+            return LookupResult(value=None, reason="mutation-receipt-not-found")
+        return LookupResult(value=_receipt_from_row(row))
+
+    def complete_mutation(
+        self,
+        receipt_id: str,
+        *,
+        response_status: int,
+        response_body: Mapping[str, Any],
+        flow_run_id: str,
+        updated_at: datetime,
+    ) -> MutationReceipt:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(
+                        "UPDATE mutation_receipts SET state = 'accepted', response_status = ?, response_body = ?, "
+                        "flow_run_id = ?, updated_at = ? WHERE receipt_id = ? AND state = 'reserved'"
+                    ),
+                    (response_status, _json(response_body), flow_run_id, updated_at.isoformat(), receipt_id),
+                )
+                completed = cursor.rowcount == 1
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        receipt = self._lookup_mutation_by_id(receipt_id)
+        if completed:
+            return receipt
+        if (
+            receipt.state == "accepted"
+            and receipt.response_status == response_status
+            and receipt.flow_run_id == flow_run_id
+        ):
+            return receipt
+        msg = f"Mutation receipt {receipt_id!r} is already complete with a different response"
+        raise ValueError(msg)
+
+    def _lookup_mutation_by_id(self, receipt_id: str) -> MutationReceipt:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(
+                        "SELECT receipt_id, actor, key_digest, operation, target_run_id, request_fingerprint, "
+                        "reason, run_id, prefect_key, state, response_status, response_body, flow_run_id, "
+                        "created_at, updated_at FROM mutation_receipts WHERE receipt_id = ?"
+                    ),
+                    (receipt_id,),
+                )
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        if row is None:
+            msg = f"Mutation receipt {receipt_id!r} is unavailable"
+            raise RunNotFoundError(msg)
+        return _receipt_from_row(row)
+
+    def record_audit(self, event: AuditEvent) -> None:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(_INSERT_AUDIT_EVENT),
+                    (
+                        event.event_id,
+                        event.run_id,
+                        event.actor,
+                        event.operation,
+                        event.reason,
+                        event.outcome,
+                        event.created_at.isoformat(),
+                    ),
+                )
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+
+    def audit_events(self, run_id: str | None = None) -> tuple[AuditEvent, ...]:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                if run_id is None:
+                    cursor.execute(
+                        "SELECT event_id, run_id, actor, operation, reason, outcome, created_at "
+                        "FROM audit_events ORDER BY created_at, event_id"
+                    )
+                else:
+                    cursor.execute(self._sql(_SELECT_AUDIT_EVENTS), (run_id,))
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        return tuple(_audit_from_row(row) for row in rows)
+
+    def record_results(self, run_id: str, results: Mapping[str, Any]) -> None:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql("UPDATE product_runs SET results = ? WHERE run_id = ?"),
+                    (_json(results), run_id),
+                )
+                _require_run_results_recorded(cursor, run_id)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
             finally:
                 cursor.close()
         finally:
@@ -664,6 +925,88 @@ class ProductProjection:
         sanitized = PrefectExecutionLink.model_validate(_redact_value(link.model_dump(mode="json"), secrets))
         self._records.add_prefect_execution(run_id, sanitized)
 
+    def observe_prefect_execution(
+        self,
+        run_id: str,
+        flow_run_id: str,
+        *,
+        state: str | None,
+        secrets: Sequence[str] = (),
+    ) -> None:
+        """Update live detail for an existing link without creating a retry link."""
+        self._records.observe_prefect_execution(
+            redact(run_id, secrets),
+            redact(flow_run_id, secrets),
+            state=None if state is None else redact(state, secrets),
+            observed_at=datetime.now(timezone.utc),
+        )
+
+    def reserve_mutation(
+        self,
+        receipt: MutationReceipt,
+        *,
+        run: ProductRun | None = None,
+        secrets: Sequence[str] = (),
+    ) -> tuple[MutationReceipt, bool]:
+        """Reserve one actor/key mutation, optionally with its run, in one transaction."""
+        sanitized_receipt = MutationReceipt.model_validate(_redact_value(receipt.model_dump(mode="json"), secrets))
+        sanitized_run = None if run is None else _redacted_run(run, secrets)
+        if sanitized_run is not None:
+            if (
+                sanitized_run.finished_at is not None
+                or sanitized_run.outcome is not None
+                or sanitized_run.artifact_refs
+            ):
+                msg = "a mutation-created product record must be unfinished and have no artifact references"
+                raise ValueError(msg)
+            if sanitized_run.run_id != sanitized_receipt.run_id:
+                msg = "a mutation receipt and its atomically created product run must share one run ID"
+                raise ValueError(msg)
+        return self._records.reserve_mutation(sanitized_receipt, sanitized_run)
+
+    def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]:
+        """Look up the durable receipt for an actor and hashed client key."""
+        return self._records.lookup_mutation(actor, key_digest)
+
+    def complete_mutation(
+        self,
+        receipt_id: str,
+        *,
+        response_status: int,
+        response_body: Mapping[str, Any],
+        flow_run_id: str,
+        secrets: Sequence[str] = (),
+    ) -> MutationReceipt:
+        """Persist the exact accepted HTTP response and Prefect identity."""
+        sanitized = cast("Mapping[str, Any]", _redact_value(_normalize_mapping(response_body), secrets))
+        return self._records.complete_mutation(
+            redact(receipt_id, secrets),
+            response_status=response_status,
+            response_body=sanitized,
+            flow_run_id=redact(flow_run_id, secrets),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    def record_audit(self, event: AuditEvent, *, secrets: Sequence[str] = ()) -> None:
+        """Append one immutable, secret-safe authorization or mutation event."""
+        sanitized = AuditEvent.model_validate(_redact_value(event.model_dump(mode="json"), secrets))
+        self._records.record_audit(sanitized)
+
+    def audit_events(self, run_id: str | None = None) -> tuple[AuditEvent, ...]:
+        """Return all audit evidence, optionally narrowed to one Sync run."""
+        return self._records.audit_events(run_id)
+
+    def record_results(
+        self,
+        run_id: str,
+        results: Mapping[str, Any],
+        *,
+        secrets: Sequence[str] = (),
+    ) -> None:
+        """Update retained result evidence without changing the run lifecycle."""
+        sanitized = cast("Mapping[str, Any]", _redact_value(_normalize_mapping(results), secrets))
+        self._records.record_results(redact(run_id, secrets), sanitized)
+
     def publish_artifact(
         self,
         run_id: str,
@@ -807,15 +1150,19 @@ def _iso(value: datetime | None) -> str | None:
 
 
 def _run_from_rows(
-    row: Sequence[Any], references: Sequence[Sequence[Any]], links: Sequence[Sequence[Any]]
+    row: Sequence[Any],
+    references: Sequence[Sequence[Any]],
+    links: Sequence[Sequence[Any]],
+    managed_audit_links: Sequence[Sequence[Any]],
 ) -> ProductRun:
+    audit_links = tuple(dict.fromkeys((*json.loads(row[4]), *(str(item[0]) for item in managed_audit_links))))
     return ProductRun.model_validate(
         {
             "run_id": row[0],
             "operation": row[1],
             "configuration_reference": row[2],
             "actor": row[3],
-            "audit_links": json.loads(row[4]),
+            "audit_links": audit_links,
             "started_at": row[5],
             "finished_at": row[6],
             "phase": row[7],
@@ -834,6 +1181,62 @@ def _run_from_rows(
                 }
                 for item in links
             ],
+        }
+    )
+
+
+def _receipt_values(receipt: MutationReceipt) -> tuple[Any, ...]:
+    return (
+        receipt.receipt_id,
+        receipt.actor,
+        receipt.key_digest,
+        receipt.operation,
+        receipt.target_run_id,
+        receipt.request_fingerprint,
+        receipt.reason,
+        receipt.run_id,
+        receipt.prefect_key,
+        receipt.state,
+        receipt.response_status,
+        None if receipt.response_body is None else _json(receipt.response_body),
+        receipt.flow_run_id,
+        receipt.created_at.isoformat(),
+        receipt.updated_at.isoformat(),
+    )
+
+
+def _receipt_from_row(row: Sequence[Any]) -> MutationReceipt:
+    return MutationReceipt.model_validate(
+        {
+            "receipt_id": row[0],
+            "actor": row[1],
+            "key_digest": row[2],
+            "operation": row[3],
+            "target_run_id": row[4],
+            "request_fingerprint": row[5],
+            "reason": row[6],
+            "run_id": row[7],
+            "prefect_key": row[8],
+            "state": row[9],
+            "response_status": row[10],
+            "response_body": None if row[11] is None else json.loads(row[11]),
+            "flow_run_id": row[12],
+            "created_at": row[13],
+            "updated_at": row[14],
+        }
+    )
+
+
+def _audit_from_row(row: Sequence[Any]) -> AuditEvent:
+    return AuditEvent.model_validate(
+        {
+            "event_id": row[0],
+            "run_id": row[1],
+            "actor": row[2],
+            "operation": row[3],
+            "reason": row[4],
+            "outcome": row[5],
+            "created_at": row[6],
         }
     )
 
@@ -890,6 +1293,18 @@ def _require_publication_marked(cursor: _Cursor, reference: ArtifactReference) -
 def _require_run_finished(cursor: _Cursor, run_id: str) -> None:
     if cursor.rowcount != 1:
         msg = f"Cannot finish unavailable Sync run ID {run_id!r}"
+        raise RunNotFoundError(msg)
+
+
+def _require_execution_observed(cursor: _Cursor, run_id: str, flow_run_id: str) -> None:
+    if cursor.rowcount != 1:
+        msg = f"Prefect flow-run ID {flow_run_id!r} is not linked to Sync run {run_id!r}"
+        raise RunNotFoundError(msg)
+
+
+def _require_run_results_recorded(cursor: _Cursor, run_id: str) -> None:
+    if cursor.rowcount != 1:
+        msg = f"Cannot record results for unavailable Sync run ID {run_id!r}"
         raise RunNotFoundError(msg)
 
 

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -45,6 +45,8 @@ CREATE TABLE IF NOT EXISTS prefect_executions (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_position
     ON prefect_executions (run_id, position);
+CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_purpose_attempt
+    ON prefect_executions (run_id, purpose, attempt);
 CREATE TABLE IF NOT EXISTS mutation_receipts (
     receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL,
     operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL,
@@ -52,6 +54,11 @@ CREATE TABLE IF NOT EXISTS mutation_receipts (
     state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
     UNIQUE (actor, key_digest)
+);
+CREATE TABLE IF NOT EXISTS write_admissions (
+    run_id TEXT PRIMARY KEY, receipt_id TEXT NOT NULL UNIQUE, operation TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES product_runs(run_id),
+    FOREIGN KEY (receipt_id) REFERENCES mutation_receipts(receipt_id)
 );
 CREATE TABLE IF NOT EXISTS audit_events (
     event_id TEXT PRIMARY KEY, run_id TEXT, actor TEXT NOT NULL, operation TEXT NOT NULL,
@@ -108,6 +115,10 @@ class DuplicatePrefectExecutionError(ValueError):
     """The Prefect flow-run ID is already linked to this Sync run."""
 
 
+class WriteAdmissionConflictError(ValueError):
+    """A product run already owns its one durable write-capable admission."""
+
+
 class ArtifactUnavailableError(RuntimeError):
     """A referenced artifact is not available as a complete, valid publication."""
 
@@ -157,13 +168,17 @@ class _RunStore(Protocol):
 
     def has_pending_artifacts(self, run_id: str) -> bool: ...
 
-    def add_prefect_execution(self, run_id: str, link: PrefectExecutionLink) -> None: ...
+    def add_prefect_execution(
+        self, run_id: str, link: PrefectExecutionLink, *, allocate_attempt: bool = False
+    ) -> PrefectExecutionLink: ...
 
     def observe_prefect_execution(
         self, run_id: str, flow_run_id: str, *, state: str | None, observed_at: datetime
     ) -> None: ...
 
-    def reserve_mutation(self, receipt: MutationReceipt, run: ProductRun | None) -> tuple[MutationReceipt, bool]: ...
+    def reserve_mutation(
+        self, receipt: MutationReceipt, run: ProductRun | None, *, admit_write: bool = False
+    ) -> tuple[MutationReceipt, bool]: ...
 
     def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]: ...
 
@@ -413,7 +428,13 @@ class _RelationalRunStore:
             connection.close()
         return row is not None and int(row[0]) > 0
 
-    def add_prefect_execution(self, run_id: str, link: PrefectExecutionLink) -> None:
+    def add_prefect_execution(
+        self,
+        run_id: str,
+        link: PrefectExecutionLink,
+        *,
+        allocate_attempt: bool = False,
+    ) -> PrefectExecutionLink:
         last_conflict: BaseException | None = None
         for attempt in range(_PREFECT_POSITION_ATTEMPTS):
             connection = self._connect()
@@ -426,7 +447,19 @@ class _RelationalRunStore:
                     )
                     position_row = cursor.fetchone()
                     position = int(position_row[0]) if position_row is not None else 0
-                    self._insert_prefect_execution(cursor, run_id, link, position)
+                    allocated_link = link
+                    if allocate_attempt:
+                        cursor.execute(
+                            self._sql(
+                                "SELECT COALESCE(MAX(attempt) + 1, 1) FROM prefect_executions "
+                                "WHERE run_id = ? AND purpose = ?"
+                            ),
+                            (run_id, link.purpose),
+                        )
+                        attempt_row = cursor.fetchone()
+                        ordinal = int(attempt_row[0]) if attempt_row is not None else 1
+                        allocated_link = link.model_copy(update={"attempt": ordinal})
+                    self._insert_prefect_execution(cursor, run_id, allocated_link, position)
                     connection.commit()
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     # DB-API drivers do not share an integrity-error base class;
@@ -436,7 +469,7 @@ class _RelationalRunStore:
                         raise
                     last_conflict = exc
                 else:
-                    return
+                    return allocated_link
                 finally:
                     cursor.close()
             finally:
@@ -448,6 +481,8 @@ class _RelationalRunStore:
             if attempt + 1 == _PREFECT_POSITION_ATTEMPTS:
                 msg = f"Could not allocate a Prefect execution position for Sync run {run_id!r}"
                 raise RuntimeError(msg) from last_conflict
+        msg = "Prefect execution allocation loop exited unexpectedly"
+        raise AssertionError(msg)
 
     def _insert_prefect_execution(
         self, cursor: _Cursor, run_id: str, link: PrefectExecutionLink, position: int
@@ -505,7 +540,13 @@ class _RelationalRunStore:
         finally:
             connection.close()
 
-    def reserve_mutation(self, receipt: MutationReceipt, run: ProductRun | None) -> tuple[MutationReceipt, bool]:
+    def reserve_mutation(
+        self,
+        receipt: MutationReceipt,
+        run: ProductRun | None,
+        *,
+        admit_write: bool = False,
+    ) -> tuple[MutationReceipt, bool]:
         """Atomically reserve actor/key and optionally create its product run."""
         connection = self._connect()
         try:
@@ -515,6 +556,11 @@ class _RelationalRunStore:
                     cursor.execute(self._sql(_INSERT_MUTATION_RECEIPT), _receipt_values(receipt))
                     if run is not None:
                         self._insert_product_run(cursor, run)
+                    if admit_write:
+                        cursor.execute(
+                            self._sql("INSERT INTO write_admissions (run_id, receipt_id, operation) VALUES (?, ?, ?)"),
+                            (receipt.run_id, receipt.receipt_id, receipt.operation),
+                        )
                     connection.commit()
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     connection.rollback()
@@ -523,6 +569,9 @@ class _RelationalRunStore:
                     existing = self.lookup_mutation(receipt.actor, receipt.key_digest)
                     if existing.value is not None:
                         return existing.value, False
+                    if admit_write and self._write_admission_exists(receipt.run_id):
+                        msg = f"Sync run {receipt.run_id!r} already has a write-capable admission"
+                        raise WriteAdmissionConflictError(msg) from exc
                     if run is not None and self.exists(run.run_id):
                         msg = f"Sync run ID {run.run_id!r} already exists"
                         raise DuplicateRunError(msg) from exc
@@ -532,6 +581,18 @@ class _RelationalRunStore:
         finally:
             connection.close()
         return receipt, True
+
+    def _write_admission_exists(self, run_id: str) -> bool:
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(self._sql("SELECT 1 FROM write_admissions WHERE run_id = ?"), (run_id,))
+                return cursor.fetchone() is not None
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
 
     def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]:
         connection = self._connect()
@@ -917,13 +978,20 @@ class ProductProjection:
         """Look up a product record by stable Sync run ID."""
         return self._records.lookup(run_id)
 
-    def add_prefect_execution(self, run_id: str, link: PrefectExecutionLink, *, secrets: Sequence[str] = ()) -> None:
-        """Append one purpose-labelled execution without changing Sync identity."""
+    def add_prefect_execution(
+        self,
+        run_id: str,
+        link: PrefectExecutionLink,
+        *,
+        allocate_attempt: bool = False,
+        secrets: Sequence[str] = (),
+    ) -> PrefectExecutionLink:
+        """Append one purpose-labelled execution, optionally allocating its ordinal atomically."""
         if not self._records.exists(run_id):
             msg = f"Cannot link a Prefect execution to unavailable Sync run ID {run_id!r}"
             raise RunNotFoundError(msg)
         sanitized = PrefectExecutionLink.model_validate(_redact_value(link.model_dump(mode="json"), secrets))
-        self._records.add_prefect_execution(run_id, sanitized)
+        return self._records.add_prefect_execution(run_id, sanitized, allocate_attempt=allocate_attempt)
 
     def observe_prefect_execution(
         self,
@@ -946,9 +1014,10 @@ class ProductProjection:
         receipt: MutationReceipt,
         *,
         run: ProductRun | None = None,
+        admit_write: bool = False,
         secrets: Sequence[str] = (),
     ) -> tuple[MutationReceipt, bool]:
-        """Reserve one actor/key mutation, optionally with its run, in one transaction."""
+        """Reserve one actor/key mutation and optional run/write admission atomically."""
         sanitized_receipt = MutationReceipt.model_validate(_redact_value(receipt.model_dump(mode="json"), secrets))
         sanitized_run = None if run is None else _redacted_run(run, secrets)
         if sanitized_run is not None:
@@ -962,7 +1031,7 @@ class ProductProjection:
             if sanitized_run.run_id != sanitized_receipt.run_id:
                 msg = "a mutation receipt and its atomically created product run must share one run ID"
                 raise ValueError(msg)
-        return self._records.reserve_mutation(sanitized_receipt, sanitized_run)
+        return self._records.reserve_mutation(sanitized_receipt, sanitized_run, admit_write=admit_write)
 
     def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]:
         """Look up the durable receipt for an actor and hashed client key."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,15 @@ infrahub-sync = "infrahub_sync.cli:app"
 prefect = [
     "prefect==3.8.1",
 ]
+# Managed HTTP service and worker profile (Python 3.11-3.13). Every runtime
+# imported directly by `infrahub_sync.managed` is declared here; the reusable
+# Prefect integration is pinned to the reviewed DB-102/103/104 stack exactly.
+managed = [
+    "fastapi>=0.115,<1; python_version >= '3.11'",
+    "opsmill-prefect-extras @ git+https://github.com/opsmill/prefect-extras.git@84688eb8d8db7e17770413640a66481ccdc3e725 ; python_version >= '3.11'",
+    "prefect==3.8.1; python_version >= '3.11'",
+    "uvicorn>=0.34,<1; python_version >= '3.11'",
+]
 dev = [
     "yamllint>=1.37.1",
     "pylint",
@@ -78,6 +87,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["infrahub_sync"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pylint.general]
 extension-pkg-whitelist = [
@@ -415,4 +427,3 @@ showcontent = true
 directory = "housekeeping"
 name = "Housekeeping"
 showcontent = true
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ prefect = [
 # Prefect integration is pinned to the reviewed DB-102/103/104 stack exactly.
 managed = [
     "fastapi>=0.115,<1; python_version >= '3.11'",
+    "httpx>=0.27,<1; python_version >= '3.11'",
     "opsmill-prefect-extras @ git+https://github.com/opsmill/prefect-extras.git@84688eb8d8db7e17770413640a66481ccdc3e725 ; python_version >= '3.11'",
     "prefect==3.8.1; python_version >= '3.11'",
     "uvicorn>=0.34,<1; python_version >= '3.11'",

--- a/tests/integration/test_managed_prefect_idempotency.py
+++ b/tests/integration/test_managed_prefect_idempotency.py
@@ -1,0 +1,57 @@
+"""Authorized temporary-server proof for managed Prefect idempotency."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import ExitStack
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+
+from prefect.client.orchestration import get_client
+from prefect.testing.utilities import prefect_test_harness
+
+from infrahub_sync.managed.orchestration import (
+    MANAGED_DEPLOYMENT_NAME,
+    MANAGED_FLOW_NAME,
+    PrefectOrchestration,
+)
+
+
+@pytest.fixture
+def isolated_prefect_server(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    """Start and fully tear down Prefect's isolated temporary API server."""
+    home = tmp_path / "prefect-home"
+    monkeypatch.setenv("PREFECT_HOME", str(home))
+    monkeypatch.setenv("PREFECT_LOCAL_STORAGE_PATH", str(home / "storage"))
+    with ExitStack() as stack:
+        stack.enter_context(prefect_test_harness())
+        yield
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_same_opaque_key_creates_one_prefect_flow_run(isolated_prefect_server: None) -> None:  # noqa: ARG001
+    parameters: dict[str, object] = {
+        "run_id": "run-server-idempotency",
+        "sync_name": "inventory",
+        "stage": "plan",
+        "configuration_reference": "sha256:configuration",
+        "branch": None,
+        "expected_checksum": None,
+        "confirm_writes": False,
+    }
+    async with get_client() as client:
+        flow_id = await client.create_flow_from_name(MANAGED_FLOW_NAME)
+        deployment_id = await client.create_deployment(flow_id, name=MANAGED_DEPLOYMENT_NAME)
+        orchestration = PrefectOrchestration(client)
+
+        first = await orchestration.submit(parameters, idempotency_key="opaque-server-proof")
+        second = await orchestration.submit(parameters, idempotency_key="opaque-server-proof")
+        runs = await client.read_flow_runs()
+
+    assert first.flow_run_id == second.flow_run_id
+    assert len([run for run in runs if run.deployment_id == deployment_id]) == 1

--- a/tests/managed/__init__.py
+++ b/tests/managed/__init__.py
@@ -1,0 +1,1 @@
+"""Managed API and flow tests."""

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+
+from opsmill_prefect_extras.deployments import apply_deployments
+from opsmill_prefect_extras.workflows import assert_valid_definitions
+from prefect.exceptions import MissingContextError, ObjectNotFound
+from prefect.states import Pending
+
+from infrahub_sync.execution import RunResult
+from infrahub_sync.managed import flow as managed_flow
+from infrahub_sync.managed.deploy import CATALOGUE
+from infrahub_sync.managed.flow import managed_sync_run
+from infrahub_sync.managed.orchestration import MANAGED_DEFINITION, PrefectOrchestration
+from infrahub_sync.orchestration.flow import infrahub_sync_run
+from infrahub_sync.plan.models import PlanManifest
+from infrahub_sync.plan.review import SavedPlan
+from infrahub_sync.product_store import ProductRun, local_product_projection
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.actions import DeploymentUpdate
+    from prefect.client.schemas.objects import State
+
+
+def _saved(run_id: str) -> SavedPlan:
+    manifest = PlanManifest(
+        format_version=2,
+        run_id=run_id,
+        created_at="2026-08-10T12:00:00+00:00",
+        config_version="configuration-v1",
+        source_snapshot=[],
+        operations_count=0,
+        delete_operations_computed=True,
+        plan_checksum="a" * 64,
+    )
+    return SavedPlan(manifest=manifest, operations=[], checksum_ok=True, verification_notes=[])
+
+
+def _instance(sync_name: str, *, directory: str) -> SimpleNamespace:  # noqa: ARG001 - resolver protocol fake.
+    return SimpleNamespace(name=sync_name)
+
+
+def _create_product_run(
+    cache: Path,
+    run_id: str,
+    *,
+    operation: Literal["plan", "sync", "verify", "apply"] = "plan",
+):
+    projection = local_product_projection(cache)
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation=operation,
+            configuration_reference="sha256:configuration",
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="accepted",
+            summary={"sync_name": "inventory"},
+        )
+    )
+    return projection
+
+
+def test_managed_and_developer_preview_flow_schemas_are_separate_and_exact() -> None:
+    assert tuple(inspect.signature(managed_sync_run.fn).parameters) == (
+        "run_id",
+        "sync_name",
+        "stage",
+        "configuration_reference",
+        "branch",
+        "expected_checksum",
+        "confirm_writes",
+    )
+    assert tuple(inspect.signature(infrahub_sync_run.fn).parameters) == (
+        "sync_name",
+        "operation",
+        "confirm_writes",
+        "branch",
+    )
+    assert CATALOGUE.keys() == (MANAGED_DEFINITION.key,)
+    assert_valid_definitions(CATALOGUE)
+
+
+def test_missing_context_uses_local_logger_without_constructing_a_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing_context():
+        raise MissingContextError
+
+    def bridge_is_forbidden(_logger):
+        msg = "RunLoggerBridge must not be constructed in the local fallback"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(managed_flow, "get_run_logger", missing_context)
+    monkeypatch.setattr(managed_flow, "RunLoggerBridge", bridge_is_forbidden)
+
+    run_logger, prefect_context = managed_flow._run_logger()
+    with managed_flow._remote_log_bridge(run_logger, prefect_context=prefect_context):
+        run_logger.info("local managed execution")
+
+    assert isinstance(run_logger, logging.Logger)
+    assert prefect_context is False
+
+
+def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    run_id = "run-managed-plan"
+    projection = _create_product_run(tmp_path.resolve(), run_id)
+    saved = _saved(run_id)
+    seen: list[str] = []
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+
+    def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
+        seen.append(run_id)
+        assert composed_sync is False
+        return saved
+
+    monkeypatch.setattr(managed_flow, "_plan", plan)
+
+    result = managed_sync_run.fn(
+        run_id,
+        "inventory",
+        "plan",
+        "sha256:configuration",
+    )
+
+    assert seen == [run_id]
+    assert result["run_id"] == run_id
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.phase == "planned"
+    assert [artifact.artifact_id for artifact in stored.artifact_refs] == ["plan-review"]
+
+
+def test_managed_verify_is_read_only_for_product_lifecycle(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    run_id = "run-managed-verify"
+    projection = _create_product_run(tmp_path.resolve(), run_id)
+    before = projection.lookup_run(run_id).value
+    saved = _saved(run_id)
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+    monkeypatch.setattr(managed_flow, "execute_run", lambda *_args, **_kwargs: saved)
+
+    result = managed_sync_run.fn(
+        run_id,
+        "inventory",
+        "verify",
+        "sha256:configuration",
+    )
+
+    assert result == {
+        "run_id": run_id,
+        "stage": "verify",
+        "outcome": "verified",
+        "checksum": "a" * 64,
+        "checksum_ok": True,
+        "verification_notes": [],
+    }
+    after = projection.lookup_run(run_id).value
+    assert after is not None
+    assert before is not None
+    assert after.model_dump(exclude={"results"}) == before.model_dump(exclude={"results"})
+    assert after.results == {"verification": result}
+
+
+def test_confirmed_managed_sync_calls_plan_verify_apply_in_order_on_one_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    run_id = "run-managed-sync"
+    projection = _create_product_run(tmp_path.resolve(), run_id, operation="sync")
+    saved = _saved(run_id)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+
+    def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
+        calls.append(("plan", run_id))
+        assert composed_sync is True
+        return saved
+
+    def execute(_instance, *, operation: str, run_id: str, **kwargs: object) -> SavedPlan | RunResult:
+        calls.append((operation, run_id))
+        if operation == "verify":
+            return saved
+        assert operation == "apply"
+        assert kwargs["expected_checksum"] == saved.manifest.plan_checksum
+        assert kwargs["confirm_writes"] is True
+        return RunResult(
+            sync_name="inventory",
+            operation="apply",
+            run_id=run_id,
+            status="no-change",
+            changed=False,
+            summary={"create": 0, "update": 0, "delete": 0},
+            artifact_path=str(tmp_path / run_id),
+        )
+
+    monkeypatch.setattr(managed_flow, "_plan", plan)
+    monkeypatch.setattr(managed_flow, "execute_run", execute)
+
+    managed_sync_run.fn(
+        run_id,
+        "inventory",
+        "sync",
+        "sha256:configuration",
+        confirm_writes=True,
+    )
+
+    assert calls == [("plan", run_id), ("verify", run_id), ("apply", run_id)]
+    assert projection.lookup_run(run_id).value is not None
+    assert projection.lookup_run(run_id).value.phase == "applied"  # type: ignore[union-attr]
+
+
+class _RemoteFlowRun:
+    def __init__(self, run_id: UUID) -> None:
+        self.id = run_id
+        self.state = Pending()
+
+
+class _RemoteClient:
+    def __init__(self) -> None:
+        self.deployment_id = uuid4()
+        self.flow_run = _RemoteFlowRun(uuid4())
+        self.keys: list[str | None] = []
+        self.parameters: list[dict[str, Any]] = []
+
+    async def read_deployment_by_name(self, name: str):
+        assert name == MANAGED_DEFINITION.key
+        return SimpleNamespace(id=self.deployment_id)
+
+    async def create_flow_run_from_deployment(
+        self,
+        deployment_id: UUID,
+        *,
+        parameters: dict[str, Any],
+        idempotency_key: str | None = None,
+    ):
+        assert deployment_id == self.deployment_id
+        self.keys.append(idempotency_key)
+        self.parameters.append(parameters)
+        return self.flow_run
+
+    async def read_flow_run(self, flow_run_id: UUID):
+        assert flow_run_id == self.flow_run.id
+        return self.flow_run
+
+    async def set_flow_run_state(self, flow_run_id: UUID, state: State[object]) -> SimpleNamespace:
+        assert flow_run_id == self.flow_run.id
+        self.flow_run.state = state
+        return SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_prefect_extras_executor_receives_opaque_key_unchanged() -> None:
+    client = _RemoteClient()
+    gateway = PrefectOrchestration(client)  # type: ignore[arg-type] - offline fake implements the protocol.
+    parameters: dict[str, object] = {
+        "run_id": "run-001",
+        "sync_name": "inventory",
+        "stage": "plan",
+        "configuration_reference": "sha256:configuration",
+        "branch": None,
+        "expected_checksum": None,
+        "confirm_writes": False,
+    }
+
+    submission = await gateway.submit(parameters, idempotency_key="opaque-prefect-key")
+
+    assert submission.flow_run_id == str(client.flow_run.id)
+    assert client.keys == ["opaque-prefect-key"]
+    assert client.parameters == [parameters]
+
+
+class _DeploymentClient:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    async def read_deployment_by_name(self, name: str) -> NoReturn:  # noqa: ARG002, PLR6301 - protocol fake.
+        raise ObjectNotFound(RuntimeError("missing deployment"))
+
+    async def create_flow_from_name(self, flow_name: str) -> UUID:  # noqa: ARG002, PLR6301 - protocol fake.
+        return uuid4()
+
+    async def create_deployment(self, flow_id: UUID, **payload: Any) -> UUID:  # noqa: ANN401, ARG002
+        self.created.append(payload)
+        return uuid4()
+
+    async def update_deployment(  # noqa: PLR6301 - protocol fake.
+        self,
+        deployment_id: UUID,  # noqa: ARG002 - protocol signature.
+        deployment: DeploymentUpdate,  # noqa: ARG002 - protocol signature.
+    ) -> None:
+        msg = "a missing deployment must be created, not updated"
+        raise AssertionError(msg)
+
+
+@pytest.mark.asyncio
+async def test_prefect_extras_deployment_converges_the_managed_catalogue_offline() -> None:
+    client = _DeploymentClient()
+
+    report = await apply_deployments(CATALOGUE, work_pool_name="managed-pool", client=client)
+
+    assert report.is_successful
+    assert [result.status for result in report.results] == ["created"]
+    assert client.created[0]["work_pool_name"] == "managed-pool"

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, NoReturn
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
 pytest.importorskip("prefect")
@@ -17,13 +18,13 @@ pytest.importorskip("opsmill_prefect_extras")
 from opsmill_prefect_extras.deployments import apply_deployments
 from opsmill_prefect_extras.workflows import assert_valid_definitions
 from prefect.exceptions import MissingContextError, ObjectNotFound
-from prefect.states import Pending
+from prefect.states import Failed, Pending
 
 from infrahub_sync.execution import RunResult
 from infrahub_sync.managed import flow as managed_flow
 from infrahub_sync.managed.deploy import CATALOGUE
 from infrahub_sync.managed.flow import managed_sync_run
-from infrahub_sync.managed.orchestration import MANAGED_DEFINITION, PrefectOrchestration
+from infrahub_sync.managed.orchestration import MANAGED_DEFINITION, Observation, PrefectOrchestration
 from infrahub_sync.orchestration.flow import infrahub_sync_run
 from infrahub_sync.plan.models import PlanManifest
 from infrahub_sync.plan.review import SavedPlan
@@ -50,6 +51,17 @@ def _saved(run_id: str) -> SavedPlan:
 
 def _instance(sync_name: str, *, directory: str) -> SimpleNamespace:  # noqa: ARG001 - resolver protocol fake.
     return SimpleNamespace(name=sync_name)
+
+
+class _RecordingRunLogger:
+    def __init__(self) -> None:
+        self.rendered: list[str] = []
+
+    def log(self, _level: int, message: str, *args: object) -> None:
+        self.rendered.append(message % args)
+
+    def info(self, message: str, *args: object) -> None:
+        self.rendered.append(message % args)
 
 
 def _create_product_run(
@@ -112,6 +124,61 @@ def test_missing_context_uses_local_logger_without_constructing_a_bridge(monkeyp
     assert prefect_context is False
 
 
+def test_managed_flow_redacts_worker_logs_exception_chain_and_failed_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    environment_canary = "worker-environment-token-canary"
+    configuration_canary = "worker-configuration-token-canary"
+    run_id = "run-managed-secret-failure"
+    projection = _create_product_run(tmp_path.resolve(), run_id)
+    run_logger = _RecordingRunLogger()
+    instance = SimpleNamespace(
+        name="inventory",
+        source=SimpleNamespace(settings={"token": configuration_canary}),
+        destination=SimpleNamespace(settings={}),
+        store=None,
+    )
+    monkeypatch.setenv("NETBOX_TOKEN", environment_canary)
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (run_logger, True))
+
+    def resolve(_sync_name: str, *, directory: str):  # noqa: ARG001
+        logging.getLogger("infrahub_sync.managed.worker").warning(
+            "resolution used %s",
+            environment_canary,
+        )
+        return instance
+
+    def fail_plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
+        logging.getLogger("infrahub_sync.managed.worker").error(
+            "execution used %s",
+            configuration_canary,
+        )
+        cause_message = f"transport rejected {environment_canary}"
+        failure_message = f"adapter rejected {configuration_canary}"
+        raise ValueError(failure_message) from ConnectionError(cause_message)
+
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", resolve)
+    monkeypatch.setattr(managed_flow, "_plan", fail_plan)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        managed_sync_run.fn(run_id, "inventory", "plan", "sha256:configuration")
+
+    failure = exc_info.value
+    failed_state = Failed(message=str(failure), data=failure)
+    chain: list[BaseException] = []
+    current: BaseException | None = failure
+    while current is not None:
+        chain.append(current)
+        current = current.__cause__
+    scanned = repr((run_logger.rendered, chain, failed_state))
+    assert environment_canary not in scanned
+    assert configuration_canary not in scanned
+    assert "***" in scanned
+    assert failure.__context__ is None
+
+
 def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -122,7 +189,7 @@ def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
     monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
-    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
 
     def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
         seen.append(run_id)
@@ -154,7 +221,7 @@ def test_managed_verify_is_read_only_for_product_lifecycle(monkeypatch: pytest.M
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
     monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
-    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(managed_flow, "execute_run", lambda *_args, **_kwargs: saved)
 
     result = managed_sync_run.fn(
@@ -190,7 +257,7 @@ def test_confirmed_managed_sync_calls_plan_verify_apply_in_order_on_one_run(
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
     monkeypatch.setattr(managed_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
-    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance: ())
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
 
     def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
         calls.append(("plan", run_id))
@@ -288,6 +355,30 @@ async def test_prefect_extras_executor_receives_opaque_key_unchanged() -> None:
     assert submission.flow_run_id == str(client.flow_run.id)
     assert client.keys == ["opaque-prefect-key"]
     assert client.parameters == [parameters]
+
+
+class _ReadTransportFailureClient:
+    async def read_flow_run(self, _flow_run_id: UUID):  # noqa: PLR6301 - protocol fake.
+        request = httpx.Request("GET", "http://prefect.invalid/api/flow_runs/id")
+        message = "Prefect is unavailable"
+        raise httpx.ConnectError(message, request=request)
+
+
+@pytest.mark.asyncio
+async def test_prefect_read_transport_failure_becomes_missing_live_detail() -> None:
+    gateway = PrefectOrchestration(
+        _ReadTransportFailureClient()  # ty: ignore[invalid-argument-type] - read-only protocol fake.
+    )
+
+    observed = await gateway.observe(str(uuid4()))
+    cancelled = await gateway.cancel(str(uuid4()))
+
+    assert observed == Observation(
+        available=False,
+        state=None,
+        reason="prefect-read-unavailable",
+    )
+    assert cancelled == observed
 
 
 class _DeploymentClient:

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -26,7 +26,8 @@ from infrahub_sync.managed.deploy import CATALOGUE
 from infrahub_sync.managed.flow import managed_sync_run
 from infrahub_sync.managed.orchestration import MANAGED_DEFINITION, Observation, PrefectOrchestration
 from infrahub_sync.orchestration.flow import infrahub_sync_run
-from infrahub_sync.plan.models import PlanManifest
+from infrahub_sync.plan.errors import OperationApplyFailedError
+from infrahub_sync.plan.models import ApplyRecord, PlanManifest
 from infrahub_sync.plan.review import SavedPlan
 from infrahub_sync.product_store import ProductRun, local_product_projection
 
@@ -177,6 +178,58 @@ def test_managed_flow_redacts_worker_logs_exception_chain_and_failed_state(
     assert configuration_canary not in scanned
     assert "***" in scanned
     assert failure.__context__ is None
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.phase == "plan-failed"
+    assert stored.outcome == "failed"
+    assert stored.results["plan_failure"] == {
+        "stage": "plan",
+        "outcome": "failed",
+        "error_type": "ValueError",
+    }
+    assert environment_canary not in stored.model_dump_json()
+    assert configuration_canary not in stored.model_dump_json()
+
+
+def test_managed_apply_failure_retains_partial_write_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_id = "run-managed-apply-failure"
+    projection = _create_product_run(tmp_path.resolve(), run_id)
+    partial = ApplyRecord(applied_operations=("op-applied",), failed_operation="op-failed")
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+
+    def fail_apply(*_args: object, **_kwargs: object) -> NoReturn:
+        msg = "destination rejected operation"
+        raise OperationApplyFailedError(msg, apply_record=partial)
+
+    monkeypatch.setattr(managed_flow, "execute_run", fail_apply)
+
+    with pytest.raises(RuntimeError):
+        managed_sync_run.fn(
+            run_id,
+            "inventory",
+            "apply",
+            "sha256:configuration",
+            expected_checksum="a" * 64,
+            confirm_writes=True,
+        )
+
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.phase == "apply-failed"
+    assert stored.outcome == "failed"
+    assert stored.summary["may_have_partially_written"] is True
+    assert stored.results["apply_failure"] == {
+        "stage": "apply",
+        "outcome": "failed",
+        "error_type": "OperationApplyFailedError",
+        **partial.as_summary_keys(),
+    }
 
 
 def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
@@ -37,6 +38,7 @@ class _FakeOrchestration:
         self.observations: dict[str, Observation] = {}
         self.fail_after_accept_once = False
         self.cancel_failure = False
+        self.cancel_exception = False
         self.cancelled: list[str] = []
 
     async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:
@@ -61,6 +63,9 @@ class _FakeOrchestration:
 
     async def cancel(self, flow_run_id: str) -> Observation:
         self.cancelled.append(flow_run_id)
+        if self.cancel_exception:
+            msg = "Prefect cancellation race exposed token-canary"
+            raise RuntimeError(msg)
         if self.cancel_failure:
             return Observation(available=False, state="running", reason="prefect-cancellation-unavailable")
         observed = Observation(available=True, state="cancelling")
@@ -205,6 +210,36 @@ def test_lost_submission_response_reuses_one_opaque_prefect_key_and_flow_run(
     assert run.prefect_executions[0].flow_run_id == next(iter(orchestration.by_key.values())).flow_run_id
 
 
+def test_reserved_apply_retry_replays_after_the_plan_artifact_expires(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+    tmp_path: Path,
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    headers = {**AUTH, "Idempotency-Key": "apply-expired-plan-retry"}
+    body = {
+        "expected_checksum": plan.checksum,
+        "reason": "approved before retention elapsed",
+        "confirm_writes": True,
+    }
+    orchestration.fail_after_accept_once = True
+
+    uncertain = client.post(f"/runs/{run_id}/apply", headers=headers, json=body)
+    with sqlite3.connect(tmp_path / "product-records.sqlite3") as connection:
+        connection.execute(
+            "UPDATE artifact_refs SET expires_at = ? WHERE run_id = ? AND artifact_id = ?",
+            ((datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(), run_id, PLAN_ARTIFACT_ID),
+        )
+    recovered = client.post(f"/runs/{run_id}/apply", headers=headers, json=body)
+
+    assert uncertain.status_code == 503
+    assert recovered.status_code == 202
+    assert len(orchestration.submissions) == 3
+    assert orchestration.submissions[-2][1] == orchestration.submissions[-1][1]
+
+
 def test_retained_routes_survive_missing_prefect_detail(
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:
@@ -277,6 +312,67 @@ def test_cancellation_transport_failure_remains_a_typed_mutation_error(
     assert response.json()["error"]["mutation_id"].startswith("m-")
 
 
+def test_cancellation_exception_remains_typed_secret_safe_and_audited(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    orchestration.cancel_exception = True
+
+    response = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-exception"},
+        json={"reason": "stop after cancellation race"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "orchestration-unavailable"
+    assert response.json()["error"]["mutation_id"].startswith("m-")
+    assert "token-canary" not in response.text
+    assert any(event.operation == "cancel" and event.outcome == "unavailable" for event in projection.audit_events())
+
+
+@pytest.mark.parametrize(
+    "newest_observation",
+    [
+        Observation(available=True, state="completed"),
+        Observation(available=False, state=None, reason="prefect-execution-unavailable"),
+    ],
+)
+def test_cancel_scans_past_newer_non_active_links(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+    newest_observation: Observation,
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    applied = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "cancel-active-apply"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    )
+    verified = client.post(
+        f"/runs/{run_id}/verify",
+        headers={**AUTH, "Idempotency-Key": "newer-finished-verify"},
+        json={"reason": "later read-only check"},
+    )
+    apply_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
+    verify_flow_run_id = verified.json()["orchestration"][-1]["flow_run_id"]
+    orchestration.observations[apply_flow_run_id] = Observation(available=True, state="running")
+    orchestration.observations[verify_flow_run_id] = newest_observation
+
+    cancelled = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": f"scan-cancel-{newest_observation.reason or newest_observation.state}"},
+        json={"reason": "stop the active write"},
+    )
+
+    assert cancelled.status_code == 202
+    assert orchestration.cancelled == [apply_flow_run_id]
+
+
 def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - one end-to-end matrix.
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:
@@ -320,8 +416,8 @@ def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - o
         headers={**AUTH, "Idempotency-Key": "cancel-ok"},
         json={"reason": "operator requested stop"},
     )
-    applied_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
-    orchestration.observations[applied_flow_run_id] = Observation(available=True, state="completed")
+    for summary in applied.json()["orchestration"]:
+        orchestration.observations[summary["flow_run_id"]] = Observation(available=True, state="completed")
     terminal_cancel = client.post(
         f"/runs/{run_id}/cancel",
         headers={**AUTH, "Idempotency-Key": "cancel-terminal"},
@@ -520,6 +616,7 @@ def test_stable_not_found_expired_unavailable_and_degraded_prefect_reads(
     unavailable = next(item for item in run.artifact_refs if item.artifact_id == "unavailable")
     (tmp_path / "artifacts" / unavailable.object_key).unlink()
     unavailable_response = client.get(f"/runs/{run_id}/artifacts/unavailable", headers=headers)
+    missing_artifact = client.get(f"/runs/{run_id}/artifacts/missing", headers=headers)
 
     expired_at = datetime.now(timezone.utc) - timedelta(seconds=1)
     with sqlite3.connect(tmp_path / "product-records.sqlite3") as connection:
@@ -537,13 +634,37 @@ def test_stable_not_found_expired_unavailable_and_degraded_prefect_reads(
 
     assert missing.status_code == 404
     assert unavailable_response.status_code == 503
+    assert missing_artifact.status_code == 404
+    assert missing_artifact.json()["error"]["code"] == "artifact-not-found"
     assert expired.status_code == 410
     assert degraded.status_code == 200
     assert degraded.json()["orchestration"][0]["detail_available"] is False
     assert degraded.json()["orchestration"][0]["unavailable_reason"] == "prefect-read-unavailable"
-    for response in (missing, unavailable_response, expired):
+    for response in (missing, missing_artifact, unavailable_response, expired):
         assert set(response.json()) == {"error"}
         assert "token-canary" not in response.text
+
+
+def test_generic_service_failure_is_contained_before_server_logging(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client, projection, _orchestration = managed
+    canary = "unexpected-storage-token-canary"
+
+    def fail_lookup(_run_id: str):
+        raise RuntimeError(canary)
+
+    monkeypatch.setattr(projection, "lookup_run", fail_lookup)
+    with caplog.at_level(logging.ERROR, logger="infrahub_sync.managed.app"):
+        response = client.get("/runs/failing-run", headers={"Authorization": f"bearer {OWNER_TOKEN}"})
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "service-unavailable"
+    assert canary not in response.text
+    assert canary not in caplog.text
+    assert "RuntimeError" in caplog.text
 
 
 def test_confirmation_schema_errors_and_openapi_contract(

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from infrahub_sync.managed.app import create_app
+from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
+from infrahub_sync.managed.models import PlanResource
+from infrahub_sync.managed.orchestration import Observation, Submission
+from infrahub_sync.managed.service import PLAN_ARTIFACT_ID, ManagedRunService
+from infrahub_sync.product_store import ProductProjection, local_product_projection
+
+OWNER_TOKEN = "owner-token-canary-0001"  # noqa: S105 - deliberate non-secret boundary canary.
+OTHER_TOKEN = "other-token-canary-0002"  # noqa: S105 - deliberate non-secret boundary canary.
+ADMIN_TOKEN = "admin-token-canary-0003"  # noqa: S105 - deliberate non-secret boundary canary.
+RAW_KEY = "client-idempotency-key-canary"
+AUTH = {"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": RAW_KEY}
+
+
+class _FakeOrchestration:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[dict[str, object], str]] = []
+        self.by_key: dict[str, Submission] = {}
+        self.observations: dict[str, Observation] = {}
+        self.fail_after_accept_once = False
+        self.cancelled: list[str] = []
+
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:
+        self.submissions.append((parameters, idempotency_key))
+        submission = self.by_key.get(idempotency_key)
+        if submission is None:
+            flow_run_id = str(uuid5(NAMESPACE_URL, idempotency_key))
+            submission = Submission(flow_run_id=flow_run_id, state="pending")
+            self.by_key[idempotency_key] = submission
+            self.observations[flow_run_id] = Observation(available=True, state="running")
+            if self.fail_after_accept_once:
+                self.fail_after_accept_once = False
+                msg = "response lost after Prefect accepted token-canary-should-redact"
+                raise TimeoutError(msg)
+        return submission
+
+    async def observe(self, flow_run_id: str) -> Observation:
+        return self.observations.get(
+            flow_run_id,
+            Observation(available=False, state=None, reason="prefect-execution-unavailable"),
+        )
+
+    async def cancel(self, flow_run_id: str) -> Observation:
+        self.cancelled.append(flow_run_id)
+        observed = Observation(available=True, state="cancelling")
+        self.observations[flow_run_id] = observed
+        return observed
+
+
+@pytest.fixture
+def managed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[TestClient, ProductProjection, _FakeOrchestration]:
+    monkeypatch.setenv(
+        PRINCIPALS_ENV,
+        json.dumps(
+            {
+                "owner": {"token": OWNER_TOKEN},
+                "other": {"token": OTHER_TOKEN},
+                "admin": {"token": ADMIN_TOKEN, "administrator": True},
+            }
+        ),
+    )
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path.resolve())
+    orchestration = _FakeOrchestration()
+    service = ManagedRunService(projection, orchestration, secrets=resolver.secret_values)
+    return TestClient(create_app(service, resolver)), projection, orchestration
+
+
+def _create(client: TestClient, *, key: str = RAW_KEY, reason: str = "review inventory changes"):
+    return client.post(
+        "/runs",
+        headers={"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": key},
+        json={
+            "sync_name": "inventory",
+            "operation": "plan",
+            "configuration_reference": "sha256:configuration",
+            "reason": reason,
+        },
+    )
+
+
+def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str = "a" * 64) -> PlanResource:
+    plan = PlanResource(
+        run_id=run_id,
+        checksum=checksum,
+        checksum_ok=True,
+        verification_notes=(),
+        summary={"by_action": {"create": 1}, "by_kind": {"Device": 1}, "total": 1},
+        operations=(
+            {
+                "operation_id": "op-001",
+                "action": "create",
+                "kind": "Device",
+                "identity": {"name": "edge-01"},
+            },
+        ),
+    )
+    projection.publish_artifact(
+        run_id,
+        artifact_id=PLAN_ARTIFACT_ID,
+        kind="saved-plan-review",
+        media_type="application/json",
+        data=plan.model_dump_json().encode(),
+    )
+    return plan
+
+
+def test_authentication_idempotency_and_secret_boundaries(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration], tmp_path: Path
+) -> None:
+    client, projection, orchestration = managed
+
+    missing = client.post("/runs", json={})
+    invalid = client.post("/runs", headers={"Authorization": "Bearer invalid-token-value"}, json={})
+    assert missing.status_code == 401
+    assert invalid.status_code == 401
+    assert missing.json()["error"]["code"] == "unauthenticated"
+
+    first = _create(client, reason=f"requested because {OWNER_TOKEN}")
+    replay = _create(client, reason=f"requested because {OWNER_TOKEN}")
+    conflict = _create(client, reason="different reason")
+
+    assert first.status_code == replay.status_code == 202
+    assert first.json() == replay.json()
+    assert conflict.status_code == 409
+    assert conflict.json()["error"]["code"] == "idempotency-conflict"
+    assert len(orchestration.submissions) == 1
+    run_id = first.json()["run"]["run_id"]
+    assert projection.lookup_run(run_id).available
+
+    parameters, opaque_key = orchestration.submissions[0]
+    assert set(parameters) == {
+        "run_id",
+        "sync_name",
+        "stage",
+        "configuration_reference",
+        "branch",
+        "expected_checksum",
+        "confirm_writes",
+    }
+    assert RAW_KEY not in opaque_key
+    boundary = repr((first.json(), parameters, projection.audit_events()))
+    assert OWNER_TOKEN not in boundary
+    assert RAW_KEY not in boundary
+    database_bytes = (tmp_path / "product-records.sqlite3").read_bytes()
+    assert OWNER_TOKEN.encode() not in database_bytes
+    assert RAW_KEY.encode() not in database_bytes
+    assert any(event.outcome == "refused-authentication" for event in projection.audit_events())
+
+    secret_parameter = client.post(
+        "/runs",
+        headers={"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": "secret-parameter-key"},
+        json={
+            "sync_name": "inventory",
+            "operation": "plan",
+            "configuration_reference": OWNER_TOKEN,
+            "reason": "reject credential-bearing parameter",
+        },
+    )
+    assert secret_parameter.status_code == 422
+    assert secret_parameter.json()["error"]["code"] == "secret-parameter-refused"
+    assert len(orchestration.submissions) == 1
+
+
+def test_lost_submission_response_reuses_one_opaque_prefect_key_and_flow_run(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    orchestration.fail_after_accept_once = True
+
+    uncertain = _create(client, key="timeout-retry-key")
+    recovered = _create(client, key="timeout-retry-key")
+
+    assert uncertain.status_code == 503
+    assert uncertain.json()["error"]["mutation_id"].startswith("m-")
+    assert recovered.status_code == 202
+    assert len(orchestration.submissions) == 2
+    assert orchestration.submissions[0][1] == orchestration.submissions[1][1]
+    run = projection.lookup_run(recovered.json()["run"]["run_id"]).value
+    assert run is not None
+    assert len(run.prefect_executions) == 1
+    assert run.prefect_executions[0].flow_run_id == next(iter(orchestration.by_key.values())).flow_run_id
+
+
+def test_retained_routes_survive_missing_prefect_detail(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    projection.publish_artifact(
+        run_id,
+        artifact_id="report",
+        kind="result-report",
+        media_type="text/plain",
+        data=b"retained result",
+    )
+    projection.finish_run(
+        run_id,
+        phase="planned",
+        outcome="planned",
+        summary={"sync_name": "inventory", "total": 1},
+        results={"status": "planned"},
+    )
+    flow_run_id = created.json()["orchestration"][0]["flow_run_id"]
+    orchestration.observations[flow_run_id] = Observation(
+        available=False,
+        state=None,
+        reason="prefect-execution-unavailable",
+    )
+
+    run_response = client.get(f"/runs/{run_id}", headers={"Authorization": f"Bearer {OTHER_TOKEN}"})
+    plan_response = client.get(f"/runs/{run_id}/plan", headers={"Authorization": f"Bearer {OWNER_TOKEN}"})
+    results = client.get(f"/runs/{run_id}/results", headers={"Authorization": f"Bearer {OWNER_TOKEN}"})
+    artifacts = client.get(f"/runs/{run_id}/artifacts", headers={"Authorization": f"Bearer {OWNER_TOKEN}"})
+    artifact = client.get(
+        f"/runs/{run_id}/artifacts/report",
+        headers={"Authorization": f"Bearer {OWNER_TOKEN}"},
+    )
+
+    assert run_response.status_code == 200
+    assert run_response.json()["orchestration"][0] == {
+        "flow_run_id": flow_run_id,
+        "purpose": "plan",
+        "attempt": 1,
+        "state": "pending",
+        "detail_available": False,
+        "unavailable_reason": "prefect-execution-unavailable",
+    }
+    assert plan_response.json() == plan.model_dump(mode="json")
+    assert results.json() == {"run_id": run_id, "results": {"status": "planned"}}
+    assert {item["artifact_id"] for item in artifacts.json()["artifacts"]} == {PLAN_ARTIFACT_ID, "report"}
+    assert artifact.content == b"retained result"
+    assert artifact.headers["digest"].startswith("sha-256=")
+
+
+def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - one end-to-end matrix.
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    other_headers = {"Authorization": f"Bearer {OTHER_TOKEN}", "Idempotency-Key": "other-key"}
+    admin_headers = {"Authorization": f"Bearer {ADMIN_TOKEN}", "Idempotency-Key": "admin-key"}
+
+    refused = client.post(f"/runs/{run_id}/verify", headers=other_headers, json={"reason": "not my run"})
+    verified = client.post(f"/runs/{run_id}/verify", headers=admin_headers, json={"reason": "admin review"})
+    verified_replay = client.post(f"/runs/{run_id}/verify", headers=admin_headers, json={"reason": "admin review"})
+    unconfirmed = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-unconfirmed"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": False},
+    )
+    stale = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-stale"},
+        json={"expected_checksum": "b" * 64, "reason": "approved", "confirm_writes": True},
+    )
+    applied = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-ok"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    )
+    applied_replay = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-ok"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    )
+    cancelled = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-ok"},
+        json={"reason": "operator requested stop"},
+    )
+    cancelled_replay = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-ok"},
+        json={"reason": "operator requested stop"},
+    )
+    applied_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
+    orchestration.observations[applied_flow_run_id] = Observation(available=True, state="completed")
+    terminal_cancel = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-terminal"},
+        json={"reason": "too late to stop"},
+    )
+
+    assert refused.status_code == 403
+    assert verified.status_code == 202
+    assert verified_replay.json() == verified.json()
+    assert unconfirmed.status_code == 409
+    assert stale.status_code == 409
+    assert applied.status_code == 202
+    assert applied_replay.json() == applied.json()
+    assert cancelled.status_code == 202
+    assert cancelled_replay.json() == cancelled.json()
+    assert terminal_cancel.status_code == 409
+    assert terminal_cancel.json()["error"]["code"] == "execution-terminal"
+    assert len(orchestration.submissions) == 3
+    assert [parameters["stage"] for parameters, _ in orchestration.submissions] == ["plan", "verify", "apply"]
+    assert orchestration.cancelled == [applied.json()["orchestration"][-1]["flow_run_id"]]
+    run = projection.lookup_run(run_id).value
+    assert run is not None
+    assert [(link.purpose, link.attempt) for link in run.prefect_executions] == [
+        ("plan", 1),
+        ("verify", 1),
+        ("apply", 1),
+    ]
+    outcomes = {event.outcome for event in projection.audit_events(run_id)}
+    assert {"refused-authorization", "refused-confirmation", "refused-checksum", "accepted"} <= outcomes
+    assert "refused-terminal" in outcomes
+    assert set(run.audit_links) == {event.event_id for event in projection.audit_events(run_id)}
+
+
+@pytest.mark.parametrize(
+    ("actor", "token", "expected_status"),
+    [
+        ("owner", OWNER_TOKEN, 202),
+        ("admin", ADMIN_TOKEN, 202),
+        ("other", OTHER_TOKEN, 403),
+    ],
+)
+@pytest.mark.parametrize("operation", ["verify", "apply", "cancel"])
+def test_owner_and_administrator_mutation_matrix(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+    actor: str,
+    token: str,
+    expected_status: int,
+    operation: str,
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": f"{actor}-{operation}"}
+    bodies = {
+        "verify": {"reason": f"{actor} verification"},
+        "apply": {
+            "expected_checksum": plan.checksum,
+            "reason": f"{actor} apply",
+            "confirm_writes": True,
+        },
+        "cancel": {"reason": f"{actor} cancellation"},
+    }
+
+    response = client.post(f"/runs/{run_id}/{operation}", headers=headers, json=bodies[operation])
+
+    assert response.status_code == expected_status
+    events = projection.audit_events(run_id)
+    allowed = expected_status == 202
+    expected_outcome = "accepted" if allowed else "refused-authorization"
+    assert any(
+        event.actor == actor and event.operation == operation and event.outcome == expected_outcome for event in events
+    )
+    if allowed and operation in {"verify", "apply"}:
+        assert len(orchestration.submissions) == 2
+        assert orchestration.submissions[-1][0]["stage"] == operation
+    elif allowed:
+        assert len(orchestration.cancelled) == 1
+    else:
+        assert len(orchestration.submissions) == 1
+        assert not orchestration.cancelled
+
+
+def test_stable_not_found_expired_unavailable_and_unhandled_errors(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, projection, orchestration = managed
+    headers = {"Authorization": f"Bearer {OWNER_TOKEN}"}
+    missing = client.get("/runs/missing", headers=headers)
+
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    _publish_plan(projection, run_id)
+    projection.publish_artifact(
+        run_id,
+        artifact_id="unavailable",
+        kind="result-report",
+        media_type="text/plain",
+        data=b"result",
+    )
+    run = projection.lookup_run(run_id).value
+    assert run is not None
+    unavailable = next(item for item in run.artifact_refs if item.artifact_id == "unavailable")
+    (tmp_path / "artifacts" / unavailable.object_key).unlink()
+    unavailable_response = client.get(f"/runs/{run_id}/artifacts/unavailable", headers=headers)
+
+    expired_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    with sqlite3.connect(tmp_path / "product-records.sqlite3") as connection:
+        connection.execute(
+            "UPDATE artifact_refs SET expires_at = ? WHERE run_id = ? AND artifact_id = ?",
+            (expired_at.isoformat(), run_id, PLAN_ARTIFACT_ID),
+        )
+    expired = client.get(f"/runs/{run_id}/plan", headers=headers)
+
+    async def broken_observation(_flow_run_id: str) -> Observation:  # noqa: RUF029
+        msg = "internal-token-canary"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(orchestration, "observe", broken_observation)
+    with TestClient(client.app, raise_server_exceptions=False) as error_client:
+        unhandled = error_client.get(f"/runs/{run_id}", headers=headers)
+
+    assert missing.status_code == 404
+    assert unavailable_response.status_code == 503
+    assert expired.status_code == 410
+    assert unhandled.status_code == 503
+    for response in (missing, unavailable_response, expired, unhandled):
+        assert set(response.json()) == {"error"}
+        assert "token-canary" not in response.text
+
+
+def test_confirmation_schema_errors_and_openapi_contract(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, _projection, orchestration = managed
+    headers = {"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": "sync-key"}
+    unconfirmed = client.post(
+        "/runs",
+        headers=headers,
+        json={
+            "sync_name": "inventory",
+            "operation": "sync",
+            "configuration_reference": "sha256:configuration",
+            "reason": "run now",
+        },
+    )
+    missing_key = client.post(
+        "/runs",
+        headers={"Authorization": f"Bearer {OWNER_TOKEN}"},
+        json={
+            "sync_name": "inventory",
+            "configuration_reference": "sha256:configuration",
+            "reason": "plan now",
+        },
+    )
+    invalid = client.post("/runs", headers=headers, json={"sync_name": "inventory"})
+    invalid_operation = client.post(
+        "/runs",
+        headers=headers,
+        json={
+            "sync_name": "inventory",
+            "operation": "delete",
+            "configuration_reference": "sha256:configuration",
+            "reason": "unsupported operation",
+        },
+    )
+
+    assert unconfirmed.status_code == 409
+    assert missing_key.status_code == 422
+    assert invalid.status_code == 422
+    assert invalid_operation.status_code == 422
+    assert all(set(response.json()) == {"error"} for response in (unconfirmed, missing_key, invalid, invalid_operation))
+    assert not orchestration.submissions
+
+    paths = client.get("/openapi.json").json()["paths"]
+    assert set(paths) == {
+        "/runs",
+        "/runs/{run_id}",
+        "/runs/{run_id}/plan",
+        "/runs/{run_id}/results",
+        "/runs/{run_id}/artifacts",
+        "/runs/{run_id}/artifacts/{artifact_id}",
+        "/runs/{run_id}/verify",
+        "/runs/{run_id}/apply",
+        "/runs/{run_id}/cancel",
+    }
+    for route in paths.values():
+        for operation in route.values():
+            assert "401" in operation["responses"]
+            assert "422" in operation["responses"]

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from threading import Barrier
 from uuid import NAMESPACE_URL, uuid5
 
 import pytest
@@ -34,6 +36,7 @@ class _FakeOrchestration:
         self.by_key: dict[str, Submission] = {}
         self.observations: dict[str, Observation] = {}
         self.fail_after_accept_once = False
+        self.cancel_failure = False
         self.cancelled: list[str] = []
 
     async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:
@@ -58,6 +61,8 @@ class _FakeOrchestration:
 
     async def cancel(self, flow_run_id: str) -> Observation:
         self.cancelled.append(flow_run_id)
+        if self.cancel_failure:
+            return Observation(available=False, state="running", reason="prefect-cancellation-unavailable")
         observed = Observation(available=True, state="cancelling")
         self.observations[flow_run_id] = observed
         return observed
@@ -253,6 +258,25 @@ def test_retained_routes_survive_missing_prefect_detail(
     assert artifact.headers["digest"].startswith("sha-256=")
 
 
+def test_cancellation_transport_failure_remains_a_typed_mutation_error(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, _projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    orchestration.cancel_failure = True
+
+    response = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-transport-failure"},
+        json={"reason": "stop after transport failure"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "orchestration-unavailable"
+    assert response.json()["error"]["mutation_id"].startswith("m-")
+
+
 def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - one end-to-end matrix.
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:
@@ -331,6 +355,97 @@ def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - o
     assert set(run.audit_links) == {event.event_id for event in projection.audit_events(run_id)}
 
 
+def test_concurrent_and_post_completion_distinct_apply_keys_are_refused(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    ready = Barrier(2)
+
+    def apply(position: int):
+        ready.wait()
+        return client.post(
+            f"/runs/{run_id}/apply",
+            headers={**AUTH, "Idempotency-Key": f"concurrent-apply-{position}"},
+            json={
+                "expected_checksum": plan.checksum,
+                "confirm_writes": True,
+                "reason": f"concurrent approval {position}",
+            },
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(apply, range(2)))
+
+    accepted = next(response for response in responses if response.status_code == 202)
+    refused = next(response for response in responses if response.status_code == 409)
+    accepted_position = next(position for position, response in enumerate(responses) if response.status_code == 202)
+    assert refused.json()["error"]["code"] == "apply-already-admitted"
+    assert len(orchestration.submissions) == 2
+
+    projection.finish_run(
+        run_id,
+        phase="applied",
+        outcome="applied",
+        summary={"sync_name": "inventory", "create": 1, "update": 0, "delete": 0},
+        results={"outcome": "applied"},
+    )
+    replay = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": f"concurrent-apply-{accepted_position}"},
+        json={
+            "expected_checksum": plan.checksum,
+            "confirm_writes": True,
+            "reason": f"concurrent approval {accepted_position}",
+        },
+    )
+    post_completion = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "post-completion-apply"},
+        json={"expected_checksum": plan.checksum, "confirm_writes": True, "reason": "apply again"},
+    )
+
+    assert replay.status_code == 202
+    assert replay.json() == accepted.json()
+    assert post_completion.status_code == 409
+    assert post_completion.json()["error"]["code"] == "apply-already-admitted"
+    assert len(orchestration.submissions) == 2
+    refusals = [event for event in projection.audit_events(run_id) if event.outcome == "refused-apply-admission"]
+    assert len(refusals) == 2
+
+
+def test_confirmed_sync_reserves_its_write_admission_and_replays(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    body = {
+        "sync_name": "inventory",
+        "operation": "sync",
+        "configuration_reference": "sha256:configuration",
+        "confirm_writes": True,
+        "reason": "approved composed sync",
+    }
+    headers = {"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": "confirmed-sync"}
+
+    accepted = client.post("/runs", headers=headers, json=body)
+    replay = client.post("/runs", headers=headers, json=body)
+    run_id = accepted.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    later_apply = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-after-sync"},
+        json={"expected_checksum": plan.checksum, "confirm_writes": True, "reason": "duplicate write"},
+    )
+
+    assert accepted.status_code == 202
+    assert replay.json() == accepted.json()
+    assert later_apply.status_code == 409
+    assert later_apply.json()["error"]["code"] == "apply-already-admitted"
+    assert [parameters["stage"] for parameters, _ in orchestration.submissions] == ["sync"]
+
+
 @pytest.mark.parametrize(
     ("actor", "token", "expected_status"),
     [
@@ -381,7 +496,7 @@ def test_owner_and_administrator_mutation_matrix(
         assert not orchestration.cancelled
 
 
-def test_stable_not_found_expired_unavailable_and_unhandled_errors(
+def test_stable_not_found_expired_unavailable_and_degraded_prefect_reads(
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -414,19 +529,19 @@ def test_stable_not_found_expired_unavailable_and_unhandled_errors(
         )
     expired = client.get(f"/runs/{run_id}/plan", headers=headers)
 
-    async def broken_observation(_flow_run_id: str) -> Observation:  # noqa: RUF029
-        msg = "internal-token-canary"
-        raise RuntimeError(msg)
+    async def unavailable_observation(_flow_run_id: str) -> Observation:  # noqa: RUF029
+        return Observation(available=False, state=None, reason="prefect-read-unavailable")
 
-    monkeypatch.setattr(orchestration, "observe", broken_observation)
-    with TestClient(client.app, raise_server_exceptions=False) as error_client:
-        unhandled = error_client.get(f"/runs/{run_id}", headers=headers)
+    monkeypatch.setattr(orchestration, "observe", unavailable_observation)
+    degraded = client.get(f"/runs/{run_id}", headers=headers)
 
     assert missing.status_code == 404
     assert unavailable_response.status_code == 503
     assert expired.status_code == 410
-    assert unhandled.status_code == 503
-    for response in (missing, unavailable_response, expired, unhandled):
+    assert degraded.status_code == 200
+    assert degraded.json()["orchestration"][0]["detail_available"] is False
+    assert degraded.json()["orchestration"][0]["unavailable_reason"] == "prefect-read-unavailable"
+    for response in (missing, unavailable_response, expired):
         assert set(response.json()) == {"error"}
         assert "token-canary" not in response.text
 

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -373,6 +373,34 @@ def test_cancel_scans_past_newer_non_active_links(
     assert orchestration.cancelled == [apply_flow_run_id]
 
 
+def test_cancel_treats_expired_and_terminal_links_as_non_cancellable(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    client, projection, orchestration = managed
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    applied = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "apply-before-expiry"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    )
+    plan_flow_run_id = created.json()["orchestration"][-1]["flow_run_id"]
+    apply_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
+    orchestration.observations.pop(plan_flow_run_id)
+    orchestration.observations[apply_flow_run_id] = Observation(available=True, state="completed")
+
+    cancelled = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-expired-and-terminal"},
+        json={"reason": "stop if still active"},
+    )
+
+    assert cancelled.status_code == 409
+    assert cancelled.json()["error"]["code"] == "execution-terminal"
+    assert orchestration.cancelled == []
+
+
 def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - one end-to-end matrix.
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -28,6 +28,7 @@ from infrahub_sync.product_store import (
     ProductProjection,
     ProductRun,
     RunNotFoundError,
+    WriteAdmissionConflictError,
     local_product_projection,
 )
 from infrahub_sync.product_store import store as product_store_store
@@ -48,6 +49,7 @@ EXPECTED_PUBLIC_NAMES = {
     "ProductRun",
     "RunNotFoundError",
     "S3Client",
+    "WriteAdmissionConflictError",
     "local_product_projection",
     "production_product_projection",
 }
@@ -288,20 +290,23 @@ def _artifact_reference(
     )
 
 
-def _receipt(
+def _receipt(  # noqa: PLR0913 - receipt factory exposes contract dimensions.
     receipt_id: str = "mutation-001",
     *,
     run_id: str = "run-001",
     reason: str = "operator requested a plan",
+    client_key: str = "client-key",
+    operation: str = "plan",
+    target_run_id: str | None = None,
 ) -> MutationReceipt:
     now = datetime(2026, 8, 10, 12, tzinfo=timezone.utc)
     return MutationReceipt(
         receipt_id=receipt_id,
         actor="operator@example.com",
-        key_digest=sha256(b"client-key").hexdigest(),
-        operation="plan",
-        target_run_id=None,
-        request_fingerprint=sha256(b"canonical-request").hexdigest(),
+        key_digest=sha256(client_key.encode()).hexdigest(),
+        operation=operation,
+        target_run_id=target_run_id,
+        request_fingerprint=sha256(f"canonical-request:{operation}:{target_run_id}".encode()).hexdigest(),
         reason=reason,
         run_id=run_id,
         prefect_key=sha256(receipt_id.encode()).hexdigest(),
@@ -448,6 +453,52 @@ def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(
     winning_run_ids = {receipt.run_id for receipt, _ in results}
     assert len(winning_run_ids) == 1
     assert projection.lookup_run(winning_run_ids.pop()).available
+
+
+def test_write_capable_mutation_admission_is_atomic_on_both_profiles(provider: ProductProjection) -> None:
+    provider.create_run(_run())
+
+    def reserve(position: int) -> str:
+        receipt = _receipt(
+            f"apply-{position}",
+            client_key=f"apply-key-{position}",
+            operation="apply",
+            target_run_id="run-001",
+        )
+        try:
+            provider.reserve_mutation(receipt, admit_write=True)
+        except WriteAdmissionConflictError:
+            return "refused"
+        return "admitted"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(reserve, range(2)))
+
+    assert sorted(outcomes) == ["admitted", "refused"]
+    receipts = [
+        provider.lookup_mutation("operator@example.com", sha256(f"apply-key-{position}".encode()).hexdigest())
+        for position in range(2)
+    ]
+    assert sum(receipt.available for receipt in receipts) == 1
+
+
+def test_write_admission_exact_receipt_replay_precedes_the_run_conflict(provider: ProductProjection) -> None:
+    provider.create_run(_run())
+    receipt = _receipt(
+        "apply-001",
+        client_key="apply-key",
+        operation="apply",
+        target_run_id="run-001",
+    )
+
+    admitted, created = provider.reserve_mutation(receipt, admit_write=True)
+    replayed, replay_created = provider.reserve_mutation(
+        receipt.model_copy(update={"receipt_id": "apply-002"}), admit_write=True
+    )
+
+    assert created is True
+    assert replay_created is False
+    assert replayed == admitted
 
 
 def test_receipt_completion_and_audit_are_durable_and_secret_safe(provider: ProductProjection) -> None:
@@ -601,6 +652,25 @@ def test_prefect_position_conflict_retries_without_misreporting_a_duplicate(tmp_
     loaded = projection.lookup_run("run-001").value
     assert loaded is not None
     assert [link.flow_run_id for link in loaded.prefect_executions] == ["flow-001"]
+
+
+def test_managed_prefect_attempt_ordinals_are_allocated_atomically(provider: ProductProjection) -> None:
+    provider.create_run(_run())
+
+    def append(position: int) -> PrefectExecutionLink:
+        return provider.add_prefect_execution(
+            "run-001",
+            PrefectExecutionLink(flow_run_id=f"flow-{position}", purpose="verify", attempt=1),
+            allocate_attempt=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        allocated = list(pool.map(append, range(2)))
+
+    assert sorted(link.attempt for link in allocated) == [1, 2]
+    run = provider.lookup_run("run-001").value
+    assert run is not None
+    assert sorted(link.attempt for link in run.prefect_executions if link.purpose == "verify") == [1, 2]
 
 
 def test_mutator_existence_checks_do_not_hydrate_the_run(tmp_path: Path) -> None:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -4,6 +4,7 @@ import sqlite3
 import subprocess  # noqa: S404 - fixed local interpreter probes restart durability.
 import sys
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
@@ -18,9 +19,11 @@ from infrahub_sync import product_store
 from infrahub_sync.product_store import (
     ArtifactReference,
     ArtifactUnavailableError,
+    AuditEvent,
     DuplicateArtifactError,
     DuplicatePrefectExecutionError,
     DuplicateRunError,
+    MutationReceipt,
     PrefectExecutionLink,
     ProductProjection,
     ProductRun,
@@ -33,11 +36,13 @@ from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunSt
 EXPECTED_PUBLIC_NAMES = {
     "ArtifactReference",
     "ArtifactUnavailableError",
+    "AuditEvent",
     "DBAPIConnection",
     "DuplicateArtifactError",
     "DuplicatePrefectExecutionError",
     "DuplicateRunError",
     "LookupResult",
+    "MutationReceipt",
     "PrefectExecutionLink",
     "ProductProjection",
     "ProductRun",
@@ -283,6 +288,28 @@ def _artifact_reference(
     )
 
 
+def _receipt(
+    receipt_id: str = "mutation-001",
+    *,
+    run_id: str = "run-001",
+    reason: str = "operator requested a plan",
+) -> MutationReceipt:
+    now = datetime(2026, 8, 10, 12, tzinfo=timezone.utc)
+    return MutationReceipt(
+        receipt_id=receipt_id,
+        actor="operator@example.com",
+        key_digest=sha256(b"client-key").hexdigest(),
+        operation="plan",
+        target_run_id=None,
+        request_fingerprint=sha256(b"canonical-request").hexdigest(),
+        reason=reason,
+        run_id=run_id,
+        prefect_key=sha256(receipt_id.encode()).hexdigest(),
+        created_at=now,
+        updated_at=now,
+    )
+
+
 def test_public_surface_is_exactly_the_supported_contract() -> None:
     assert set(product_store.__all__) == EXPECTED_PUBLIC_NAMES
 
@@ -389,6 +416,108 @@ def test_zero_link_standalone_round_trip(provider: ProductProjection) -> None:
     assert result.value == expected
     assert result.value is not None
     assert result.value.prefect_executions == ()
+
+
+def test_mutation_reservation_atomically_creates_one_run_and_replays_on_both_profiles(
+    provider: ProductProjection,
+) -> None:
+    receipt = _receipt()
+
+    first, created = provider.reserve_mutation(receipt, run=_run())
+    replay_request = _receipt("mutation-002", run_id="run-never-created")
+    replay, replay_created = provider.reserve_mutation(replay_request, run=_run("run-never-created"))
+
+    assert created is True
+    assert replay_created is False
+    assert replay == first
+    assert provider.lookup_run("run-001").value == _run()
+    assert provider.lookup_run("run-never-created").reason == "run-not-found"
+
+
+def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(tmp_path: Path) -> None:
+    projection = local_product_projection(tmp_path.resolve())
+
+    def reserve(position: int) -> tuple[MutationReceipt, bool]:
+        receipt = _receipt(f"mutation-{position:03d}", run_id=f"run-{position:03d}")
+        return projection.reserve_mutation(receipt, run=_run(f"run-{position:03d}"))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(reserve, range(8)))
+
+    assert sum(created for _, created in results) == 1
+    winning_run_ids = {receipt.run_id for receipt, _ in results}
+    assert len(winning_run_ids) == 1
+    assert projection.lookup_run(winning_run_ids.pop()).available
+
+
+def test_receipt_completion_and_audit_are_durable_and_secret_safe(provider: ProductProjection) -> None:
+    token = "token-canary-value"  # noqa: S105 - deliberate non-secret boundary canary.
+    receipt = _receipt(reason=f"requested with {token}")
+    reserved, created = provider.reserve_mutation(receipt, run=_run(), secrets=(token,))
+    assert created
+    assert reserved.reason == "requested with ***"
+
+    completed = provider.complete_mutation(
+        reserved.receipt_id,
+        response_status=202,
+        response_body={"run_id": "run-001", "detail": token},
+        flow_run_id="flow-001",
+        secrets=(token,),
+    )
+    replayed_completion = provider.complete_mutation(
+        reserved.receipt_id,
+        response_status=202,
+        response_body={"run_id": "run-001", "detail": token},
+        flow_run_id="flow-001",
+        secrets=(token,),
+    )
+    converged_completion = provider.complete_mutation(
+        reserved.receipt_id,
+        response_status=202,
+        response_body={"run_id": "racing-response"},
+        flow_run_id="flow-001",
+    )
+    provider.record_audit(
+        AuditEvent(
+            event_id="audit-001",
+            run_id="run-001",
+            actor="operator@example.com",
+            operation="plan",
+            reason=token,
+            outcome="accepted",
+            created_at=datetime.now(timezone.utc),
+        ),
+        secrets=(token,),
+    )
+
+    assert completed.state == "accepted"
+    assert replayed_completion == completed
+    assert converged_completion == completed
+    assert completed.response_body == {"detail": "***", "run_id": "run-001"}
+    assert provider.audit_events("run-001")[0].reason == "***"
+    audited_run = provider.lookup_run("run-001").value
+    assert audited_run is not None
+    assert audited_run.audit_links == ("ticket:change-42", "audit-001")
+
+    with pytest.raises(ValueError, match="different response"):
+        provider.complete_mutation(
+            reserved.receipt_id,
+            response_status=202,
+            response_body={"run_id": "different"},
+            flow_run_id="flow-002",
+        )
+
+
+def test_record_results_does_not_change_product_lifecycle(provider: ProductProjection) -> None:
+    original = _run().model_copy(update={"phase": "planned", "summary": {"total": 1}})
+    provider.create_run(original)
+
+    provider.record_results("run-001", {"verification": {"outcome": "verified"}})
+
+    updated = provider.lookup_run("run-001").value
+    assert updated is not None
+    assert updated.model_dump(exclude={"results"}) == original.model_dump(exclude={"results"})
+    assert updated.results == {"verification": {"outcome": "verified"}}
 
 
 def test_sqlite_foreign_key_failure_passes_through_as_integrity_error(tmp_path: Path) -> None:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
+from threading import Barrier
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -1292,6 +1293,25 @@ def test_redaction_precedes_every_relational_and_artifact_write(provider: Produc
     assert artifact is not None
     assert secret.encode() not in artifact
     assert b"***" in artifact
+
+
+def test_concurrent_result_merges_retain_every_stage_on_both_profiles(provider: ProductProjection) -> None:
+    provider.create_run(_run())
+    ready = Barrier(2)
+
+    def merge(stage: str) -> None:
+        ready.wait()
+        provider.merge_results("run-001", {stage: {"outcome": stage}})
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(merge, ("verification", "apply_failure")))
+
+    loaded = provider.lookup_run("run-001").value
+    assert loaded is not None
+    assert loaded.results == {
+        "apply_failure": {"outcome": "apply_failure"},
+        "verification": {"outcome": "verification"},
+    }
 
 
 @pytest.mark.parametrize("mutation", ["create", "finish"])

--- a/tests/test_no_prefect_import.py
+++ b/tests/test_no_prefect_import.py
@@ -1,4 +1,4 @@
-"""The base package must never import Prefect (DBA-001, SC-006, DBR-010).
+"""The base package must never import optional Prefect profiles (DBA-001, SC-006, DBR-010).
 
 The `sys.modules` half runs in a FRESH interpreter on purpose: this suite is
 collected with the `prefect` extra installed, and collecting
@@ -19,19 +19,23 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_ROOT = REPO_ROOT / "infrahub_sync"
 EXAMPLES_DIR = REPO_ROOT / "examples"
+OPTIONAL_PACKAGE_NAMES = frozenset({"managed", "orchestration"})
+OPTIONAL_PACKAGE_PREFIXES = tuple(f"infrahub_sync.{name}" for name in sorted(OPTIONAL_PACKAGE_NAMES))
+OPTIONAL_DISTRIBUTION_NAMES = frozenset({"fastapi", "opsmill_prefect_extras", "prefect", "uvicorn"})
 
 PROBE_SCRIPT = f"""
 import sys
 
 
-class BlockPrefectImport:
+class BlockOptionalImport:
     def find_spec(self, fullname, path=None, target=None):
-        if fullname == "prefect" or fullname.startswith("prefect."):
-            raise ModuleNotFoundError("Prefect is deliberately unavailable in this base-package probe")
+        root = fullname.partition(".")[0]
+        if root in {sorted(OPTIONAL_DISTRIBUTION_NAMES)!r}:
+            raise ModuleNotFoundError(f"{{root}} is deliberately unavailable in this base-package probe")
         return None
 
 
-sys.meta_path.insert(0, BlockPrefectImport())
+sys.meta_path.insert(0, BlockOptionalImport())
 
 import infrahub_sync
 import infrahub_sync.api.v1
@@ -47,18 +51,19 @@ list_result = runner.invoke(
 )
 assert list_result.exit_code == 0, list_result.output
 
-leaked = sorted(m for m in sys.modules if m == "prefect" or m.startswith("prefect."))
-assert not leaked, f"prefect modules imported by the base package: {{leaked}}"
-print("NO-PREFECT-IMPORT-OK")
+optional_roots = {sorted(OPTIONAL_DISTRIBUTION_NAMES)!r}
+leaked = sorted(m for m in sys.modules if m.partition(".")[0] in optional_roots)
+assert not leaked, f"optional managed modules imported by the base package: {{leaked}}"
+print("NO-OPTIONAL-MANAGED-IMPORT-OK")
 """
 
 
 def _module_paths() -> list[Path]:
-    """Every base-package module — the whole package except `orchestration/`."""
+    """Every base-package module, excluding optional runtime profiles."""
     return [
         path
         for path in sorted(PACKAGE_ROOT.rglob("*.py"))
-        if "orchestration" not in path.relative_to(PACKAGE_ROOT).parts
+        if not OPTIONAL_PACKAGE_NAMES.intersection(path.relative_to(PACKAGE_ROOT).parts)
     ]
 
 
@@ -95,8 +100,8 @@ def _imported_names(path: Path, *, root: Path = REPO_ROOT) -> set[str]:
     return names
 
 
-def test_base_package_imports_and_runs_without_prefect_in_a_fresh_interpreter() -> None:
-    """Importing the package and running CLI sanity must not pull in Prefect."""
+def test_base_package_imports_and_runs_without_managed_dependencies_in_a_fresh_interpreter() -> None:
+    """Base imports and CLI sanity must not pull in managed dependencies."""
     completed = subprocess.run(  # noqa: S603 - fixed argv, this interpreter, no shell
         [sys.executable, "-c", PROBE_SCRIPT],
         capture_output=True,
@@ -105,24 +110,23 @@ def test_base_package_imports_and_runs_without_prefect_in_a_fresh_interpreter() 
         cwd=str(REPO_ROOT),
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert "NO-PREFECT-IMPORT-OK" in completed.stdout
+    assert "NO-OPTIONAL-MANAGED-IMPORT-OK" in completed.stdout
 
 
-def test_execution_surface_imports_no_prefect_and_no_orchestration() -> None:
-    """The shared surface is import-light: no Prefect, no orchestration package."""
+def test_execution_surface_imports_no_optional_managed_runtime() -> None:
+    """The shared surface imports no optional runtime distribution or package."""
     imported = _imported_names(PACKAGE_ROOT / "execution.py")
-    assert not [name for name in imported if name == "prefect" or name.startswith("prefect.")]
-    assert not [name for name in imported if name.startswith("infrahub_sync.orchestration")]
+    assert not [name for name in imported if name.partition(".")[0] in OPTIONAL_DISTRIBUTION_NAMES]
+    assert not [name for name in imported if name.startswith(OPTIONAL_PACKAGE_PREFIXES)]
 
 
-def test_no_base_package_module_imports_the_orchestration_package() -> None:
-    """Nothing outside `orchestration/` may reach into it — that is what keeps the
-    base install Prefect-free even though the extra ships in the same package."""
+def test_no_base_package_module_imports_an_optional_runtime_package() -> None:
+    """Base modules must not reach into optional runtime profiles."""
     offenders = {
         str(path.relative_to(REPO_ROOT)): sorted(
             name
             for name in _imported_names(path)
-            if name == "prefect" or name.startswith(("prefect.", "infrahub_sync.orchestration"))
+            if name.partition(".")[0] in OPTIONAL_DISTRIBUTION_NAMES or name.startswith(OPTIONAL_PACKAGE_PREFIXES)
         )
         for path in _module_paths()
     }
@@ -136,9 +140,11 @@ def test_no_base_package_module_imports_the_orchestration_package() -> None:
         ("infrahub_sync/probe.py", "from . import orchestration\n"),
         ("infrahub_sync/adapters/probe.py", "from ..orchestration import flow\n"),
         ("infrahub_sync/adapters/__init__.py", "from ..orchestration import flow\n"),
+        ("infrahub_sync/probe.py", "from .managed import app\n"),
+        ("infrahub_sync/adapters/probe.py", "from ..managed import app\n"),
     ],
 )
-def test_the_scan_resolves_relative_imports_of_the_orchestration_package(
+def test_the_scan_resolves_relative_imports_of_optional_runtime_packages(
     tmp_path: Path, module_path: str, source: str
 ) -> None:
     """The boundary is only enforced if the scan sees the in-package import forms.
@@ -153,4 +159,4 @@ def test_the_scan_resolves_relative_imports_of_the_orchestration_package(
 
     names = _imported_names(probe, root=tmp_path)
 
-    assert [name for name in names if name.startswith("infrahub_sync.orchestration")]
+    assert [name for name in names if name.startswith(OPTIONAL_PACKAGE_PREFIXES)]

--- a/uv.lock
+++ b/uv.lock
@@ -1101,6 +1101,12 @@ dev = [
     { name = "types-ujson" },
     { name = "yamllint" },
 ]
+managed = [
+    { name = "fastapi", marker = "python_full_version >= '3.11'" },
+    { name = "opsmill-prefect-extras", marker = "python_full_version >= '3.11'" },
+    { name = "prefect", marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
+]
 prefect = [
     { name = "prefect" },
 ]
@@ -1108,13 +1114,16 @@ prefect = [
 [package.metadata]
 requires-dist = [
     { name = "diffsync", specifier = ">=2.1,<3.0" },
+    { name = "fastapi", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = ">=0.115,<1" },
     { name = "filelock", specifier = ">=3.13" },
     { name = "fsspec", specifier = ">=2024.6" },
     { name = "infrahub-sdk", extras = ["all"], specifier = ">=1.17,<2" },
     { name = "invoke", marker = "extra == 'dev'", specifier = ">=2.2.1,<3" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "netutils", specifier = ">=1.9,<2.0" },
+    { name = "opsmill-prefect-extras", marker = "python_full_version >= '3.11' and extra == 'managed'", git = "https://github.com/opsmill/prefect-extras.git?rev=84688eb8d8db7e17770413640a66481ccdc3e725" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0,<5.0" },
+    { name = "prefect", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = "==3.8.1" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = "==3.8.1" },
     { name = "pyarrow", specifier = ">=17,<22" },
     { name = "pylint", marker = "extra == 'dev'" },
@@ -1135,9 +1144,10 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "types-toml", marker = "extra == 'dev'" },
     { name = "types-ujson", marker = "extra == 'dev'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = ">=0.34,<1" },
     { name = "yamllint", marker = "extra == 'dev'", specifier = ">=1.37.1" },
 ]
-provides-extras = ["prefect", "dev"]
+provides-extras = ["prefect", "managed", "dev"]
 
 [[package]]
 name = "iniconfig"
@@ -1639,6 +1649,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opsmill-prefect-extras"
+version = "0.1.0"
+source = { git = "https://github.com/opsmill/prefect-extras.git?rev=84688eb8d8db7e17770413640a66481ccdc3e725#84688eb8d8db7e17770413640a66481ccdc3e725" }
+dependencies = [
+    { name = "prefect", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1103,6 +1103,7 @@ dev = [
 ]
 managed = [
     { name = "fastapi", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
     { name = "opsmill-prefect-extras", marker = "python_full_version >= '3.11'" },
     { name = "prefect", marker = "python_full_version >= '3.11'" },
     { name = "uvicorn", marker = "python_full_version >= '3.11'" },
@@ -1117,6 +1118,7 @@ requires-dist = [
     { name = "fastapi", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = ">=0.115,<1" },
     { name = "filelock", specifier = ">=3.13" },
     { name = "fsspec", specifier = ">=2024.6" },
+    { name = "httpx", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = ">=0.27,<1" },
     { name = "infrahub-sdk", extras = ["all"], specifier = ">=1.17,<2" },
     { name = "invoke", marker = "extra == 'dev'", specifier = ">=2.2.1,<3" },
     { name = "ipython", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

This PR adds an optional, authenticated HTTP API for managed Infrahub Sync execution through Prefect.

It provides run creation and inspection, retained results and artifacts, plan verification, reviewed apply, confirmed sync, and cancellation. Sync owns durable run identity, audit records, idempotency receipts, write admission, and failure evidence; Prefect provides remote execution.

## Review guidance

Important areas:

- `infrahub_sync/managed/` — HTTP, authorization, orchestration, and worker flow
- `infrahub_sync/product_store/store.py` — receipts, write admission, execution links, and result merging
- `tests/managed/` — API, replay, cancellation, failure, and redaction behavior
- `tests/integration/test_managed_prefect_idempotency.py` — server-backed Prefect deduplication

Please focus on:

1. Exact-key replay and distinct-key write refusal.
2. Checksum-gated apply and permanent one-write admission per run.
3. Cancellation of the newest active execution.
4. Retained reads and typed errors during Prefect outages.
5. Secret redaction across HTTP, persistence, logs, and exceptions.
6. Base-package isolation from managed dependencies.

## Fast tests

```bash
uv sync --extra dev --extra prefect --extra managed
uv run pytest -q tests/managed tests/product_store/test_contract.py
uv run pytest -q -m integration tests/integration/test_managed_prefect_idempotency.py
```

## Validation

- Focused managed/product-store suite: 144 passed
- Full Python 3.13 suite: 1,292 passed, 2 skipped, 1 xfailed
- Python 3.10 Prefect suite: 1,259 passed, 5 skipped, 1 xfailed
- Clean base-install suite: 1,226 passed, 7 skipped, 1 xfailed
- Real Prefect idempotency and PostgreSQL concurrency proofs passed
- Formatting, Ruff, ty, YAML, docs, package build, and CLI help/list passed

## Scope limits

- The managed profile supports Python 3.11–3.13.
- A failed or cancelled write-capable execution still consumes the run’s write admission; another attempt requires a new plan run.
- The managed service is intended for a trusted network boundary.