### PR TITLE
fix: refuse lossy Infrahub upserts

### DIFF
--- a/changelog/+sync-36-convergence-identity.fixed.md
+++ b/changelog/+sync-36-convergence-identity.fixed.md
@@ -1,4 +1,4 @@
-Refuse Infrahub syncs before destination writes when the generated model
+Refuse Infrahub creates before destination writes when the generated model
 identity is finer than the human-friendly ID (or fallback default filter) used
 to match upserts, preventing distinct source objects from silently converging
 onto one object. Serial and parallel sync modes both report the refusal through

--- a/changelog/+sync-36-convergence-identity.fixed.md
+++ b/changelog/+sync-36-convergence-identity.fixed.md
@@ -1,3 +1,4 @@
-Refuse Infrahub syncs before destination writes when the schema mapping identity
-is finer than every key declared by the destination schema, preventing distinct
-source objects from silently converging onto one object.
+Refuse Infrahub syncs before destination writes when the generated model
+identity is finer than the human-friendly ID (or fallback default filter) used
+to match upserts, preventing distinct source objects from silently converging
+onto one object.

--- a/changelog/+sync-36-convergence-identity.fixed.md
+++ b/changelog/+sync-36-convergence-identity.fixed.md
@@ -1,4 +1,5 @@
 Refuse Infrahub syncs before destination writes when the generated model
 identity is finer than the human-friendly ID (or fallback default filter) used
 to match upserts, preventing distinct source objects from silently converging
-onto one object.
+onto one object. Serial and parallel sync modes both report the refusal through
+the normal CLI error path.

--- a/changelog/+sync-36-convergence-identity.fixed.md
+++ b/changelog/+sync-36-convergence-identity.fixed.md
@@ -1,0 +1,3 @@
+Refuse Infrahub syncs before destination writes when the schema mapping identity
+is finer than every key declared by the destination schema, preventing distinct
+source objects from silently converging onto one object.

--- a/docs/docs/reference/schema-mapping.mdx
+++ b/docs/docs/reference/schema-mapping.mdx
@@ -117,14 +117,18 @@ identifiers: ["address", "vrf"]
 
 All listed fields must be present and unique together. Each identifier field must also be mapped in the `fields` list.
 
-When Infrahub is the destination, at least one human-friendly ID or uniqueness
-constraint in the destination schema must cover every field in `identifiers`.
-For example, a mapping identified by `["name", "site"]` requires a destination
-key that includes both `name` and `site`. The `sync` command refuses the run
-before writing when every destination key is coarser, because otherwise two
-source objects could silently converge onto one destination object. Read-only
-comparison remains available so you can inspect the proposed changes before
-aligning the mapping or destination schema.
+When Infrahub is the destination, its human-friendly ID must cover every field
+in the generated model's identity. If the kind has no human-friendly ID, its
+default filter must provide that coverage instead. For example, a model
+identified by `["name", "site"]` requires a human-friendly ID containing both
+`name` and `site`. A uniqueness constraint alone is not sufficient because it
+does not change how Infrahub matches an upsert to an existing object.
+
+The `sync` command refuses the run before writing when the upsert key is
+coarser, because otherwise two source objects could silently converge onto one
+destination object. Read-only comparison remains available so you can inspect
+the proposed changes before aligning the generated model or destination
+schema.
 
 ## Filters
 

--- a/docs/docs/reference/schema-mapping.mdx
+++ b/docs/docs/reference/schema-mapping.mdx
@@ -117,6 +117,15 @@ identifiers: ["address", "vrf"]
 
 All listed fields must be present and unique together. Each identifier field must also be mapped in the `fields` list.
 
+When Infrahub is the destination, at least one human-friendly ID or uniqueness
+constraint in the destination schema must cover every field in `identifiers`.
+For example, a mapping identified by `["name", "site"]` requires a destination
+key that includes both `name` and `site`. The `sync` command refuses the run
+before writing when every destination key is coarser, because otherwise two
+source objects could silently converge onto one destination object. Read-only
+comparison remains available so you can inspect the proposed changes before
+aligning the mapping or destination schema.
+
 ## Filters
 
 Filters control which objects from the source get synced. Apply them at the model level to include or exclude specific objects.

--- a/docs/docs/reference/schema-mapping.mdx
+++ b/docs/docs/reference/schema-mapping.mdx
@@ -126,11 +126,12 @@ does not change how Infrahub matches an upsert to an existing object.
 Relationship identifiers must also be covered at the peer's full generated
 identity; matching only one component of a composite peer identity is unsafe.
 
-The `sync` command refuses the run before writing when the upsert key is
-coarser, because otherwise two source objects could silently converge onto one
-destination object. Read-only comparison remains available so you can inspect
-the proposed changes before aligning the generated model or destination
-schema.
+The `sync` command refuses creates for the affected kind before writing when
+the upsert key is coarser, because otherwise two source objects could silently
+converge onto one destination object. Updates remain safe because they address
+an existing Infrahub node by ID. Read-only comparison remains available so you
+can inspect the proposed changes before aligning the generated model or
+destination schema.
 
 ## Filters
 

--- a/docs/docs/reference/schema-mapping.mdx
+++ b/docs/docs/reference/schema-mapping.mdx
@@ -123,6 +123,8 @@ default filter must provide that coverage instead. For example, a model
 identified by `["name", "site"]` requires a human-friendly ID containing both
 `name` and `site`. A uniqueness constraint alone is not sufficient because it
 does not change how Infrahub matches an upsert to an existing object.
+Relationship identifiers must also be covered at the peer's full generated
+identity; matching only one component of a composite peer identity is unsafe.
 
 The `sync` command refuses the run before writing when the upsert key is
 coarser, because otherwise two source objects could silently converge onto one

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -438,7 +438,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
             for peer_identifier in peer_identifiers
         )
 
-    def _validate_convergence_identities(self, diff: Diff | None = None) -> None:
+    def validate_convergence_identities(self, diff: Diff | None = None) -> None:
         """Refuse writable model identities finer than Infrahub's upsert key."""
         writable_kinds = _writable_diff_kinds(diff) if diff is not None else None
         for mapping in self.config.schema_mapping:
@@ -485,7 +485,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         diff: Diff | None = None,
     ) -> Diff:
         """Validate convergence identities before entering DiffSync's write path."""
-        self._validate_convergence_identities(diff=diff)
+        self.validate_convergence_identities(diff=diff)
         return super().sync_from(
             source=source,
             diff_class=diff_class,

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -284,24 +284,19 @@ def _component_field(component: str) -> str:
     return component.split("__", 1)[0]
 
 
-def _destination_identity_keys(node_schema: object) -> list[frozenset[str]]:
-    """Return the destination keys that can distinguish convergent writes."""
-    constraints = getattr(node_schema, "uniqueness_constraints", None) or []
+def _destination_upsert_key(node_schema: object) -> frozenset[str]:
+    """Return the schema fields Infrahub actually uses to match an upsert."""
     human_friendly_id = getattr(node_schema, "human_friendly_id", None)
-    declared = [*constraints, *([human_friendly_id] if human_friendly_id else [])]
-    keys = {frozenset(_component_field(component) for component in key) for key in declared if key}
-    return sorted(keys, key=lambda key: tuple(sorted(key)))
+    if human_friendly_id:
+        return frozenset(_component_field(component) for component in human_friendly_id)
 
+    default_filter = getattr(node_schema, "default_filter", None)
+    if default_filter:
+        return frozenset({_component_field(default_filter)})
 
-def _closest_destination_key(
-    identifiers: frozenset[str],
-    destination_keys: list[frozenset[str]],
-) -> frozenset[str]:
-    """Choose the declared key that covers the largest part of an identity."""
-    return min(
-        destination_keys,
-        key=lambda key: (-len(identifiers & key), tuple(sorted(key))),
-    )
+    # Keyless upserts have a separate duplication hazard, but cannot collapse
+    # distinct source identities by matching them onto one destination object.
+    return frozenset()
 
 
 class InfrahubAdapter(DiffSyncMixin, Adapter):
@@ -375,27 +370,28 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         self.schema: MutableMapping[str, MainSchemaTypesAPI] = self.client.schema.all(branch=infrahub_branch)
 
     def _validate_convergence_identities(self) -> None:
-        """Refuse mappings whose identity is finer than every destination key."""
+        """Refuse runtime model identities finer than Infrahub's upsert key."""
         for mapping in self.config.schema_mapping:
-            identifiers = frozenset(mapping.identifiers or ())
+            model_class = getattr(self, mapping.name, None)
+            identifiers = frozenset(getattr(model_class, "_identifiers", None) or mapping.identifiers or ())
             node_schema = self.schema.get(mapping.name)
             if not identifiers or node_schema is None:
                 continue
 
-            destination_keys = _destination_identity_keys(node_schema)
-            if not destination_keys or any(identifiers <= key for key in destination_keys):
+            upsert_key = _destination_upsert_key(node_schema)
+            if not upsert_key or identifiers <= upsert_key:
                 continue
 
-            closest = _closest_destination_key(identifiers, destination_keys)
-            uncovered = ", ".join(sorted(identifiers - closest))
+            uncovered = ", ".join(sorted(identifiers - upsert_key))
             mapping_identity = ", ".join(sorted(identifiers))
-            destination_key = ", ".join(sorted(closest))
+            destination_key = ", ".join(sorted(upsert_key))
             msg = (
-                f"Refusing to sync destination kind {mapping.name}: mapping identity "
-                f"({mapping_identity}) is finer than every declared destination key; "
-                f"closest key: ({destination_key}); uncovered mapping identifier(s): {uncovered}. "
-                "Align the schema mapping identifiers with a destination human-friendly ID "
-                "or uniqueness constraint before retrying."
+                f"Refusing to sync destination kind {mapping.name}: generated model identity "
+                f"({mapping_identity}) is finer than its destination upsert key "
+                f"({destination_key}); uncovered mapping identifier(s): {uncovered}. "
+                "Align the generated model identity with the destination human-friendly ID "
+                "(or its default filter when no human-friendly ID exists) before retrying. "
+                "A uniqueness constraint alone does not change the upsert match key."
             )
             raise ConvergenceIdentityError(msg)
 

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -306,7 +306,7 @@ def _writable_diff_kinds(diff: Diff) -> frozenset[str]:
     pending = list(diff.get_children())
     while pending:
         element = pending.pop()
-        if element.action is DiffSyncActions.CREATE:
+        if element.action == DiffSyncActions.CREATE:
             writable.add(element.type)
         pending.extend(element.get_children())
     return frozenset(writable)

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -301,12 +301,12 @@ def _path_parts(path: str) -> tuple[str, ...]:
 
 
 def _writable_diff_kinds(diff: Diff) -> frozenset[str]:
-    """Return model kinds with create or update actions in a DiffSync diff."""
+    """Return model kinds with create actions that can enter the upsert path."""
     writable: set[str] = set()
     pending = list(diff.get_children())
     while pending:
         element = pending.pop()
-        if element.action in {DiffSyncActions.CREATE, DiffSyncActions.UPDATE}:
+        if element.action is DiffSyncActions.CREATE:
             writable.add(element.type)
         pending.extend(element.get_children())
     return frozenset(writable)

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -7,7 +7,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from diffsync import Adapter, Diff, DiffSyncModel
-from diffsync.enum import DiffSyncFlags
+from diffsync.enum import DiffSyncActions, DiffSyncFlags
 from infrahub_sdk import (
     Config,
     InfrahubClientSync,
@@ -279,24 +279,37 @@ class ConvergenceIdentityError(ValueError):
     """Raised before writes when no destination key covers a mapping identity."""
 
 
-def _component_field(component: str) -> str:
-    """Return the mapping field at the root of an Infrahub schema key path."""
-    return component.split("__", 1)[0]
-
-
-def _destination_upsert_key(node_schema: object) -> frozenset[str]:
-    """Return the schema fields Infrahub actually uses to match an upsert."""
+def _destination_upsert_paths(node_schema: object) -> tuple[str, ...]:
+    """Return the schema paths Infrahub actually uses to match an upsert."""
     human_friendly_id = getattr(node_schema, "human_friendly_id", None)
     if human_friendly_id:
-        return frozenset(_component_field(component) for component in human_friendly_id)
+        return tuple(human_friendly_id)
 
     default_filter = getattr(node_schema, "default_filter", None)
     if default_filter:
-        return frozenset({_component_field(default_filter)})
+        return (default_filter,)
 
-    # Keyless upserts have a separate duplication hazard, but cannot collapse
-    # distinct source identities by matching them onto one destination object.
-    return frozenset()
+    return ()
+
+
+def _path_parts(path: str) -> tuple[str, ...]:
+    """Split an Infrahub key path, excluding attribute-property suffixes."""
+    parts = tuple(path.split("__"))
+    if parts and parts[-1] in {"value", "id"}:
+        return parts[:-1]
+    return parts
+
+
+def _writable_diff_kinds(diff: Diff) -> frozenset[str]:
+    """Return model kinds with create or update actions in a DiffSync diff."""
+    writable: set[str] = set()
+    pending = list(diff.get_children())
+    while pending:
+        element = pending.pop()
+        if element.action in {DiffSyncActions.CREATE, DiffSyncActions.UPDATE}:
+            writable.add(element.type)
+        pending.extend(element.get_children())
+    return frozenset(writable)
 
 
 class InfrahubAdapter(DiffSyncMixin, Adapter):
@@ -369,22 +382,73 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         # We will keep a copy of the schema
         self.schema: MutableMapping[str, MainSchemaTypesAPI] = self.client.schema.all(branch=infrahub_branch)
 
-    def _validate_convergence_identities(self) -> None:
-        """Refuse runtime model identities finer than Infrahub's upsert key."""
+    def _identifier_is_covered(
+        self,
+        *,
+        kind: str,
+        identifier: str,
+        paths: tuple[tuple[str, ...], ...],
+        visited: frozenset[tuple[str, str]] = frozenset(),
+    ) -> bool:
+        """Return whether upsert paths distinguish a generated identifier value."""
+        matching_tails = tuple(path[1:] for path in paths if path and path[0] == identifier)
+        if not matching_tails:
+            return False
+
+        node_schema = self.schema.get(kind)
+        relationships = getattr(node_schema, "relationships", ())
+        relationship = next((item for item in relationships if item.name == identifier), None)
+        if relationship is None:
+            return True
+
+        peer_kind = relationship.peer
+        peer_model = getattr(self, peer_kind, None)
+        peer_identifiers = tuple(getattr(peer_model, "_identifiers", ()) or ())
+        if not peer_identifiers:
+            return False
+
+        marker = (kind, identifier)
+        if marker in visited:
+            return False
+        next_visited = visited | {marker}
+        return all(
+            self._identifier_is_covered(
+                kind=peer_kind,
+                identifier=peer_identifier,
+                paths=matching_tails,
+                visited=next_visited,
+            )
+            for peer_identifier in peer_identifiers
+        )
+
+    def _validate_convergence_identities(self, diff: Diff | None = None) -> None:
+        """Refuse writable model identities finer than Infrahub's upsert key."""
+        writable_kinds = _writable_diff_kinds(diff) if diff is not None else None
         for mapping in self.config.schema_mapping:
+            if writable_kinds is not None and mapping.name not in writable_kinds:
+                continue
+
             model_class = getattr(self, mapping.name, None)
             identifiers = frozenset(getattr(model_class, "_identifiers", None) or mapping.identifiers or ())
             node_schema = self.schema.get(mapping.name)
             if not identifiers or node_schema is None:
                 continue
 
-            upsert_key = _destination_upsert_key(node_schema)
-            if not upsert_key or identifiers <= upsert_key:
+            upsert_paths = _destination_upsert_paths(node_schema)
+            path_parts = tuple(_path_parts(path) for path in upsert_paths)
+            uncovered_identifiers = frozenset(
+                identifier
+                for identifier in identifiers
+                if not self._identifier_is_covered(kind=mapping.name, identifier=identifier, paths=path_parts)
+            )
+            if not uncovered_identifiers:
                 continue
 
-            uncovered = ", ".join(sorted(identifiers - upsert_key))
+            uncovered = ", ".join(sorted(uncovered_identifiers))
             mapping_identity = ", ".join(sorted(identifiers))
-            destination_key = ", ".join(sorted(upsert_key))
+            destination_key = ", ".join(sorted(path.replace("__value", "").replace("__", ".") for path in upsert_paths))
+            if not destination_key:
+                destination_key = "none"
             msg = (
                 f"Refusing to sync destination kind {mapping.name}: generated model identity "
                 f"({mapping_identity}) is finer than its destination upsert key "
@@ -404,7 +468,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         diff: Diff | None = None,
     ) -> Diff:
         """Validate convergence identities before entering DiffSync's write path."""
-        self._validate_convergence_identities()
+        self._validate_convergence_identities(diff=diff)
         return super().sync_from(
             source=source,
             diff_class=diff_class,

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -6,7 +6,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from diffsync import Adapter, DiffSyncModel
+from diffsync import Adapter, Diff, DiffSyncModel
+from diffsync.enum import DiffSyncFlags
 from infrahub_sdk import (
     Config,
     InfrahubClientSync,
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 _TIMESTAMP_FILTER_KW = "node_metadata__updated_at__after"
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping, MutableMapping
+    from collections.abc import Callable, Iterator, Mapping, MutableMapping
 
     from infrahub_sdk.node import InfrahubNodeSync, RelatedNodeSync, RelationshipManagerSync
     from infrahub_sdk.schema import MainSchemaTypesAPI
@@ -274,6 +275,35 @@ class PeerIdentifierError(ValueError):
         super().__init__(msg)
 
 
+class ConvergenceIdentityError(ValueError):
+    """Raised before writes when no destination key covers a mapping identity."""
+
+
+def _component_field(component: str) -> str:
+    """Return the mapping field at the root of an Infrahub schema key path."""
+    return component.split("__", 1)[0]
+
+
+def _destination_identity_keys(node_schema: object) -> list[frozenset[str]]:
+    """Return the destination keys that can distinguish convergent writes."""
+    constraints = getattr(node_schema, "uniqueness_constraints", None) or []
+    human_friendly_id = getattr(node_schema, "human_friendly_id", None)
+    declared = [*constraints, *([human_friendly_id] if human_friendly_id else [])]
+    keys = {frozenset(_component_field(component) for component in key) for key in declared if key}
+    return sorted(keys, key=lambda key: tuple(sorted(key)))
+
+
+def _closest_destination_key(
+    identifiers: frozenset[str],
+    destination_keys: list[frozenset[str]],
+) -> frozenset[str]:
+    """Choose the declared key that covers the largest part of an identity."""
+    return min(
+        destination_keys,
+        key=lambda key: (-len(identifiers & key), tuple(sorted(key))),
+    )
+
+
 class InfrahubAdapter(DiffSyncMixin, Adapter):
     type = "Infrahub"
 
@@ -343,6 +373,49 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
 
         # We will keep a copy of the schema
         self.schema: MutableMapping[str, MainSchemaTypesAPI] = self.client.schema.all(branch=infrahub_branch)
+
+    def _validate_convergence_identities(self) -> None:
+        """Refuse mappings whose identity is finer than every destination key."""
+        for mapping in self.config.schema_mapping:
+            identifiers = frozenset(mapping.identifiers or ())
+            node_schema = self.schema.get(mapping.name)
+            if not identifiers or node_schema is None:
+                continue
+
+            destination_keys = _destination_identity_keys(node_schema)
+            if not destination_keys or any(identifiers <= key for key in destination_keys):
+                continue
+
+            closest = _closest_destination_key(identifiers, destination_keys)
+            uncovered = ", ".join(sorted(identifiers - closest))
+            mapping_identity = ", ".join(sorted(identifiers))
+            destination_key = ", ".join(sorted(closest))
+            msg = (
+                f"Refusing to sync destination kind {mapping.name}: mapping identity "
+                f"({mapping_identity}) is finer than every declared destination key; "
+                f"closest key: ({destination_key}); uncovered mapping identifier(s): {uncovered}. "
+                "Align the schema mapping identifiers with a destination human-friendly ID "
+                "or uniqueness constraint before retrying."
+            )
+            raise ConvergenceIdentityError(msg)
+
+    def sync_from(  # pylint: disable=too-many-positional-arguments
+        self,
+        source: Adapter,
+        diff_class: type[Diff] = Diff,
+        flags: DiffSyncFlags = DiffSyncFlags.NONE,
+        callback: Callable[[str, int, int], None] | None = None,
+        diff: Diff | None = None,
+    ) -> Diff:
+        """Validate convergence identities before entering DiffSync's write path."""
+        self._validate_convergence_identities()
+        return super().sync_from(
+            source=source,
+            diff_class=diff_class,
+            flags=flags,
+            callback=callback,
+            diff=diff,
+        )
 
     def cursor_tier_for(self, model_name: str) -> CursorTier:
         """TIMESTAMP for any kind present in the live Infrahub schema.

--- a/infrahub_sync/cli.py
+++ b/infrahub_sync/cli.py
@@ -252,20 +252,10 @@ def sync_cmd(
                 )
 
             if parallel and ptd.tiers:
-                try:
-                    ptd.sync_in_tiers(parallel=True, allow_rowcount_drop=allow_rowcount_drop)
-                except ValueError as exc:
-                    run_file.status = "failed"
-                    run_file.save()
-                    print_error_and_abort(str(exc))
+                ptd.sync_in_tiers(parallel=True, allow_rowcount_drop=allow_rowcount_drop)
                 run_file.summary = {"resources": len(ptd.top_level), "mode": "parallel"}
             else:
-                try:
-                    ptd.load_both_sides()
-                except ValueError as exc:
-                    run_file.status = "failed"
-                    run_file.save()
-                    print_error_and_abort(str(exc))
+                ptd.load_both_sides()
                 ptd.check_rowcount_guardrail(allow_drop=allow_rowcount_drop)
                 mydiff = ptd.diff()
                 ptd.write_plan(mydiff)
@@ -282,6 +272,10 @@ def sync_cmd(
                 run_file.summary = {"resources": len(ptd.top_level), "mode": "serial"}
 
             run_file.status = "applied"
+        except ValueError as exc:
+            run_file.status = "failed"
+            run_file.save()
+            print_error_and_abort(str(exc))
         except Exception:
             run_file.status = "failed"
             run_file.save()

--- a/infrahub_sync/cli.py
+++ b/infrahub_sync/cli.py
@@ -10,6 +10,7 @@ import typer
 from infrahub_sdk import InfrahubClientSync
 from infrahub_sdk.exceptions import ServerNotResponsiveError
 
+from infrahub_sync.adapters.infrahub import ConvergenceIdentityError
 from infrahub_sync.cache.locks import pipeline_lock
 from infrahub_sync.cache.sidecars import RunFile
 from infrahub_sync.utils import (
@@ -252,10 +253,20 @@ def sync_cmd(
                 )
 
             if parallel and ptd.tiers:
-                ptd.sync_in_tiers(parallel=True, allow_rowcount_drop=allow_rowcount_drop)
+                try:
+                    ptd.sync_in_tiers(parallel=True, allow_rowcount_drop=allow_rowcount_drop)
+                except ValueError as exc:
+                    run_file.status = "failed"
+                    run_file.save()
+                    print_error_and_abort(str(exc))
                 run_file.summary = {"resources": len(ptd.top_level), "mode": "parallel"}
             else:
-                ptd.load_both_sides()
+                try:
+                    ptd.load_both_sides()
+                except ValueError as exc:
+                    run_file.status = "failed"
+                    run_file.save()
+                    print_error_and_abort(str(exc))
                 ptd.check_rowcount_guardrail(allow_drop=allow_rowcount_drop)
                 mydiff = ptd.diff()
                 ptd.write_plan(mydiff)
@@ -263,7 +274,12 @@ def sync_cmd(
                     if diff:
                         logger.info("\n%s", mydiff.str())
                     start_synctime = timer()
-                    ptd.sync(diff=mydiff)
+                    try:
+                        ptd.sync(diff=mydiff)
+                    except ConvergenceIdentityError as exc:
+                        run_file.status = "failed"
+                        run_file.save()
+                        print_error_and_abort(str(exc))
                     end_synctime = timer()
                     logger.info("Sync: Completed in %s sec", end_synctime - start_synctime)
                 else:
@@ -272,10 +288,6 @@ def sync_cmd(
                 run_file.summary = {"resources": len(ptd.top_level), "mode": "serial"}
 
             run_file.status = "applied"
-        except ValueError as exc:
-            run_file.status = "failed"
-            run_file.save()
-            print_error_and_abort(str(exc))
         except Exception:
             run_file.status = "failed"
             run_file.save()

--- a/infrahub_sync/potenda/__init__.py
+++ b/infrahub_sync/potenda/__init__.py
@@ -475,7 +475,7 @@ class Potenda:
         self.check_rowcount_guardrail(allow_drop=allow_rowcount_drop)
         saved_top = self.destination.top_level
         aggregated_rows: list[dict[str, str]] = []
-        any_writes = False
+        tier_diffs: list[tuple[list[str], Diff]] = []
         try:
             for idx, tier in enumerate(self.tiers):
                 tier_list = sorted(tier)
@@ -483,9 +483,20 @@ class Potenda:
                 self.destination.top_level = tier_list  # ty: ignore[invalid-attribute-access]
                 diff = self.diff()
                 aggregated_rows.extend(self._diff_to_rows(diff))
-                if diff.has_diffs():
-                    self.sync(diff=diff)
-                    any_writes = True
+                tier_diffs.append((tier_list, diff))
+
+            validate = getattr(self.destination, "validate_convergence_identities", None)
+            if callable(validate):
+                for _, diff in tier_diffs:
+                    validate(diff=diff)
+
+            any_writes = False
+            for tier_list, diff in tier_diffs:
+                self.destination.top_level = tier_list  # ty: ignore[invalid-attribute-access]
+                if not diff.has_diffs():
+                    continue
+                self.sync(diff=diff)
+                any_writes = True
         finally:
             self.destination.top_level = saved_top  # ty: ignore[invalid-attribute-access]
 

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 from diffsync import Adapter, Diff
+from diffsync.diff import DiffElement
 
 from infrahub_sync import SchemaMappingModel, SyncAdapter, SyncConfig
 from infrahub_sync.adapters.infrahub import InfrahubAdapter
@@ -213,6 +214,113 @@ def test_default_filter_is_validated_when_destination_has_no_hfid(
         destination.sync_from(Adapter())
 
     assert entered_write_path is False
+
+
+def test_missing_upsert_key_is_refused_before_destination_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A destination without any match key cannot prove a composite identity is safe."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=None,
+            default_filter=None,
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    with pytest.raises(ValueError) as exc_info:
+        destination.sync_from(Adapter())
+
+    assert "destination upsert key (none)" in str(exc_info.value)
+    assert "uncovered mapping identifier(s): name, site" in str(exc_info.value)
+    assert entered_write_path is False
+
+
+def test_relationship_hfid_must_cover_full_peer_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relationship key by peer name is unsafe when the peer also needs tenant."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.LocationRack = SimpleNamespace(_identifiers=("name", "site"))
+    destination.LocationSite = SimpleNamespace(_identifiers=("name", "tenant"))
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value", "site__name__value"],
+            relationships=[SimpleNamespace(name="site", peer="LocationSite")],
+        ),
+        "LocationSite": SimpleNamespace(relationships=[]),
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    with pytest.raises(ValueError) as exc_info:
+        destination.sync_from(Adapter())
+
+    assert "uncovered mapping identifier(s): site" in str(exc_info.value)
+    assert entered_write_path is False
+
+
+def test_inactive_unsafe_mapping_does_not_block_unrelated_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only kinds with create or update actions in the supplied diff are validated."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="mixed-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[
+            SchemaMappingModel(name="LocationRack", identifiers=["name", "site"]),
+            SchemaMappingModel(name="BuiltinTag", identifiers=["name"]),
+        ],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(human_friendly_id=["name__value"], relationships=[]),
+        "BuiltinTag": SimpleNamespace(human_friendly_id=["name__value"], relationships=[]),
+    }
+    diff = Diff()
+    tag = DiffElement(obj_type="BuiltinTag", name="red", keys={"name": "red"})
+    tag.add_attrs(source={"description": "Red"})
+    diff.add(tag)
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    destination.sync_from(Adapter(), diff=diff)
+
+    assert entered_write_path is True
 
 
 def test_read_only_diff_remains_available_for_an_unsafe_identity(

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -314,7 +314,7 @@ def test_relationship_hfid_must_cover_full_peer_identity(
 def test_inactive_unsafe_mapping_does_not_block_unrelated_write(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only kinds with create or update actions in the supplied diff are validated."""
+    """Only kinds with create actions in the supplied diff are validated."""
     destination = InfrahubAdapter.__new__(InfrahubAdapter)
     destination.config = SyncConfig(
         name="mixed-sync",

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -51,10 +51,10 @@ def test_finer_mapping_identity_is_refused_before_destination_writes(
     assert entered_write_path is False
 
 
-def test_covering_uniqueness_constraint_allows_destination_writes(
+def test_covering_uniqueness_constraint_does_not_override_coarser_hfid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A destination key covering `(name, site)` preserves the mapping identity."""
+    """Upsert matches by HFID, so a covering constraint cannot make a coarse HFID safe."""
     destination = InfrahubAdapter.__new__(InfrahubAdapter)
     destination.config = SyncConfig(
         name="rack-sync",
@@ -82,6 +82,165 @@ def test_covering_uniqueness_constraint_allows_destination_writes(
 
     monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
 
+    with pytest.raises(ValueError):
+        destination.sync_from(Adapter())
+
+    assert entered_write_path is False
+
+
+def test_covering_hfid_allows_destination_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An HFID covering `(name, site)` preserves the identity used by upsert."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value", "site__name__value"],
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
     destination.sync_from(Adapter())
 
     assert entered_write_path is True
+
+
+def test_generated_model_identity_is_validated_when_config_identifiers_are_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The generated model's actual identity must drive the pre-write check."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack")],
+    )
+    destination.LocationRack = SimpleNamespace(_identifiers=("name", "site"))
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value"],
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    with pytest.raises(ValueError):
+        destination.sync_from(Adapter())
+
+    assert entered_write_path is False
+
+
+def test_generated_model_identity_prevents_a_stale_config_false_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checked-in model keyed by `name` must not be judged by stale composite config."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.LocationRack = SimpleNamespace(_identifiers=("name",))
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value"],
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    destination.sync_from(Adapter())
+
+    assert entered_write_path is True
+
+
+def test_default_filter_is_validated_when_destination_has_no_hfid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an HFID, Infrahub upsert matches on the schema's default filter."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=None,
+            default_filter="name__value",
+            uniqueness_constraints=[],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    with pytest.raises(ValueError):
+        destination.sync_from(Adapter())
+
+    assert entered_write_path is False
+
+
+def test_read_only_diff_remains_available_for_an_unsafe_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identity validation belongs to the mutation boundary, not `diff_from`."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value"],
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_diff_path = False
+
+    def _enter_diff_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_diff_path
+        entered_diff_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "diff_from", _enter_diff_path)
+
+    destination.diff_from(Adapter())
+
+    assert entered_diff_path is True

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -9,7 +9,21 @@ from diffsync import Adapter, Diff
 from diffsync.diff import DiffElement
 
 from infrahub_sync import SchemaMappingModel, SyncAdapter, SyncConfig
-from infrahub_sync.adapters.infrahub import InfrahubAdapter
+from infrahub_sync.adapters.infrahub import ConvergenceIdentityError, InfrahubAdapter
+
+
+def _two_rack_create_diff() -> Diff:
+    """Build the production-shaped diff for two same-named racks in different sites."""
+    diff = Diff()
+    for site in ("atlanta", "boston"):
+        rack = DiffElement(
+            obj_type="LocationRack",
+            name=f"rack-a__{site}",
+            keys={"name": "rack-a", "site": site},
+        )
+        rack.add_attrs(source={"description": f"Rack in {site}"})
+        diff.add(rack)
+    return diff
 
 
 def test_finer_mapping_identity_is_refused_before_destination_writes(
@@ -34,6 +48,7 @@ def test_finer_mapping_identity_is_refused_before_destination_writes(
             uniqueness_constraints=[["name__value"]],
         )
     }
+    destination.client = SimpleNamespace(create=pytest.fail)
     entered_write_path = False
 
     def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
@@ -43,8 +58,8 @@ def test_finer_mapping_identity_is_refused_before_destination_writes(
 
     monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
 
-    with pytest.raises(ValueError) as exc_info:
-        destination.sync_from(Adapter())
+    with pytest.raises(ConvergenceIdentityError) as exc_info:
+        destination.sync_from(Adapter(), diff=_two_rack_create_diff())
 
     message = str(exc_info.value)
     assert "LocationRack" in message
@@ -106,16 +121,25 @@ def test_covering_hfid_allows_destination_writes(monkeypatch: pytest.MonkeyPatch
     }
     entered_write_path = False
 
-    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+    observed_keys: list[dict[str, str]] = []
+
+    def _enter_write_path(*_args: object, **kwargs: object) -> Diff:
         nonlocal entered_write_path
         entered_write_path = True
-        return Diff()
+        supplied_diff = kwargs["diff"]
+        assert isinstance(supplied_diff, Diff)
+        observed_keys.extend(child.keys for child in supplied_diff.get_children())
+        return supplied_diff
 
     monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
 
-    destination.sync_from(Adapter())
+    destination.sync_from(Adapter(), diff=_two_rack_create_diff())
 
     assert entered_write_path is True
+    assert observed_keys == [
+        {"name": "rack-a", "site": "atlanta"},
+        {"name": "rack-a", "site": "boston"},
+    ]
 
 
 def test_generated_model_identity_is_validated_when_config_identifiers_are_omitted(
@@ -315,6 +339,42 @@ def test_inactive_unsafe_mapping_does_not_block_unrelated_write(
         nonlocal entered_write_path
         entered_write_path = True
         return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    destination.sync_from(Adapter(), diff=diff)
+
+    assert entered_write_path is True
+
+
+def test_update_only_diff_does_not_enter_upsert_identity_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Updates address an existing Infrahub node by ID and do not use the upsert key."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[SchemaMappingModel(name="LocationRack", identifiers=["name", "site"])],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(human_friendly_id=["name__value"], relationships=[]),
+    }
+    diff = Diff()
+    rack = DiffElement(
+        obj_type="LocationRack",
+        name="rack-a__atlanta",
+        keys={"name": "rack-a", "site": "atlanta"},
+    )
+    rack.add_attrs(source={"description": "New"}, dest={"description": "Old"})
+    diff.add(rack)
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return diff
 
     monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
 

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -1,0 +1,51 @@
+"""Regression coverage for Infrahub convergence-identity validation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from diffsync import Adapter, Diff
+
+from infrahub_sync import SchemaMappingModel, SyncAdapter, SyncConfig
+from infrahub_sync.adapters.infrahub import InfrahubAdapter
+
+
+def test_finer_mapping_identity_is_refused_before_destination_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `(name, site)` rack identity must not converge onto destination key `(name)`."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[
+            SchemaMappingModel(
+                name="LocationRack",
+                identifiers=["name", "site"],
+            )
+        ],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value"],
+            uniqueness_constraints=[["name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    with pytest.raises(ValueError) as exc_info:
+        destination.sync_from(Adapter())
+
+    message = str(exc_info.value)
+    assert "LocationRack" in message
+    assert "uncovered mapping identifier(s): site" in message
+    assert entered_write_path is False

--- a/tests/adapters/test_infrahub_convergence_identity.py
+++ b/tests/adapters/test_infrahub_convergence_identity.py
@@ -49,3 +49,39 @@ def test_finer_mapping_identity_is_refused_before_destination_writes(
     assert "LocationRack" in message
     assert "uncovered mapping identifier(s): site" in message
     assert entered_write_path is False
+
+
+def test_covering_uniqueness_constraint_allows_destination_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A destination key covering `(name, site)` preserves the mapping identity."""
+    destination = InfrahubAdapter.__new__(InfrahubAdapter)
+    destination.config = SyncConfig(
+        name="rack-sync",
+        source=SyncAdapter(name="netbox"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[
+            SchemaMappingModel(
+                name="LocationRack",
+                identifiers=["name", "site"],
+            )
+        ],
+    )
+    destination.schema = {
+        "LocationRack": SimpleNamespace(
+            human_friendly_id=["name__value"],
+            uniqueness_constraints=[["name__value", "site__name__value"]],
+        )
+    }
+    entered_write_path = False
+
+    def _enter_write_path(*_args: object, **_kwargs: object) -> Diff:
+        nonlocal entered_write_path
+        entered_write_path = True
+        return Diff()
+
+    monkeypatch.setattr(Adapter, "sync_from", _enter_write_path)
+
+    destination.sync_from(Adapter())
+
+    assert entered_write_path is True

--- a/tests/cache/test_sync_cache_flow.py
+++ b/tests/cache/test_sync_cache_flow.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from infrahub_sync.cache.parquet_io import read_table
 from infrahub_sync.potenda import Potenda
 
@@ -81,6 +83,42 @@ def test_sync_in_tiers_aggregates_plan_rows_across_tiers(tmp_path: Path) -> None
     assert sorted(plan.column("resource").to_pylist()) == ["Device", "Tag"]
     assert sorted(plan.column("action").to_pylist()) == ["create", "create"]
     ptd.persist_baseline_counts.assert_called_once()  # ty: ignore[unresolved-attribute]
+
+
+def test_sync_in_tiers_validates_every_diff_before_the_first_write(tmp_path: Path) -> None:
+    """An unsafe later tier must refuse before an earlier safe tier is written."""
+    src = _make_fake_adapter({"Tag": [_FakeRecord(name="prod")], "Device": [_FakeRecord(name="d1")]})
+    dst = _make_fake_adapter({"Tag": [], "Device": []})
+    diffs = [
+        _Diff({"Tag": [_Child("create", "prod")]}),
+        _Diff({"Device": [_Child("create", "d1")]}),
+    ]
+    diff_iter = iter(diffs)
+    validated: list[_Diff] = []
+
+    def validate(*, diff: _Diff) -> None:
+        validated.append(diff)
+        if diff is diffs[1]:
+            msg = "unsafe Device identity"
+            raise ValueError(msg)
+
+    dst.validate_convergence_identities = validate
+    ptd = Potenda(
+        source=src,
+        destination=dst,
+        config=None,  # ty: ignore[invalid-argument-type]
+        top_level=["Tag", "Device"],
+        tiers=[{"Tag"}, {"Device"}],
+        run_dir=tmp_path,
+    )
+    ptd.diff = lambda: next(diff_iter)  # ty: ignore[invalid-assignment]
+    ptd.sync = MagicMock()  # ty: ignore[invalid-assignment]
+
+    with pytest.raises(ValueError, match="unsafe Device identity"):
+        ptd.sync_in_tiers(parallel=True)
+
+    assert validated == diffs
+    ptd.sync.assert_not_called()  # ty: ignore[unresolved-attribute]
 
 
 def test_sync_in_tiers_runs_rowcount_guardrail(tmp_path: Path) -> None:

--- a/tests/test_cli_parallel.py
+++ b/tests/test_cli_parallel.py
@@ -114,6 +114,33 @@ def test_serial_sync_presents_convergence_refusal_without_raw_exception(
     abort.assert_called_once_with(refusal)
 
 
+def test_serial_sync_does_not_present_unrelated_value_error_as_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only convergence refusals use the serial sync presentation path."""
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path))
+    run_dir = tmp_path / "from-netbox" / "test-run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    fake_ptd = _make_fake_potenda(tiers=None, run_dir=run_dir)
+    unrelated_error = ValueError("unexpected diff failure")
+    fake_ptd.diff.side_effect = unrelated_error
+    runner = CliRunner()
+
+    with (
+        patch("infrahub_sync.cli.get_potenda_from_instance", return_value=fake_ptd),
+        patch("infrahub_sync.cli.print_error_and_abort", side_effect=typer.Abort) as abort,
+    ):
+        result = runner.invoke(
+            app,
+            ["sync", "--no-parallel", "--name", "from-netbox", "--directory", str(EXAMPLES_DIR)],
+        )
+
+    assert result.exit_code == 1
+    assert result.exception is unrelated_error
+    abort.assert_not_called()
+
+
 def test_parallel_flag_warns_when_order_explicit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_cli_parallel.py
+++ b/tests/test_cli_parallel.py
@@ -123,8 +123,9 @@ def test_serial_sync_does_not_present_unrelated_value_error_as_refusal(
     run_dir = tmp_path / "from-netbox" / "test-run"
     run_dir.mkdir(parents=True, exist_ok=True)
     fake_ptd = _make_fake_potenda(tiers=None, run_dir=run_dir)
+    fake_ptd.diff.return_value.has_diffs.return_value = True
     unrelated_error = ValueError("unexpected diff failure")
-    fake_ptd.diff.side_effect = unrelated_error
+    fake_ptd.sync.side_effect = unrelated_error
     runner = CliRunner()
 
     with (

--- a/tests/test_cli_parallel.py
+++ b/tests/test_cli_parallel.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import typer
 from typer.testing import CliRunner
 
+from infrahub_sync.adapters.infrahub import ConvergenceIdentityError
 from infrahub_sync.cli import app
 
 if TYPE_CHECKING:
@@ -83,6 +85,33 @@ def test_no_parallel_runs_serial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     fake_ptd.sync_in_tiers.assert_not_called()
     fake_ptd.load_both_sides.assert_called_once()
     fake_ptd.diff.assert_called_once()
+
+
+def test_serial_sync_presents_convergence_refusal_without_raw_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serial sync must present the pre-write refusal through the normal CLI error path."""
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path))
+    run_dir = tmp_path / "from-netbox" / "test-run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    fake_ptd = _make_fake_potenda(tiers=None, run_dir=run_dir)
+    fake_ptd.diff.return_value.has_diffs.return_value = True
+    refusal = "Refusing to sync destination kind LocationRack: uncovered mapping identifier(s): site."
+    fake_ptd.sync.side_effect = ConvergenceIdentityError(refusal)
+    runner = CliRunner()
+
+    with (
+        patch("infrahub_sync.cli.get_potenda_from_instance", return_value=fake_ptd),
+        patch("infrahub_sync.cli.print_error_and_abort", side_effect=typer.Abort) as abort,
+    ):
+        result = runner.invoke(
+            app,
+            ["sync", "--no-parallel", "--name", "from-netbox", "--directory", str(EXAMPLES_DIR)],
+        )
+
+    assert result.exit_code == 1
+    abort.assert_called_once_with(refusal)
 
 
 def test_parallel_flag_warns_when_order_explicit(


### PR DESCRIPTION
## Why

A schema mapping declares how Sync identifies an object. If it declares
`identifiers: [name, site]`, two racks with the same name in different sites
are distinct objects.

Infrahub previously allowed that mapping to write into a destination keyed only
by `name`. Both racks matched the same destination object, and the second write
silently replaced the first.

This change enforces the configured identity: a mapping keyed by `(name, site)`
requires Infrahub's upsert key to distinguish both `name` and `site`. Otherwise,
`sync` refuses the affected kind before an ambiguous create and identifies the
unsupported field.

Closes #166

## What changed

- Validate the generated model identity before the affected kind's first
  destination create.
- Validate only kinds with create actions in the current diff; updates target
  existing nodes by ID.
- Match it against Infrahub's human-friendly ID, or its default filter when no
  human-friendly ID exists.
- Require relationship key paths to cover the peer's complete generated
  identity.
- Do not accept uniqueness constraints as upsert keys because Infrahub does not
  use them to select an existing object.
- Keep `diff` available for reviewing unsafe mappings.
- Report refusals consistently in serial and parallel sync modes.

Serial sync validates its whole-run diff before writing. Tiered sync validates
each tier at its write boundary, so safe earlier tiers may complete before a
later unsafe tier is refused; the affected kind is still stopped before any
lossy create.

Example:

```text
Refusing to sync destination kind LocationRack:
generated model identity (name, site) is finer than its
destination upsert key (name);
uncovered mapping identifier(s): site.
```

## Documentation

Updated the schema-mapping reference with the destination identity requirement
and added a bug-fix changelog fragment.

## Test plan

```bash
uv sync --extra dev
uv run pytest -q
uv run ty check .
uv run invoke docs.generate
uv run invoke docs.docusaurus
uv run infrahub-sync --help
uv run infrahub-sync list --directory examples/
```

Results:

- 123 passed, 3 skipped.
- Focused identity and serial/parallel CLI tests passed.
- Ruff passed on changed files.
- `ty check .` passed with three existing warnings in untouched tests.
- Documentation generation and production build passed.
- Repository-wide Pylint retains the existing `main` branch diagnostics.

The `generate` sanity check was not run because no local Infrahub server was
available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to prevent creates when destination upsert identifiers do not fully cover generated model identities.
  - Applies to serial and parallel sync modes, including nested relationship identifiers.
  - Updates and read-only comparisons remain available when creates are refused.

- **Bug Fixes**
  - Sync failures now use the standard CLI error path and are recorded as failed runs.

- **Documentation**
  - Expanded composite identifier guidance and documented identifier coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->