### PR TITLE
Vendor opsmill-prefect-extras, removing the private Git dependency

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -10,6 +10,7 @@ markdown_all: &markdown_all
 
 sync_files: &sync_files
   - "infrahub_sync/**"
+  - "opsmill_prefect_extras/**"
 
 test_files: &test_files
   - "tests/**"

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -104,9 +104,13 @@ jobs:
       - name: "Assert Python 3.10 is active"
         run: uv run --no-sync python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version"
 
+      # opsmill_prefect_extras is vendored first-party code shipped with the package,
+      # so it is present on disk in every install; the base-package guarantee that
+      # nothing imports it without the managed extra is enforced by
+      # tests/test_no_prefect_import.py.
       - name: "Assert managed runtime dependencies are absent from this environment"
         run: |
-          for module in prefect fastapi uvicorn opsmill_prefect_extras; do
+          for module in prefect fastapi uvicorn; do
             if uv run --no-sync python -c "import ${module}" 2>/dev/null; then
               echo "${module} is importable — this leg must be a base install"
               exit 1

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -135,8 +135,12 @@ userinfo
 uuid
 UUID
 uv
+Uvicorn
+uvicorn
 validator
 validators
+vendored
+vendoring
 Version Control
 VRFs
 walkthrough

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ uv run invoke docs.docusaurus
 **Policy:**
 
 - New or changed code is Ruff-clean and typed where touched (docstrings, specific exceptions).
-- The codebase is clean under ty with no `[[tool.ty.overrides]]` blocks in `pyproject.toml`. Don't reintroduce overrides to mask type errors — fix the underlying issue, or use a targeted `# ty: ignore[<rule>]` with a short TODO at the call site. Run `uv run ty check --exclude tests/vendored_prefect_extras .` in the full Python 3.11–3.13 profile (the vendored upstream tests are frozen and not held to this repository's checks; the vendored package itself is). On Python 3.10, also exclude `infrahub_sync/managed` and `tests/managed`.
+- The codebase is clean under ty with no `[[tool.ty.overrides]]` blocks in `pyproject.toml`. Don't reintroduce overrides to mask type errors — fix the underlying issue, or use a targeted `# ty: ignore[<rule>]` with a short TODO at the call site. Run `uv run ty check .` in the full Python 3.11–3.13 profile (the frozen vendored upstream tests are excluded via `[tool.ty.src]` in `pyproject.toml`; the vendored package itself stays checked). On Python 3.10, run `uv run ty check --exclude infrahub_sync/managed --exclude tests/managed .`.
 - If you add tests, run `uv run pytest -q`.
 
 ## Repository Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@
 
 ## Setup
 
-Use Python 3.11–3.13 for the full development profile. The `managed` extra currently
-includes an exact Git dependency on the private `opsmill/prefect-extras` repository, so
-this command requires read access to that repository:
+Use Python 3.11–3.13 for the full development profile. The former private
+`opsmill/prefect-extras` Git dependency is vendored at `opsmill_prefect_extras/`
+(frozen; see its `VENDORED.md`), so no special repository access is required:
 
 ```bash
 uv sync --extra dev --extra prefect --extra managed
@@ -48,7 +48,7 @@ documented in [`dev/knowledge/quality-gates.md`](dev/knowledge/quality-gates.md)
 The `prefect` extra is not optional for development: without it `ty` cannot resolve
 `infrahub_sync/orchestration/`'s imports and `tests/orchestration/test_flow.py` skips
 itself whole. On Python 3.11–3.13, the `managed` extra is required too; otherwise `ty`
-cannot resolve the managed service's Prefect Extras imports. On Python 3.10,
+cannot resolve the managed service's FastAPI and Prefect imports. On Python 3.10,
 `invoke linter.lint-ty` and `invoke linter.lint-pylint` exclude `infrahub_sync/managed`
 (ty also excludes `tests/managed`), matching CI's direct Prefect gate. CI also runs a base-install job that keeps the Prefect-free
 guarantee honest.
@@ -79,7 +79,7 @@ uv run invoke docs.docusaurus
 **Policy:**
 
 - New or changed code is Ruff-clean and typed where touched (docstrings, specific exceptions).
-- The codebase is clean under ty with no `[[tool.ty.overrides]]` blocks in `pyproject.toml`. Don't reintroduce overrides to mask type errors — fix the underlying issue, or use a targeted `# ty: ignore[<rule>]` with a short TODO at the call site. Run `uv run ty check .` in the full Python 3.11–3.13 profile. On Python 3.10, run `uv run ty check --exclude infrahub_sync/managed --exclude tests/managed .`.
+- The codebase is clean under ty with no `[[tool.ty.overrides]]` blocks in `pyproject.toml`. Don't reintroduce overrides to mask type errors — fix the underlying issue, or use a targeted `# ty: ignore[<rule>]` with a short TODO at the call site. Run `uv run ty check --exclude tests/vendored_prefect_extras .` in the full Python 3.11–3.13 profile (the vendored upstream tests are frozen and not held to this repository's checks; the vendored package itself is). On Python 3.10, also exclude `infrahub_sync/managed` and `tests/managed`.
 - If you add tests, run `uv run pytest -q`.
 
 ## Repository Structure

--- a/dev/knowledge/quality-gates.md
+++ b/dev/knowledge/quality-gates.md
@@ -114,8 +114,10 @@ restore incidental generated-file changes before committing unrelated work.
 ## CI
 
 Python 3.11–3.13 linting runs in an environment synced with
-`--extra dev --extra prefect --extra managed`. The type gate checks the full tree; the
-managed extra requires read access to the private `opsmill/prefect-extras` Git dependency.
+`--extra dev --extra prefect --extra managed`. The type gate checks the full tree except
+the frozen vendored upstream tests (excluded via `[tool.ty.src]`); the former private
+`opsmill/prefect-extras` Git dependency is vendored in-repo, so no special access is
+required.
 
 Python 3.10 linting uses `--extra dev --extra prefect` and runs:
 

--- a/docs/docs/reference/managed-http-api.mdx
+++ b/docs/docs/reference/managed-http-api.mdx
@@ -16,9 +16,8 @@ control.
 ## Install the managed profile
 
 The managed profile requires Python 3.11 or later. No published package carries this
-profile yet, and its exact OpsMill Prefect Extras pin currently requires read access to
-that private repository, so install from a repository checkout on the API host and every
-worker that can run its deployment:
+profile yet, so install from a repository checkout on the API host and every worker
+that can run its deployment:
 
 ```bash
 uv sync --extra dev --extra prefect --extra managed
@@ -27,9 +26,10 @@ uv sync --extra dev --extra prefect --extra managed
 Once a release with the managed profile is published, `pip install
 'infrahub-sync[managed]'` becomes the deployment path.
 
-The profile directly installs FastAPI, HTTPX, Uvicorn, Prefect 3.8.1, and OpsMill Prefect
-Extras from commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does
-not import these packages. Ordinary CLI and Python API imports remain Prefect-free.
+The profile directly installs FastAPI, HTTPX, Uvicorn, and Prefect 3.8.1. The OpsMill
+Prefect Extras integration ships with the package itself as a vendored copy of upstream
+commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does not import
+any of these modules. Ordinary CLI and Python API imports remain Prefect-free.
 
 You also need:
 

--- a/opsmill_prefect_extras/VENDORED.md
+++ b/opsmill_prefect_extras/VENDORED.md
@@ -1,0 +1,32 @@
+# Vendored: opsmill-prefect-extras
+
+This directory is a **byte-identical** copy of the private upstream package
+`opsmill/prefect-extras` at commit `84688eb8d8db7e17770413640a66481ccdc3e725`
+(branch `feature/db-104-executors`; upstream PRs #13–#17 remain open). Its
+upstream unit tests are copied, also byte-identical, under
+`tests/vendored_prefect_extras/`. Only this file and the test directory's
+`__init__.py`/`conftest.py` guard are local additions; no upstream file is
+modified.
+
+It is vendored so this repository installs and tests without access to the
+private upstream repository. It keeps its original top-level import name so
+that consumer imports, tests, and the eventual re-adoption need no rewrites,
+and so `diff -r` against the upstream commit stays empty.
+
+## Freeze rule — do not modify this directory
+
+A change needed here must either:
+
+1. be submitted upstream first and re-copied byte-identically (updating the
+   pinned commit recorded above and in `pyproject.toml`), or
+2. be explicitly recorded in the planning decision log as ending the
+   re-adoption plan.
+
+Local lint/format tooling must exclude this directory rather than rewrite it.
+
+## Re-adoption condition
+
+When upstream `opsmill/prefect-extras` is merged and published, delete this
+directory and `tests/vendored_prefect_extras/`, remove
+`"opsmill_prefect_extras"` from `[tool.hatch.build.targets.wheel] packages`,
+and restore the dependency in the `managed` extra.

--- a/opsmill_prefect_extras/VENDORED.md
+++ b/opsmill_prefect_extras/VENDORED.md
@@ -13,6 +13,12 @@ private upstream repository. It keeps its original top-level import name so
 that consumer imports, tests, and the eventual re-adoption need no rewrites,
 and so `diff -r` against the upstream commit stays empty.
 
+Known side effect of the frozen test suite: upstream's
+`tests/vendored_prefect_extras/workflows/conftest.py` computes a "repository
+root" from its own location and prepends it to `sys.path`; in this repository
+that path is the `tests/` directory. It is harmless here (nothing imports the
+test packages by their short names) and is left in place rather than edited.
+
 ## Freeze rule — do not modify this directory
 
 A change needed here must either:
@@ -29,4 +35,7 @@ Local lint/format tooling must exclude this directory rather than rewrite it.
 When upstream `opsmill/prefect-extras` is merged and published, delete this
 directory and `tests/vendored_prefect_extras/`, remove
 `"opsmill_prefect_extras"` from `[tool.hatch.build.targets.wheel] packages`,
-and restore the dependency in the `managed` extra.
+restore the dependency in the `managed` extra, and drop the vendoring entries
+from the Ruff exclude list, `[tool.ty.src]` exclude, the isort
+`known-third-party` pin, and `.github/file-filters.yml`.
+`tests/test_vendoring_consistency.py` fails on any half-executed re-adoption.

--- a/opsmill_prefect_extras/__init__.py
+++ b/opsmill_prefect_extras/__init__.py
@@ -1,0 +1,3 @@
+"""Tools to integrate Prefect into another application."""
+
+__version__ = "0.1.0"

--- a/opsmill_prefect_extras/deployments.py
+++ b/opsmill_prefect_extras/deployments.py
@@ -1,0 +1,399 @@
+"""Apply declared workflow deployments to a Prefect server.
+
+This module is deliberately limited to deployment convergence.  Applications
+provide their own work-pool name, job variables, client configuration, and any
+multi-replica coordination.  It creates neither pools nor workers and never
+starts a flow.
+
+The only workflow-feature import is :mod:`.workflows.definitions`, its common
+data module.  In particular, applying deployments does not import the
+catalogue or validation facades.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, cast
+from uuid import UUID
+
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.actions import DeploymentCreate, DeploymentUpdate
+from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+ApplyStatus = Literal["created", "updated", "unchanged", "failed"]
+"""One definition's convergence verdict."""
+
+_COMPARABLE_FIELDS: tuple[str, ...] = (
+    "name",
+    "tags",
+    "schedules",
+    "concurrency_options",
+    "entrypoint",
+    "work_pool_name",
+    "job_variables",
+)
+"""Fields this feature owns and therefore reconciles."""
+
+_SENTINEL_FLOW_ID: UUID = UUID("00000000-0000-0000-0000-000000000000")
+"""A local schema-validation stand-in; it is never sent to Prefect."""
+
+__all__: list[str] = [
+    "ApplyStatus",
+    "DefinitionPreflightError",
+    "DeploymentApplyConnectionError",
+    "DeploymentApplyReport",
+    "DeploymentApplyResult",
+    "DeploymentClient",
+    "DeploymentClientFactory",
+    "DeploymentRecord",
+    "apply_deployments",
+]
+
+
+class DeploymentRecord(Protocol):
+    """The small part of Prefect's deployment response required for updates."""
+
+    id: UUID
+
+    # Any: Prefect's model serializer returns heterogeneous JSON-compatible data.
+    def model_dump(self, *, mode: str, exclude_none: bool) -> Mapping[str, Any]:
+        """Return a JSON-compatible deployment representation."""
+
+
+class DeploymentClient(Protocol):
+    """Injectable asynchronous seam over the four Prefect calls this feature uses."""
+
+    async def create_flow_from_name(self, flow_name: str) -> UUID:
+        """Create or retrieve the server flow identified by ``flow_name``."""
+
+    # Any: Prefect deployment payload fields are deliberately heterogeneous.
+    async def create_deployment(self, flow_id: UUID, **payload: Any) -> UUID:
+        """Create a deployment; Prefect may upsert an existing identity."""
+
+    async def read_deployment_by_name(self, name: str) -> DeploymentRecord:
+        """Read by ``flow_name/deployment_name``, raising if it is absent."""
+
+    async def update_deployment(
+        self, deployment_id: UUID, deployment: DeploymentUpdate
+    ) -> None:
+        """Update the fields this feature owns on an existing deployment."""
+
+
+DeploymentClientFactory = Callable[[], AbstractAsyncContextManager[DeploymentClient]]
+"""A caller-injectable client context factory, useful for connection setup."""
+
+
+class DeploymentApplyConnectionError(RuntimeError):
+    """The client context could not open, so no definition was attempted.
+
+    Attributes:
+        cause_type: The class name of the opening failure.  Its value is not
+            rendered, because client exceptions can contain credentials.
+    """
+
+    cause_type: str
+
+    def __init__(self, cause: BaseException) -> None:
+        """Describe a connection-opening failure without disclosing its value."""
+        self.cause_type = type(cause).__name__
+        super().__init__(
+            "could not open the Prefect client before deployment apply began "
+            f"({self.cause_type})"
+        )
+
+
+class DefinitionPreflightError(ValueError):
+    """A definition no longer satisfies its key grammar at apply time."""
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DeploymentApplyResult:
+    """The convergence result for one workflow definition.
+
+    Attributes:
+        definition: The definition this outcome concerns.
+        status: Whether it was created, updated, already unchanged, or failed.
+        error_type: The failure class name when ``status`` is ``"failed"``.
+            Exception values are intentionally never retained.
+    """
+
+    definition: WorkflowDefinition
+    status: ApplyStatus
+    error_type: str | None = None
+
+    def __post_init__(self) -> None:
+        """Keep successful and failed results internally consistent.
+
+        Raises:
+            ValueError: If a failure has no type or a success carries one.
+        """
+        if self.status == "failed" and self.error_type is None:
+            raise ValueError("a failed deployment result needs an error type")
+        if self.status != "failed" and self.error_type is not None:
+            raise ValueError("a successful deployment result cannot have an error type")
+
+    @property
+    def key(self) -> str:
+        """Return this result's ``flow_name/deployment_name`` identity."""
+        return self.definition.key
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DeploymentApplyReport:
+    """The complete, ordered result of one deployment apply operation."""
+
+    results: tuple[DeploymentApplyResult, ...]
+
+    @property
+    def created(self) -> tuple[DeploymentApplyResult, ...]:
+        """Return outcomes for deployments newly created by this call."""
+        return self._with_status("created")
+
+    @property
+    def updated(self) -> tuple[DeploymentApplyResult, ...]:
+        """Return outcomes for deployments reconciled by this call."""
+        return self._with_status("updated")
+
+    @property
+    def unchanged(self) -> tuple[DeploymentApplyResult, ...]:
+        """Return outcomes already matching their declared payload."""
+        return self._with_status("unchanged")
+
+    @property
+    def failed(self) -> tuple[DeploymentApplyResult, ...]:
+        """Return outcomes whose individual deployment operation failed."""
+        return self._with_status("failed")
+
+    @property
+    def is_successful(self) -> bool:
+        """Whether every attempted definition converged successfully."""
+        return not self.failed
+
+    def _with_status(self, status: ApplyStatus) -> tuple[DeploymentApplyResult, ...]:
+        """Select report results with one status."""
+        return tuple(result for result in self.results if result.status == status)
+
+
+async def apply_deployments(
+    definitions: Iterable[WorkflowDefinition],
+    *,
+    work_pool_name: str,
+    job_variables: Mapping[str, Any] | None = None,
+    client: DeploymentClient | None = None,
+    client_factory: DeploymentClientFactory | None = None,
+) -> DeploymentApplyReport:
+    """Converge definitions to deployments using caller-owned infrastructure.
+
+    Each definition is read before any write because Prefect's create endpoint
+    upserts an existing identity.  A match is unchanged, a difference is
+    updated, and only a missing deployment is created.  Schema and definition
+    preflight failures, plus server failures after apply starts, become
+    per-definition ``failed`` results so later definitions continue.
+
+    Args:
+        definitions: Definitions or a ``WorkflowCatalogue`` to reconcile.
+        work_pool_name: Existing Prefect work pool selected by the application.
+        job_variables: Optional Prefect job variables owned by the application.
+        client: An already-open Prefect client or offline fake client.
+        client_factory: A context factory for a Prefect client.  Its opening
+            errors raise :class:`DeploymentApplyConnectionError` before any
+            definition is attempted.  Mutually exclusive with ``client``.
+
+    Returns:
+        An ordered report with one verdict for every supplied definition.
+
+    Raises:
+        ValueError: If both client injection options are supplied.
+        DeploymentApplyConnectionError: If the selected client context cannot
+            open before processing starts.
+    """
+    if client is not None and client_factory is not None:
+        raise ValueError("pass either client or client_factory, not both")
+
+    if client is not None:
+        return await _apply_with_client(
+            definitions,
+            work_pool_name=work_pool_name,
+            job_variables=job_variables,
+            client=client,
+        )
+
+    manager = get_client() if client_factory is None else client_factory()
+    entered = False
+    try:
+        async with manager as active_client:
+            entered = True
+            return await _apply_with_client(
+                definitions,
+                work_pool_name=work_pool_name,
+                job_variables=job_variables,
+                client=cast(DeploymentClient, active_client),
+            )
+    except Exception as exc:
+        if not entered:
+            raise DeploymentApplyConnectionError(exc) from None
+        raise
+
+
+async def _apply_with_client(
+    definitions: Iterable[WorkflowDefinition],
+    *,
+    work_pool_name: str,
+    job_variables: Mapping[str, Any] | None,
+    client: DeploymentClient,
+) -> DeploymentApplyReport:
+    """Apply every definition after a client has opened successfully."""
+    results: list[DeploymentApplyResult] = []
+    for definition in definitions:
+        results.append(
+            await _apply_definition(
+                definition,
+                work_pool_name=work_pool_name,
+                job_variables=job_variables,
+                client=client,
+            )
+        )
+    return DeploymentApplyReport(results=tuple(results))
+
+
+async def _apply_definition(
+    definition: WorkflowDefinition,
+    *,
+    work_pool_name: str,
+    job_variables: Mapping[str, Any] | None,
+    client: DeploymentClient,
+) -> DeploymentApplyResult:
+    """Apply one definition, retaining only an exception's safe type name."""
+    try:
+        payload = _validated_payload(
+            definition, work_pool_name=work_pool_name, job_variables=job_variables
+        )
+        try:
+            existing = await client.read_deployment_by_name(definition.key)
+        except ObjectNotFound:
+            flow_id = await client.create_flow_from_name(definition.flow_name)
+            try:
+                await client.create_deployment(flow_id, **payload)
+            except ObjectAlreadyExists:
+                # Some servers surface a create/create race as a conflict.
+                # Prefect OSS upserts instead, so applications with multiple
+                # replicas still own their coordination boundary.
+                existing = await client.read_deployment_by_name(definition.key)
+            else:
+                return DeploymentApplyResult(definition=definition, status="created")
+
+        if _matches(existing, payload):
+            return DeploymentApplyResult(definition=definition, status="unchanged")
+        await client.update_deployment(existing.id, _update(payload))
+        return DeploymentApplyResult(definition=definition, status="updated")
+    except Exception as exc:
+        return DeploymentApplyResult(
+            definition=definition, status="failed", error_type=type(exc).__name__
+        )
+
+
+def _validated_payload(
+    definition: WorkflowDefinition,
+    *,
+    work_pool_name: str,
+    job_variables: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Render the caller-owned payload after definition and Prefect checks."""
+    _assert_definition_key_grammar(definition)
+    # Any: workflow definitions render Prefect's heterogeneous input payload.
+    payload: dict[str, Any] = definition.to_deployment_input()
+    payload["work_pool_name"] = work_pool_name
+    if job_variables is not None:
+        payload["job_variables"] = dict(job_variables)
+    DeploymentCreate(flow_id=_SENTINEL_FLOW_ID, **payload)
+    return payload
+
+
+def _assert_definition_key_grammar(definition: WorkflowDefinition) -> None:
+    """Recheck the definition's two construction rules before an external call."""
+    if "/" in definition.flow_name or "/" in definition.deployment_name:
+        raise DefinitionPreflightError(
+            "definition names must not contain the deployment address separator"
+        )
+
+
+def _matches(existing: DeploymentRecord, desired: Mapping[str, Any]) -> bool:
+    """Compare the persisted deployment with the fields this feature owns."""
+    existing_payload = existing.model_dump(mode="json", exclude_none=True)
+    comparable_existing = {
+        field: existing_payload[field]
+        for field in _COMPARABLE_FIELDS
+        if field in existing_payload
+    }
+    if "schedules" in comparable_existing:
+        comparable_existing["schedules"] = _response_schedules(
+            comparable_existing["schedules"]
+        )
+    normalized_existing = _normalised_payload(comparable_existing)
+    desired_payload = _normalised_payload(desired)
+    fields_match = all(
+        normalized_existing.get(field) == desired_payload.get(field)
+        for field in _COMPARABLE_FIELDS
+    )
+    return fields_match and _response_concurrency_limit(existing_payload) == (
+        desired_payload.get("concurrency_limit")
+    )
+
+
+def _response_concurrency_limit(payload: Mapping[str, Any]) -> object:
+    """Read a deployment limit from Prefect's response-shaped payload.
+
+    Newer Prefect responses keep the deprecated ``concurrency_limit`` field as
+    ``None`` and put the effective value under ``global_concurrency_limit``.
+    Older response shapes may still carry the direct field, so that remains a
+    fallback for the declared compatibility range.
+    """
+    global_limit = payload.get("global_concurrency_limit")
+    if isinstance(global_limit, Mapping):
+        return global_limit.get("limit")
+    return payload.get("concurrency_limit")
+
+
+def _response_schedules(value: object) -> object:
+    """Drop server-owned identity and timestamp fields from schedule entries."""
+    if not isinstance(value, list):
+        return value
+    owned_fields = ("schedule", "active", "parameters")
+    normalized: list[object] = []
+    for entry in value:
+        if not isinstance(entry, Mapping):
+            normalized.append(entry)
+            continue
+        # Any: Prefect's JSON response mapping has heterogeneous values.
+        response_entry = cast(Mapping[str, Any], entry)
+        normalized.append(
+            {
+                field: response_entry[field]
+                for field in owned_fields
+                if field in response_entry
+            }
+        )
+    return normalized
+
+
+def _normalised_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Ask Prefect to normalize defaults before comparing a desired payload."""
+    model = DeploymentCreate(flow_id=_SENTINEL_FLOW_ID, **payload)
+    return cast(Mapping[str, Any], model.model_dump(mode="json", exclude_none=True))
+
+
+def _update(payload: Mapping[str, Any]) -> DeploymentUpdate:
+    """Build Prefect's named update schema from the fields this feature owns."""
+    normalized = _normalised_payload(payload)
+    update_fields = {
+        field: normalized[field]
+        for field in _COMPARABLE_FIELDS
+        if field != "name" and field in normalized
+    }
+    # Setting this field explicitly also lets an update clear a prior limit.
+    update_fields["concurrency_limit"] = normalized.get("concurrency_limit")
+    return DeploymentUpdate(**update_fields)

--- a/opsmill_prefect_extras/executors.py
+++ b/opsmill_prefect_extras/executors.py
@@ -1,0 +1,609 @@
+"""Execute declared Prefect workflows locally or through a deployment.
+
+Applications choose an executor at their composition root.  Both
+:class:`LocalWorkflowExecutor` and :class:`RemoteWorkflowExecutor` accept the
+same :class:`~opsmill_prefect_extras.workflows.definitions.WorkflowDefinition`
+and a mapping of parameters.  :meth:`WorkflowExecutor.run` waits for and
+returns the flow result; :meth:`WorkflowExecutor.submit` returns an execution
+handle as soon as the execution was accepted.
+
+The modes intentionally have different operational properties:
+
+* Local runs execute ``Flow.fn`` in this Python process after Prefect validates
+  the parameters.  They have a ``local:`` identity, are not Prefect flow-run
+  IDs, create no server history or UI entry, and disappear on process restart.
+  Cancelling a local handle cancels its asyncio task; it cannot stop synchronous
+  work that is already running in its worker thread.
+* Remote runs are addressed as ``flow_name/deployment_name`` and have the
+  server-assigned Prefect flow-run ID.  Their durability, restart survival, and
+  UI/history are supplied by the configured Prefect server.  Cancellation is a
+  request sent to that server; its worker decides when it takes effect.  The
+  :class:`IdempotentWorkflowExecutor` capability additionally accepts Prefect's
+  optional ``idempotency_key``; consumers own its stable derivation and must
+  not put private data in it. :class:`RemoteWorkflowExecutor` satisfies that
+  capability; local execution deliberately does not.
+
+Local execution intentionally has no Prefect flow-run context or engine.
+Calling :func:`prefect.get_run_logger` inside a local ``Flow.fn`` therefore
+raises :class:`prefect.exceptions.MissingContextError` unless the consumer flow
+provides its own fallback. Prefect retries, hooks, timeouts, runtime logging,
+state, and history are bypassed. Consumers needing full engine semantics must
+use remote mode. A generic consumer-owned fallback catches *only*
+``MissingContextError`` around ``get_run_logger`` and uses a normal module
+logger instead::
+
+    import logging
+
+    from prefect import get_run_logger
+    from prefect.exceptions import MissingContextError
+
+    def workflow_logger() -> logging.Logger | logging.LoggerAdapter[logging.Logger]:
+        try:
+            return get_run_logger()
+        except MissingContextError:
+            return logging.getLogger(__name__)
+
+The local executor deliberately retains only active tasks.  A caller-held
+handle retains its completed result or exception, while the executor keeps no
+completed-run registry, persistence, or TTL cache.  Call :meth:`shutdown` at
+application shutdown to reject new submissions, drain active tasks for a
+bounded period, and cancel any work still pending.
+
+Example:
+    An application chooses local execution for a test or single-process mode::
+
+        from opsmill_prefect_extras.executors import LocalWorkflowExecutor
+
+        executor = LocalWorkflowExecutor()
+        result = await executor.run(INVENTORY_REFRESH, {"full": False})
+        await executor.shutdown()
+
+    Production wiring owns the Prefect client lifecycle and supplies it to the
+    remote executor::
+
+        from prefect.client.orchestration import get_client
+
+        from opsmill_prefect_extras.executors import RemoteWorkflowExecutor
+
+        async with get_client() as client:
+            executor = RemoteWorkflowExecutor(client)
+            handle = await executor.submit(INVENTORY_REFRESH, {"full": False})
+            result = await handle.result()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+from uuid import UUID, uuid4
+
+from prefect.client.schemas.objects import State
+from prefect.exceptions import MissingResult, ObjectNotFound
+from prefect.flows import Flow
+from prefect.states import Cancelling
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+ExecutionStatus = Literal[
+    "pending",
+    "running",
+    "cancelling",
+    "completed",
+    "failed",
+    "crashed",
+    "cancelled",
+]
+"""The portable execution state exposed by a run handle."""
+
+__all__: list[str] = [
+    "CancelledFlowRunError",
+    "CrashedFlowRunError",
+    "ExecutionStatus",
+    "ExecutorClosedError",
+    "FailedFlowRunError",
+    "FlowRunError",
+    "IdempotentWorkflowExecutor",
+    "LocalWorkflowExecutor",
+    "MissingFlowRunResultError",
+    "RemoteExecutionClient",
+    "RemoteWorkflowExecutor",
+    "WorkflowExecutor",
+    "WorkflowNotFoundError",
+    "WorkflowRunHandle",
+]
+
+
+class WorkflowRunHandle(Protocol):
+    """A retained reference to one accepted workflow execution.
+
+    ``id`` is a ``local:`` identity for local handles and the real Prefect
+    flow-run ID for remote handles.  ``result`` waits for terminal completion
+    and returns the flow result, or raises the documented mode-specific error.
+    """
+
+    @property
+    def id(self) -> str:
+        """Return this execution's identity."""
+
+    async def status(self) -> ExecutionStatus:
+        """Inspect the current portable execution status."""
+
+    async def wait(self) -> ExecutionStatus:
+        """Wait until terminal status and return it."""
+
+    async def result(self) -> object:
+        """Wait for terminal completion and return the flow result."""
+
+    async def cancel(self) -> ExecutionStatus:
+        """Request cancellation and return the status observed afterward."""
+
+
+class WorkflowExecutor(Protocol):
+    """The application-facing execution contract.
+
+    Implementations use Prefect's ``Flow.validate_parameters`` before they
+    accept work, so a definition rejects the same parameter shape in both
+    modes.
+    """
+
+    async def run(
+        self, definition: WorkflowDefinition, parameters: Mapping[str, object]
+    ) -> object:
+        """Execute one definition, wait for it, and return its flow result."""
+
+    async def submit(
+        self, definition: WorkflowDefinition, parameters: Mapping[str, object]
+    ) -> WorkflowRunHandle:
+        """Accept one definition and immediately return its retained handle."""
+
+
+class IdempotentWorkflowExecutor(WorkflowExecutor, Protocol):
+    """Execution contract with server-backed run-creation idempotency.
+
+    Consumers that require deduplicated submission can depend on this capability
+    without naming a concrete executor. Implementations pass the optional key to
+    their durable run-creation boundary; they do not derive or store it.
+    """
+
+    async def run(
+        self,
+        definition: WorkflowDefinition,
+        parameters: Mapping[str, object],
+        *,
+        idempotency_key: str | None = None,
+    ) -> object:
+        """Execute one definition, optionally idempotently, and return its result."""
+
+    async def submit(
+        self,
+        definition: WorkflowDefinition,
+        parameters: Mapping[str, object],
+        *,
+        idempotency_key: str | None = None,
+    ) -> WorkflowRunHandle:
+        """Accept one definition with an optional run-creation key."""
+
+
+class ExecutorClosedError(RuntimeError):
+    """A local executor was shut down and cannot accept further submissions."""
+
+
+class WorkflowNotFoundError(LookupError):
+    """The remote deployment named by a definition does not exist."""
+
+    target: str
+
+    def __init__(self, definition: WorkflowDefinition) -> None:
+        """Describe the missing ``flow_name/deployment_name`` target."""
+        self.target = definition.key
+        super().__init__(f"Prefect deployment {self.target!r} was not found")
+
+
+class FlowRunError(RuntimeError):
+    """A terminal local or remote workflow run cannot produce a normal result."""
+
+    run_id: str
+
+    def __init__(self, run_id: str, detail: str) -> None:
+        """Keep the execution identity with a narrowly classified failure."""
+        self.run_id = run_id
+        super().__init__(f"workflow run {run_id} {detail}")
+
+
+class FailedFlowRunError(FlowRunError):
+    """A workflow run failed, preserving its original local cause when present."""
+
+    def __init__(self, run_id: str) -> None:
+        """Describe a failed workflow run."""
+        super().__init__(run_id, "failed")
+
+
+class CrashedFlowRunError(FlowRunError):
+    """A remote run reached Prefect's crashed terminal state."""
+
+    def __init__(self, run_id: str) -> None:
+        """Describe a crashed workflow run."""
+        super().__init__(run_id, "crashed")
+
+
+class CancelledFlowRunError(FlowRunError):
+    """A local or remote workflow run reached a cancelled terminal state."""
+
+    def __init__(self, run_id: str) -> None:
+        """Describe a cancelled workflow run."""
+        super().__init__(run_id, "was cancelled")
+
+
+class MissingFlowRunResultError(FlowRunError):
+    """A remote run has no retrievable Prefect state or result."""
+
+    def __init__(self, run_id: str) -> None:
+        """Describe a remote run whose state or result is unavailable."""
+        super().__init__(run_id, "has no retrievable state or result")
+
+
+class _RemoteDeployment(Protocol):
+    """The deployment identity required to create a remote flow run."""
+
+    id: UUID
+
+
+class _RemoteFlowRun(Protocol):
+    """The subset of a Prefect flow-run response used by this feature."""
+
+    id: UUID
+    # Any: a Prefect state carries the consumer flow's arbitrary result type.
+    state: State[Any] | None
+
+
+class RemoteExecutionClient(Protocol):
+    """Injectable, offline-testable seam over the Prefect execution calls."""
+
+    async def read_deployment_by_name(self, name: str) -> _RemoteDeployment:
+        """Read a deployment by its ``flow_name/deployment_name`` target."""
+
+    async def create_flow_run_from_deployment(
+        self,
+        deployment_id: UUID,
+        *,
+        parameters: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> _RemoteFlowRun:
+        """Submit parameters and an optional server idempotency key."""
+
+    async def read_flow_run(self, flow_run_id: UUID) -> _RemoteFlowRun:
+        """Read the current remote flow-run state."""
+
+    async def set_flow_run_state(self, flow_run_id: UUID, state: State[Any]) -> object:
+        """Request a state transition for one remote flow run."""
+
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+
+    def _prefect_client_is_a_remote_execution_client(
+        client: PrefectClient,
+    ) -> RemoteWorkflowExecutor:
+        """Keep the real Prefect client structurally checked without connecting."""
+        return RemoteWorkflowExecutor(client)
+
+
+def _validated_flow_and_parameters(
+    definition: WorkflowDefinition, parameters: Mapping[str, object]
+) -> tuple[Flow[Any, Any], dict[str, object]]:
+    """Resolve a real flow and ask Prefect to validate its parameters.
+
+    Returns:
+        The resolved Prefect flow and its Prefect-normalized parameters.
+
+    Raises:
+        TypeError: If the definition does not resolve to a Prefect flow.
+        prefect.exceptions.ParameterTypeError: If Prefect rejects parameters.
+    """
+    flow = definition.load()
+    # Flow parameters are dynamic application values; Prefect owns their types.
+    validated: dict[str, Any] = flow.validate_parameters(dict(parameters))
+    return flow, dict(validated)
+
+
+async def _execute_local_flow(
+    flow: Flow[Any, Any], parameters: dict[str, object]
+) -> object:
+    """Call a validated Prefect flow's underlying function without an engine.
+
+    ``Flow.fn`` is intentionally used instead of invoking the ``Flow`` object:
+    calling a Flow can start Prefect's temporary server.  The object was still
+    resolved and parameter-validated by Prefect, while this execution remains
+    in-process and needs no server, worker, queue, child process, or history.
+    """
+    # Flow is intentionally dynamic after definition resolution; its fn has the
+    # consumer application's precise signature rather than a library signature.
+    flow_function = flow.fn
+    if inspect.iscoroutinefunction(flow_function):
+        return await flow_function(**parameters)
+    return await asyncio.to_thread(flow_function, **parameters)
+
+
+@dataclass(slots=True)
+class _LocalFlowRunHandle:
+    """A caller-owned reference to one local background asyncio task."""
+
+    _id: str
+    _task: asyncio.Task[object]
+
+    @property
+    def id(self) -> str:
+        """Return a local-only identity, never a Prefect flow-run ID."""
+        return self._id
+
+    async def status(self) -> ExecutionStatus:
+        """Return the task's current portable status."""
+        if not self._task.done():
+            return "running"
+        if self._task.cancelled():
+            return "cancelled"
+        if self._task.exception() is not None:
+            return "failed"
+        return "completed"
+
+    async def wait(self) -> ExecutionStatus:
+        """Wait for this task to finish without consuming its exception."""
+        try:
+            await asyncio.shield(self._task)
+        except asyncio.CancelledError:
+            if not self._task.cancelled():
+                raise
+        except Exception:
+            pass
+        return await self.status()
+
+    async def result(self) -> object:
+        """Return the retained result or raise the shared terminal error type."""
+        try:
+            return await asyncio.shield(self._task)
+        except asyncio.CancelledError as exc:
+            if self._task.cancelled():
+                raise CancelledFlowRunError(self.id) from exc
+            raise
+        except Exception as exc:
+            raise FailedFlowRunError(self.id) from exc
+
+    async def cancel(self) -> ExecutionStatus:
+        """Cancel local asyncio work unless it is already terminal."""
+        if not self._task.done():
+            self._task.cancel()
+            await self.wait()
+        return await self.status()
+
+
+class LocalWorkflowExecutor:
+    """Run flow functions locally without a Prefect server, context, or engine."""
+
+    _active_tasks: set[asyncio.Task[object]]
+    _closed: bool
+
+    def __init__(self) -> None:
+        """Create an executor with no active tasks and open submissions."""
+        self._active_tasks = set()
+        self._closed = False
+
+    async def run(
+        self, definition: WorkflowDefinition, parameters: Mapping[str, object]
+    ) -> object:
+        """Execute a flow and wait for its result.
+
+        Raises:
+            ExecutorClosedError: If shutdown has started.
+            prefect.exceptions.ParameterTypeError: If Prefect rejects parameters.
+            FailedFlowRunError: If the flow fails, with its original exception
+                chained as the cause.
+            CancelledFlowRunError: If a concurrent shutdown cancels the local
+                task before it completes.
+        """
+        handle = await self.submit(definition, parameters)
+        return await handle.result()
+
+    async def submit(
+        self, definition: WorkflowDefinition, parameters: Mapping[str, object]
+    ) -> WorkflowRunHandle:
+        """Validate and start a local background flow task.
+
+        The returned handle owns its task after completion.  This executor
+        removes completed tasks from its active set and retains no history.
+
+        Raises:
+            ExecutorClosedError: If shutdown has started.
+            prefect.exceptions.ParameterTypeError: If Prefect rejects parameters.
+        """
+        if self._closed:
+            raise ExecutorClosedError("local executor is shut down")
+        flow, validated = _validated_flow_and_parameters(definition, parameters)
+        task = asyncio.create_task(_execute_local_flow(flow, validated))
+        self._active_tasks.add(task)
+        task.add_done_callback(self._complete_task)
+        return _LocalFlowRunHandle(f"local:{uuid4()}", task)
+
+    def _complete_task(self, task: asyncio.Task[object]) -> None:
+        """Drop active tracking and consume discarded task exceptions safely."""
+        self._active_tasks.discard(task)
+        if not task.cancelled():
+            task.exception()
+
+    async def shutdown(self, *, timeout: float = 5.0) -> None:
+        """Stop accepting work, drain it briefly, then cancel pending tasks.
+
+        Args:
+            timeout: Maximum seconds to wait for active tasks before cancelling
+                the ones still pending.  Must be non-negative.
+
+        Raises:
+            ValueError: If ``timeout`` is negative.
+        """
+        if timeout < 0:
+            raise ValueError("shutdown timeout must be non-negative")
+        self._closed = True
+        tasks = tuple(self._active_tasks)
+        if not tasks:
+            return
+        _, pending = await asyncio.wait(tasks, timeout=timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _status_for_state(state: State[Any] | None) -> ExecutionStatus:
+    """Map Prefect state, including absent API state, into portable statuses."""
+    if state is None:
+        return "failed"
+    if state.is_completed():
+        return "completed"
+    if state.is_failed():
+        return "failed"
+    if state.is_crashed():
+        return "crashed"
+    if state.is_cancelled():
+        return "cancelled"
+    if state.is_cancelling():
+        return "cancelling"
+    if state.is_final():
+        return "failed"
+    if state.is_running():
+        return "running"
+    return "pending"
+
+
+@dataclass(slots=True)
+class _RemoteFlowRunHandle:
+    """A handle for a real Prefect server flow run."""
+
+    _client: RemoteExecutionClient
+    _flow_run_id: UUID
+    _poll_interval: float
+
+    @property
+    def id(self) -> str:
+        """Return the server-assigned Prefect flow-run ID."""
+        return str(self._flow_run_id)
+
+    async def _state(self) -> State[Any] | None:
+        """Read the latest state; ``None`` is an unrecoverable missing state."""
+        return (await self._client.read_flow_run(self._flow_run_id)).state
+
+    async def status(self) -> ExecutionStatus:
+        """Read and map the current server state."""
+        return _status_for_state(await self._state())
+
+    async def _wait_for_terminal_state(self) -> State[Any] | None:
+        """Poll until final, stopping immediately when Prefect omits state."""
+        while True:
+            state = await self._state()
+            if state is None or state.is_final():
+                return state
+            await asyncio.sleep(self._poll_interval)
+
+    async def wait(self) -> ExecutionStatus:
+        """Wait for a terminal server state and return its portable status."""
+        return _status_for_state(await self._wait_for_terminal_state())
+
+    async def result(self) -> object:
+        """Return the completed result or raise a typed terminal-state error."""
+        state = await self._wait_for_terminal_state()
+        if state is None:
+            raise MissingFlowRunResultError(self.id)
+        if state.is_crashed():
+            raise CrashedFlowRunError(self.id)
+        if state.is_failed():
+            raise FailedFlowRunError(self.id)
+        if state.is_cancelled():
+            raise CancelledFlowRunError(self.id)
+        if not state.is_completed():
+            raise FailedFlowRunError(self.id)
+        try:
+            result = state.result()
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        except MissingResult as exc:
+            raise MissingFlowRunResultError(self.id) from exc
+
+    async def cancel(self) -> ExecutionStatus:
+        """Request server cancellation unless the flow run is already terminal."""
+        state = await self._state()
+        if state is None or state.is_final():
+            return await self.status()
+        await self._client.set_flow_run_state(self._flow_run_id, Cancelling())
+        return await self.status()
+
+
+class RemoteWorkflowExecutor:
+    """Submit declared flows to already-created Prefect deployments."""
+
+    _client: RemoteExecutionClient
+    _poll_interval: float
+
+    def __init__(
+        self, client: RemoteExecutionClient, *, poll_interval: float = 1.0
+    ) -> None:
+        """Use an application-owned Prefect client to execute deployments.
+
+        Args:
+            client: An open Prefect orchestration client.  The application owns
+                its context-manager lifetime for every returned handle.
+            poll_interval: Seconds between remote state reads while waiting.
+
+        Raises:
+            ValueError: If ``poll_interval`` is negative.
+        """
+        if poll_interval < 0:
+            raise ValueError("poll interval must be non-negative")
+        self._client = client
+        self._poll_interval = poll_interval
+
+    async def run(
+        self,
+        definition: WorkflowDefinition,
+        parameters: Mapping[str, object],
+        *,
+        idempotency_key: str | None = None,
+    ) -> object:
+        """Submit a deployment, optionally idempotently, and return its result.
+
+        The key is passed unchanged to Prefect. Consumers own its derivation,
+        stability, and privacy.
+        """
+        handle = await self.submit(
+            definition, parameters, idempotency_key=idempotency_key
+        )
+        return await handle.result()
+
+    async def submit(
+        self,
+        definition: WorkflowDefinition,
+        parameters: Mapping[str, object],
+        *,
+        idempotency_key: str | None = None,
+    ) -> WorkflowRunHandle:
+        """Validate parameters and submit to the named remote deployment.
+
+        ``idempotency_key`` is passed unchanged to Prefect. Consumers own its
+        derivation, stability, and privacy; the executor stores no key registry.
+
+        Raises:
+            WorkflowNotFoundError: If the named deployment does not exist.
+            prefect.exceptions.ParameterTypeError: If Prefect rejects parameters.
+        """
+        _, validated = _validated_flow_and_parameters(definition, parameters)
+        try:
+            deployment = await self._client.read_deployment_by_name(definition.key)
+            flow_run = await self._client.create_flow_run_from_deployment(
+                deployment.id,
+                parameters=validated,
+                idempotency_key=idempotency_key,
+            )
+        except ObjectNotFound as exc:
+            raise WorkflowNotFoundError(definition) from exc
+        return _RemoteFlowRunHandle(self._client, flow_run.id, self._poll_interval)

--- a/opsmill_prefect_extras/workflows/__init__.py
+++ b/opsmill_prefect_extras/workflows/__init__.py
@@ -1,0 +1,195 @@
+"""Declarative workflow definitions and catalogue.
+
+Public import surface for the ``workflows`` feature: describe Prefect
+deployments as immutable data, compose them explicitly into a catalogue, and
+validate the whole catalogue offline -- no network, no Prefect server -- in one
+call. Catalogue construction, lookup, iteration and rendering import no
+workflow implementation module; the references are resolved only by explicit
+``load()`` and validation calls, which is how validation detects a rename.
+
+Example:
+    The 60-second tour, for a consuming application called ``example_app``. Each
+    block below is a complete module. They are parsed straight out of this
+    docstring and executed verbatim by ``tests/workflows/test_example.py``, so
+    an example that stopped working would fail the suite rather than rot.
+
+    The flows are ordinary Prefect flows, written as they always are -- they
+    know nothing about any catalogue::
+
+        # example_app/inventory/flows.py
+        from prefect import flow
+
+
+        @flow(name="inventory-refresh")
+        def refresh_inventory() -> str:
+            return "refreshed"
+
+    Beside them, the domain declares its workflows as data. This module
+    imports nothing from ``example_app.inventory.flows``: it only names it::
+
+        # example_app/inventory/workflows.py
+        from opsmill_prefect_extras.workflows import WorkflowDefinition
+
+        INVENTORY_REFRESH = WorkflowDefinition(
+            flow_name="inventory-refresh",   # the flow's own name, and ...
+            deployment_name="scheduled",     # ... a distinct deployment name
+            module="example_app.inventory.flows",  # resolved on demand
+            function="refresh_inventory",
+            tags=("inventory",),
+            cron="0 2 * * *",
+            concurrency_limit=1,
+            collision_strategy="CANCEL_NEW",
+        )
+
+        # A "definition group" is any iterable of definitions -- there is no
+        # group class to subclass, no decorator, and no import-time
+        # registration: the tuple below *is* the group.
+        INVENTORY_WORKFLOWS = (INVENTORY_REFRESH,)
+
+    A second domain package has exactly the same shape::
+
+        # example_app/reports/flows.py
+        from prefect import flow
+
+
+        @flow(name="reports")
+        def nightly_report() -> str:
+            return "reported"
+
+    ::
+
+        # example_app/reports/workflows.py
+        from opsmill_prefect_extras.workflows import WorkflowDefinition
+
+        REPORT_WORKFLOWS = (
+            WorkflowDefinition(
+                flow_name="reports",
+                deployment_name="nightly",
+                module="example_app.reports.flows",
+                function="nightly_report",
+                tags=("reports",),
+            ),
+        )
+
+    The application composes the groups once, at its own composition root.
+    Composition, lookup and rendering import no flow module at all -- an
+    author adding a workflow edits only their own package::
+
+        # example_app/composition.py
+        from example_app.inventory.workflows import INVENTORY_WORKFLOWS
+        from example_app.reports.workflows import REPORT_WORKFLOWS
+        from opsmill_prefect_extras.workflows import WorkflowCatalogue
+
+        CATALOGUE = WorkflowCatalogue(INVENTORY_WORKFLOWS, REPORT_WORKFLOWS)
+
+        definition = CATALOGUE["inventory-refresh/scheduled"]
+        payload = definition.to_deployment_input()
+        # {
+        #     "name": "scheduled",
+        #     "tags": ["inventory"],
+        #     "schedules": [{"schedule": {"cron": "0 2 * * *"}}],
+        #     "concurrency_limit": 1,
+        #     "concurrency_options": {"collision_strategy": "CANCEL_NEW"},
+        # }
+
+    ``payload`` splats into Prefect's ``create_deployment`` alongside the
+    server-assigned ``flow_id``, which the payload deliberately omits. Settings
+    the definition does not carry -- ``entrypoint`` here -- are absent keys,
+    never defaults invented by this library.
+
+    One import wires the shipped check into the application's own test suite.
+    It resolves every definition in the catalogue and fails naming every
+    broken one at once, so a renamed flow function is one CI failure rather
+    than a hunt::
+
+        # tests/test_workflow_catalogue.py
+        from example_app.composition import CATALOGUE
+        from opsmill_prefect_extras.workflows import assert_valid_definitions
+
+
+        def test_workflow_catalogue_resolves() -> None:
+            assert_valid_definitions(CATALOGUE)
+
+    Omitting ``deployment_name`` defaults it to ``flow_name``, giving the key
+    ``name/name``; every other optional setting simply stays out of the
+    rendering.
+"""
+
+from typing import TYPE_CHECKING
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+if TYPE_CHECKING:
+    from opsmill_prefect_extras.workflows.catalogue import (
+        DuplicateWorkflowError,
+        WorkflowCatalogue,
+    )
+    from opsmill_prefect_extras.workflows.validation import (
+        DefinitionFailure,
+        ValidationReport,
+        assert_valid_definitions,
+        validate_definitions,
+    )
+
+__all__: list[str] = [
+    "DefinitionFailure",
+    "DuplicateWorkflowError",
+    "ValidationReport",
+    "WorkflowCatalogue",
+    "WorkflowDefinition",
+    "assert_valid_definitions",
+    "validate_definitions",
+]
+
+
+def __getattr__(name: str) -> object:
+    """Load a workflow helper only when its public name is requested.
+
+    Importing the definitions submodule is a common-core operation used by
+    independent features.  Deferring the catalogue and validation facades
+    keeps that import from initializing those sibling modules.
+
+    Args:
+        name: The requested module attribute.
+
+    Returns:
+        The requested public workflow helper.
+
+    Raises:
+        AttributeError: If ``name`` is not part of this module's public API.
+    """
+    if name in {"DuplicateWorkflowError", "WorkflowCatalogue"}:
+        from opsmill_prefect_extras.workflows.catalogue import (
+            DuplicateWorkflowError,
+            WorkflowCatalogue,
+        )
+
+        return {
+            "DuplicateWorkflowError": DuplicateWorkflowError,
+            "WorkflowCatalogue": WorkflowCatalogue,
+        }[name]
+    if name in {
+        "DefinitionFailure",
+        "ValidationReport",
+        "assert_valid_definitions",
+        "validate_definitions",
+    }:
+        from opsmill_prefect_extras.workflows.validation import (
+            DefinitionFailure,
+            ValidationReport,
+            assert_valid_definitions,
+            validate_definitions,
+        )
+
+        return {
+            "DefinitionFailure": DefinitionFailure,
+            "ValidationReport": ValidationReport,
+            "assert_valid_definitions": assert_valid_definitions,
+            "validate_definitions": validate_definitions,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Expose lazy public names to interactive and documentation tooling."""
+    return sorted(set(globals()) | set(__all__))

--- a/opsmill_prefect_extras/workflows/_prefect_input_validation.py
+++ b/opsmill_prefect_extras/workflows/_prefect_input_validation.py
@@ -1,0 +1,205 @@
+"""Prefect's and pydantic's error shapes, understood in exactly one place.
+
+This module is the boundary that understands third-party internals: the shape of
+a pydantic validation error's entries (``loc`` / ``msg`` / ``input``), the way
+Prefect's schedule union labels the branch each complaint came from, and the
+``DeploymentCreate`` construction that asks Prefect for its verdict at all.
+Those are the feature's only real version-sensitive knowledge, so they are
+quarantined here rather than spread through the stable domain model: nothing in
+``validation.py`` -- which owns the public report types -- reads a third-party
+error entry, and nothing outside this module names a
+``prefect.client.schemas`` type.
+
+Asking Prefect at all is a deliberate decision: a value is invalid exactly when
+Prefect's own client-side deployment-input schema rejects it, and this library
+invents no validity rules on top of that verdict. What lives here is only the
+*reading* of it, which is where the version risk actually sits: at Prefect 3.8.1
+one unparseable cron arrives as six error entries, five of them branch noise.
+
+Private to the feature: nothing here is exported from
+``opsmill_prefect_extras.workflows``, and ``validation.py`` is the public facade
+over it. Depends *downward* on ``definitions.py`` -- this feature's common
+internal module -- and never upward on the facade, so the two cannot cycle.
+
+Nothing here contacts a Prefect server or the network: the schema construction
+is a local pydantic parse, and the sentinel ``flow_id`` never leaves this
+module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# Any: values read off a third-party schema rejection, whose shapes come from
+# Prefect's own dependency; the readers below narrow each one at runtime.
+from typing import Any, TypeAlias, cast
+from uuid import UUID
+
+from prefect.client.schemas.actions import DeploymentCreate
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+# TypeAlias, not a PEP 695 ``type`` statement: this package supports Python
+# 3.11 (``requires-python = ">=3.11"``), where the ``type`` statement does not
+# parse.
+ErrorEntry: TypeAlias = Mapping[str, Any]
+"""One structured entry off a schema rejection -- an untyped third-party mapping
+from field name to path, complaint or rejected input."""
+
+ErrorLocation: TypeAlias = tuple[Any, ...]
+"""The path to a rejected value, mixing field names with sequence indices."""
+
+_SENTINEL_FLOW_ID: UUID = UUID("00000000-0000-0000-0000-000000000000")
+"""Stand-in for the server-assigned ``flow_id``, which ``DeploymentCreate``
+requires but no offline check can know. Internal to validation: it is never
+rendered, returned, or sent anywhere."""
+
+_SCHEDULES_FIELD: str = "schedules"
+_SCHEDULE_FIELD: str = "schedule"
+_SCHEDULE_TYPE_MARKER: str = "Schedule"
+_CRON_BRANCH: str = "CronSchedule"
+
+
+def rejected_input_messages(definition: WorkflowDefinition) -> tuple[str, ...]:
+    """Ask Prefect whether it accepts this definition's deployment input.
+
+    The question is put the way Prefect's own client puts it -- by constructing
+    ``DeploymentCreate`` -- with a sentinel ``flow_id`` standing in for the
+    server-assigned one. Purely local; nothing is sent anywhere.
+
+    Args:
+        definition: The definition to render and submit to the schema.
+
+    Returns:
+        One message per rejected value, empty when Prefect accepts the payload.
+        Reporting those messages against their definition is the facade's job,
+        not this module's.
+    """
+    try:
+        DeploymentCreate(flow_id=_SENTINEL_FLOW_ID, **definition.to_deployment_input())
+    # Any failure here is *treated as* invalid input -- a deliberate fallback
+    # policy, not a certainty about what Prefect meant. It keeps one bad
+    # definition from destroying the aggregate report, at the price of also
+    # classifying an unexpected Prefect internal error, or a bug in the payload
+    # construction above, as invalid input.
+    except Exception as exc:
+        return _rejection_messages(exc)
+    return ()
+
+
+def exception_text(exc: BaseException) -> str:
+    """Describe an exception as ``TypeName: message``, degrading if it cannot.
+
+    Shared with the facade, whose resolution checks read exceptions inside the
+    same kind of broad handler.
+
+    Args:
+        exc: The exception to describe.
+
+    Returns:
+        ``"TypeName: message"``, or the type name alone when the exception's own
+        ``__str__`` raises. Rendering runs inside the broad handlers this
+        feature relies on, so a rendering failure has to degrade to a
+        still-useful defect rather than escape
+        :func:`~opsmill_prefect_extras.workflows.validation.validate_definitions`.
+    """
+    try:
+        return f"{type(exc).__name__}: {exc}"
+    except Exception:
+        return type(exc).__name__
+
+
+def _rejection_messages(exc: Exception) -> tuple[str, ...]:
+    """Turn a schema rejection into one message per rejected value.
+
+    The read assumes pydantic's documented ``ValidationError.errors()``
+    contract, duck-called rather than imported: pydantic reaches this library
+    only through Prefect, so naming it directly would make an undeclared
+    package part of this feature's dependencies. Any deviation from that
+    contract -- a rejection with no ``errors()``, an entry that cannot be
+    read -- degrades the whole rejection to the exception's own text rather
+    than escaping, preserving
+    :func:`~opsmill_prefect_extras.workflows.validation.validate_definitions`'s
+    promise never to raise.
+
+    Returns:
+        One message per rejected value, or the exception's own text when the
+        entries could not be read -- never empty, so a rejection is always at
+        least one defect.
+    """
+    try:
+        entries: Any = cast("Any", exc).errors()
+        messages = [
+            _rejection_message(entry)
+            for entry in entries
+            if not _is_other_schedule_branch(_entry_loc(entry))
+        ]
+    except Exception:
+        messages = []
+    if not messages:
+        messages.append(exception_text(exc))
+    return tuple(messages)
+
+
+def _entry_loc(entry: ErrorEntry) -> ErrorLocation:
+    """Read an entry's location path."""
+    return tuple(entry.get("loc", ()))
+
+
+def _schedule_branch(location: ErrorLocation) -> tuple[int, str] | None:
+    """Locate the schedule-union branch in an error path, if one is present."""
+    if len(location) < 5:
+        return None
+    for schedules_index, part in enumerate(location[:-4]):
+        if (
+            part != _SCHEDULES_FIELD
+            or not isinstance(location[schedules_index + 1], int)
+            or location[schedules_index + 2] != _SCHEDULE_FIELD
+        ):
+            continue
+        for branch_index in range(schedules_index + 3, len(location) - 1):
+            branch = location[branch_index]
+            if isinstance(branch, str) and _SCHEDULE_TYPE_MARKER in branch:
+                return branch_index, branch
+    return None
+
+
+def _is_other_schedule_branch(location: ErrorLocation) -> bool:
+    """Whether an error is noise from a schedule branch we never render.
+
+    A rendered cron schedule is checked against every branch of Prefect's
+    schedule union, and each branch that is not the cron one complains about the
+    shape it expected instead: at Prefect 3.8.1 a single unparseable cron
+    produces six errors, of which one is the cron branch's real verdict and five
+    are branch noise -- three rejecting ``cron`` as an extra input (interval,
+    rrule, no-schedule) and two demanding the ``interval`` and ``rrule`` fields
+    the payload never carried. Only the cron branch's verdict is about the value
+    the definition actually holds; reporting the rest would bury it.
+    """
+    branch = _schedule_branch(location)
+    return branch is not None and _CRON_BRANCH not in branch[1]
+
+
+def _rejection_message(entry: ErrorEntry) -> str:
+    """Render a rejected value as its path, Prefect's complaint, and the value."""
+    location = _entry_loc(entry)
+    path = _rendered_path(location)
+    complaint = str(entry.get("msg", "rejected by Prefect"))
+    if "input" in entry:
+        return f"{path}: {complaint} (got {entry['input']!r})"
+    return f"{path}: {complaint}"
+
+
+def _rendered_path(location: ErrorLocation) -> str:
+    """Render an error location as a dotted path, e.g. ``schedules.0.schedule.cron``.
+
+    The schedule-union branch tag is dropped: it names an internal schema
+    branch, not a field of the payload the definition rendered.
+    """
+    branch = _schedule_branch(location)
+    if branch is None:
+        parts = location
+    else:
+        index, _ = branch
+        parts = (*location[:index], *location[index + 1 :])
+    return ".".join(str(part) for part in parts) or "<deployment input>"

--- a/opsmill_prefect_extras/workflows/catalogue.py
+++ b/opsmill_prefect_extras/workflows/catalogue.py
@@ -1,0 +1,230 @@
+"""The immutable, explicitly composed workflow catalogue.
+
+Depends *downward* on ``definitions.py`` -- this feature's common internal
+module -- and on nothing else beyond the standard library. It never imports a
+sibling feature, and it never imports a workflow implementation module: a
+catalogue handles a definition's ``module`` and ``function`` strings only by
+storing them.
+
+There is no global registry, no decorator, and no import-time side effect. An
+application builds its catalogue by calling :class:`WorkflowCatalogue` at its
+own composition root, passing definitions and "definition groups" -- which are
+plain iterables, not a class of ours.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from opsmill_prefect_extras.workflows.definitions import (
+    _KEY_FORMAT,
+    WorkflowDefinition,
+)
+
+MAX_LISTED_KEYS: int = 10
+"""How many known keys a lookup-miss message lists before summarizing."""
+
+
+class DuplicateWorkflowError(ValueError):
+    """Two composed definitions claim one deployment identity.
+
+    A :exc:`ValueError` subclass, so a caller who does not import this name
+    still catches the collision conventionally. The colliding
+    ``flow_name/deployment_name`` is available as :attr:`key` and appears in
+    the message.
+
+    Attributes:
+        key: The identity both definitions rendered, as
+            ``flow_name/deployment_name``.
+    """
+
+    key: str
+
+    def __init__(self, key: str) -> None:
+        """Report the collision, naming the identity both definitions claim.
+
+        Args:
+            key: The colliding ``flow_name/deployment_name`` identity.
+        """
+        super().__init__(
+            f"{key!r} is claimed by two composed definitions -- a deployment "
+            f"identity ({_KEY_FORMAT}) is unique to one definition, whether "
+            f"they were supplied individually, within one group, or across "
+            f"groups; compose one of them out, or give it its own deployment "
+            f"name"
+        )
+        self.key = key
+
+
+class WorkflowCatalogue:
+    """An immutable collection of workflow definitions, keyed by identity.
+
+    Composed explicitly and read-only thereafter: there are no mutator
+    methods, so building a different catalogue is the only way to get
+    different contents.
+
+    Deliberately **not** a :class:`collections.abc.Mapping`: iteration yields
+    definitions rather than keys, because the definition is what every consumer
+    goes on to use. Keys remain available through :meth:`keys` and
+    ``key in catalogue``.
+
+    Example:
+        Composing this imports nothing from ``example_app`` -- not even the modules
+        the definitions name::
+
+            from opsmill_prefect_extras.workflows import (
+                WorkflowCatalogue,
+                WorkflowDefinition,
+            )
+
+            INVENTORY_REFRESH = WorkflowDefinition(
+                flow_name="inventory-refresh",
+                deployment_name="scheduled",
+                module="example_app.inventory.flows",
+                function="refresh_inventory",
+                tags=("inventory",),
+            )
+            # A "definition group" is any iterable of definitions.
+            REPORT_WORKFLOWS = (
+                WorkflowDefinition(
+                    flow_name="reports",
+                    deployment_name="nightly",
+                    module="example_app.reports.flows",
+                    function="nightly_report",
+                ),
+            )
+
+            CATALOGUE = WorkflowCatalogue(INVENTORY_REFRESH, REPORT_WORKFLOWS)
+
+            CATALOGUE["inventory-refresh/scheduled"]          # lookup by key
+            [definition.key for definition in CATALOGUE]       # composition order
+            "inventory-refresh/scheduled" in CATALOGUE         # True
+    """
+
+    __slots__ = ("_definitions",)
+
+    _definitions: dict[str, WorkflowDefinition]
+
+    def __init__(
+        self, *sources: WorkflowDefinition | Iterable[WorkflowDefinition]
+    ) -> None:
+        """Compose a catalogue from definitions and definition groups.
+
+        Sources are flattened in argument order; a group contributes its
+        definitions in its own iteration order, at its position among the
+        arguments. Nothing is imported and nothing is resolved: ``module`` and
+        ``function`` are only stored. Composing no sources at all yields a
+        valid, empty catalogue.
+
+        Args:
+            *sources: Each either a single :class:`WorkflowDefinition` or any
+                iterable of them (a "definition group" -- domain packages
+                declare plain tuples). Iterables are consumed once, here, so
+                generators are fine.
+
+        Raises:
+            DuplicateWorkflowError: If two of the flattened definitions share a
+                ``(flow_name, deployment_name)`` identity, however they were
+                supplied. Raised on the second occurrence, so no definition is
+                ever silently overwritten.
+        """
+        definitions: dict[str, WorkflowDefinition] = {}
+        seen_identities: set[tuple[str, str]] = set()
+        for source in sources:
+            group: Iterable[WorkflowDefinition]
+            if isinstance(source, WorkflowDefinition):
+                group = (source,)
+            else:
+                group = source
+            for definition in group:
+                # The identity tuple, not the rendered key, is the detection
+                # basis; the two agree because `/` is banned in both
+                # name halves, which is what keeps the key injective.
+                identity = (definition.flow_name, definition.deployment_name)
+                if identity in seen_identities:
+                    raise DuplicateWorkflowError(definition.key)
+                seen_identities.add(identity)
+                definitions[definition.key] = definition
+
+        self._definitions = definitions
+
+    def __getitem__(self, key: str) -> WorkflowDefinition:
+        """Look a definition up by its ``flow_name/deployment_name`` key.
+
+        Args:
+            key: The definition's derived key.
+
+        Returns:
+            The stored definition.
+
+        Raises:
+            KeyError: If no definition has that key -- never a silent
+                default. The message names the missing key, states the key
+                convention, and lists the known keys, so the commonest miss
+                (a bare flow name) corrects itself. It is a single line on
+                purpose: :exc:`KeyError` reprs its argument, which would
+                otherwise escape the newlines.
+        """
+        try:
+            return self._definitions[key]
+        except KeyError:
+            raise KeyError(self._lookup_miss_message(key)) from None
+
+    def __iter__(self) -> Iterator[WorkflowDefinition]:
+        """Iterate the definitions -- not the keys -- in composition order.
+
+        Returns:
+            An iterator over the definitions, ordered as they were composed.
+        """
+        return iter(self._definitions.values())
+
+    def __len__(self) -> int:
+        """Count the definitions.
+
+        Returns:
+            How many definitions this catalogue holds.
+        """
+        return len(self._definitions)
+
+    def __contains__(self, item: object) -> bool:
+        """Test membership of a key.
+
+        Args:
+            item: A ``flow_name/deployment_name`` key, or anything else.
+
+        Returns:
+            ``True`` if a definition has that key; ``False`` for a miss and
+            for every non-``str`` object.
+        """
+        return isinstance(item, str) and item in self._definitions
+
+    def keys(self) -> tuple[str, ...]:
+        """List the keys in composition order.
+
+        Returns:
+            Every definition's key as a tuple, ordered like iteration.
+        """
+        return tuple(self._definitions)
+
+    def _lookup_miss_message(self, key: str) -> str:
+        """Build the actionable lookup-miss message.
+
+        Args:
+            key: The key that was asked for and not found.
+
+        Returns:
+            A single-line message naming the missing key, the key convention,
+            the total number of known keys, and up to
+            :data:`MAX_LISTED_KEYS` of them.
+        """
+        known = self.keys()
+        listed = ", ".join(known[:MAX_LISTED_KEYS])
+        if not known:
+            listed = "<none -- this catalogue is empty>"
+        elif len(known) > MAX_LISTED_KEYS:
+            listed = f"{listed}, ... (+{len(known) - MAX_LISTED_KEYS} more)"
+        return (
+            f"{key!r} is not in this catalogue -- keys are rendered as "
+            f"{_KEY_FORMAT}, so a bare flow name never matches; "
+            f"{len(known)} known key(s): {listed}"
+        )

--- a/opsmill_prefect_extras/workflows/definitions.py
+++ b/opsmill_prefect_extras/workflows/definitions.py
@@ -1,0 +1,292 @@
+"""Immutable workflow definitions -- this feature's **common internal module**.
+
+This module is the ``workflows`` feature's designated **common internal
+module**: the one place a shape shared across the feature lives, and this
+docstring is the durable in-package record of that designation. ``catalogue.py``
+and ``validation.py`` depend *downward* on it; it depends on nothing but the
+standard library and ``prefect.flows.Flow``. Nothing here may ever import a
+sibling module of this package, and any future feature that needs the
+workflow-definition shape depends on this module rather than sideways on a
+peer feature.
+
+Its dependency floor is deliberate: every version-risky
+``prefect.client.schemas`` name -- ``DeploymentCreate``, and whatever else
+asking Prefect for its verdict requires -- lives in the private
+``_prefect_input_validation`` adapter alone, behind the ``validation.py``
+facade, so the value object every consumer touches keeps working across the
+whole declared Prefect range.
+
+A ``WorkflowDefinition`` describes one Prefect deployment by data only -- names,
+a dotted ``module``/``function`` import reference, and execution settings. It
+holds no callable, resolves nothing at construction, and judges no value's
+validity: that is Prefect's call, made in ``validation.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from prefect.flows import Flow
+
+_KEY_SEPARATOR: str = "/"
+"""Separator rendering a definition's key as ``flow_name/deployment_name``."""
+
+_KEY_FORMAT: str = "flow_name/deployment_name"
+"""The key convention as diagnostics state it. Every message that names the
+convention renders this."""
+
+
+def _not_a_flow_message(*, module: str, function: str, resolved: object) -> str:
+    """Describe a reference that resolved to something other than a Prefect flow.
+
+    Shared by :meth:`WorkflowDefinition.load`, which raises it prefixed with the
+    definition's key, and by aggregate validation, which reports it unprefixed
+    as a validation message. One formatter is why the direct-load and
+    aggregate-validation wordings for the same fact cannot drift apart.
+
+    Args:
+        module: Dotted module path the reference named.
+        function: Attribute name read off that module.
+        resolved: Whatever the reference resolved to instead of a flow; only its
+            type is rendered.
+
+    Returns:
+        The diagnostic, with no leading key prefix -- a caller that wants one
+        adds it.
+    """
+    return (
+        f"{module}:{function} is not a Prefect flow -- resolved a "
+        f"{type(resolved).__name__} instead (is the @flow decorator missing?)"
+    )
+
+
+@dataclass(frozen=True, kw_only=True, slots=True, init=False)
+class WorkflowDefinition:
+    """One Prefect workflow, described entirely by data.
+
+    Immutable (assignment raises :exc:`dataclasses.FrozenInstanceError`) and
+    keyword-only: the flow and deployment names are both bare strings, so
+    positional construction would invite silent identity mixups.
+
+    The declared annotations below are the honest *attribute* types -- what a
+    consumer reads back off an instance. The ergonomic parameter types live on
+    :meth:`__init__`, which normalizes and then freezes the values.
+
+    Attributes:
+        flow_name: Declared Prefect flow name, compared against the resolved
+            ``Flow.name`` during validation. Must not contain ``/``.
+        module: Dotted module path of the import reference, used only by
+            :meth:`load` and validation.
+        function: Attribute name of the flow object inside ``module``.
+        deployment_name: Deployment name; always a ``str`` after construction,
+            equal to ``flow_name`` when the caller supplied none. Must not
+            contain ``/``.
+        tags: Deployment tags, always a tuple, empty when none were given.
+        cron: Optional cron schedule. Validity is Prefect's judgment, not this
+            library's.
+        concurrency_limit: Optional deployment concurrency limit. Not
+            range-checked here -- Prefect's own deployment-input contract
+            decides what it accepts.
+        collision_strategy: Optional concurrency collision strategy. Prefect's
+            ``ConcurrencyLimitStrategy`` members are ``str`` instances, so they
+            pass through unchanged; at the installed Prefect version the valid
+            strategies are ``"ENQUEUE"`` and ``"CANCEL_NEW"``, and that enum --
+            ``prefect.client.schemas.objects.ConcurrencyLimitStrategy`` -- not
+            this docstring, is the authoritative set.
+        entrypoint: Optional explicit source entrypoint, distinct from the
+            ``module``/``function`` import reference. It appears only in
+            deployment-creation input and is never used for resolution.
+
+    Example:
+        Data only -- constructing this imports nothing from ``example_app``::
+
+            from opsmill_prefect_extras.workflows import WorkflowDefinition
+
+            INVENTORY_REFRESH = WorkflowDefinition(
+                flow_name="inventory-refresh",
+                deployment_name="scheduled",
+                module="example_app.inventory.flows",
+                function="refresh_inventory",
+                tags=("inventory",),
+                cron="0 2 * * *",
+                concurrency_limit=1,
+                collision_strategy="CANCEL_NEW",
+            )
+
+            INVENTORY_REFRESH.key                    # "inventory-refresh/scheduled"
+            INVENTORY_REFRESH.to_deployment_input()  # plain-data payload
+            INVENTORY_REFRESH.load()                 # imports the named module
+    """
+
+    flow_name: str
+    module: str
+    function: str
+    deployment_name: str
+    tags: tuple[str, ...]
+    cron: str | None = None
+    concurrency_limit: int | None = None
+    collision_strategy: str | None = None
+    entrypoint: str | None = None
+
+    def __init__(
+        self,
+        *,
+        flow_name: str,
+        module: str,
+        function: str,
+        deployment_name: str | None = None,
+        tags: Iterable[str] = (),
+        cron: str | None = None,
+        concurrency_limit: int | None = None,
+        collision_strategy: str | None = None,
+        entrypoint: str | None = None,
+    ) -> None:
+        """Normalize the ergonomic arguments, then freeze them.
+
+        Performs no resolution, no import of ``module``, and no validation of
+        any value's *validity* -- only the two shape checks below, which
+        protect this library's own signature and key grammar.
+
+        Args:
+            flow_name: Declared Prefect flow name.
+            module: Dotted module path holding the flow object.
+            function: Attribute name of the flow object inside ``module``.
+            deployment_name: Deployment name; ``None`` means "use
+                ``flow_name``".
+            tags: Any iterable of tags, normalized to a tuple. A bare ``str``
+                or ``bytes`` is refused rather than character-split.
+            cron: Optional cron schedule.
+            concurrency_limit: Optional deployment concurrency limit.
+            collision_strategy: Optional collision strategy -- at the
+                installed Prefect version, ``"ENQUEUE"`` or ``"CANCEL_NEW"``
+                (authoritative set: Prefect's ``ConcurrencyLimitStrategy``).
+            entrypoint: Optional explicit source entrypoint.
+
+        Raises:
+            TypeError: If ``tags`` is a bare ``str`` or ``bytes``, which would
+                otherwise be split into one tag per character.
+            ValueError: If ``flow_name`` or the resolved ``deployment_name``
+                contains ``/``, the separator this library renders keys with.
+        """
+        if isinstance(tags, (str, bytes)):
+            rendered = f'"{tags}"' if isinstance(tags, str) else repr(tags)
+            raise TypeError(
+                f"tags must be an iterable of tag strings, not a bare "
+                f"{type(tags).__name__} (it would be split into one tag per "
+                f"character) -- did you mean tags=({rendered},)?"
+            )
+
+        resolved_deployment_name = (
+            flow_name if deployment_name is None else deployment_name
+        )
+        for name, value in (
+            ("flow_name", flow_name),
+            ("deployment_name", resolved_deployment_name),
+        ):
+            if _KEY_SEPARATOR in value:
+                raise ValueError(
+                    f"{name} must not contain {_KEY_SEPARATOR!r}: {value!r} -- a "
+                    f"definition's key is rendered as {_KEY_FORMAT}, "
+                    f"so a separator inside either name would make keys "
+                    f"ambiguous (Prefect bans it in both names too)"
+                )
+
+        # object.__setattr__ is how a frozen dataclass populates its fields;
+        # going through it keeps the frozen/slots semantics intact.
+        object.__setattr__(self, "flow_name", flow_name)
+        object.__setattr__(self, "module", module)
+        object.__setattr__(self, "function", function)
+        object.__setattr__(self, "deployment_name", resolved_deployment_name)
+        object.__setattr__(self, "tags", tuple(tags))
+        object.__setattr__(self, "cron", cron)
+        object.__setattr__(self, "concurrency_limit", concurrency_limit)
+        object.__setattr__(self, "collision_strategy", collision_strategy)
+        object.__setattr__(self, "entrypoint", entrypoint)
+
+    @property
+    def key(self) -> str:
+        """The deployment identity, as ``flow_name/deployment_name``.
+
+        Returns:
+            The rendered key. Derived, never caller-supplied; injective,
+            because ``/`` is rejected in both name halves at construction.
+        """
+        return f"{self.flow_name}{_KEY_SEPARATOR}{self.deployment_name}"
+
+    # Flow[Any, Any]: the resolved flow's signature is the consumer's, not ours.
+    def load(self) -> Flow[Any, Any]:
+        """Resolve the implementing Prefect flow, fresh on every call.
+
+        Imports ``module``, reads ``function`` off it, and confirms the result
+        really is a Prefect flow. Nothing is cached, so the answer always
+        reflects the current state of the process -- a rename or reload between
+        calls is seen by the next one.
+
+        Returns:
+            The resolved :class:`prefect.flows.Flow` object.
+
+        Raises:
+            ModuleNotFoundError: If ``module`` does not exist. Propagated
+                unwrapped.
+            Exception: Whatever ``module`` itself raises at import time,
+                propagated unwrapped and never rewrapped as an
+                :exc:`ImportError`.
+            AttributeError: If ``module`` has no ``function`` attribute.
+            TypeError: If the resolved object is not a Prefect flow. The
+                message names this definition's key and the object's type.
+        """
+        module = importlib.import_module(self.module)
+        resolved = getattr(module, self.function)
+        if not isinstance(resolved, Flow):
+            # Prefixed with the key, which a direct call has and an aggregate
+            # report supplies for itself; the diagnostic itself is shared.
+            detail = _not_a_flow_message(
+                module=self.module, function=self.function, resolved=resolved
+            )
+            raise TypeError(f"{self.key}: {detail}")
+        return resolved
+
+    # dict[str, Any]: a deployment-creation payload is heterogeneous by nature.
+    def to_deployment_input(self) -> dict[str, Any]:
+        """Render this definition as deployment-creation input.
+
+        The keys are Prefect's own: parameter names of
+        ``PrefectClient.create_deployment`` / fields of
+        ``prefect.client.schemas.actions.DeploymentCreate``. Values are plain
+        data (strings, ints, lists, dicts -- no Prefect model instances), which
+        Prefect coerces into its typed schema on receipt, so the payload splats
+        into ``create_deployment`` alongside the server-assigned ``flow_id``.
+
+        ``name`` and ``tags`` are always present; every optional setting
+        appears only when it was supplied, because this library invents no
+        defaults for the ones that were not. ``flow_name`` is deliberately
+        absent -- ``create_deployment`` has no such parameter, and the
+        definition itself travels with the payload as the single handle. The
+        server-assigned ``flow_id`` is likewise absent.
+
+        Returns:
+            A fresh ``dict`` on every call, safe for the caller to mutate.
+
+        Raises:
+            Nothing. Rendering neither validates nor imports; invalid values
+            surface through validation, or when Prefect itself rejects the
+            payload downstream.
+        """
+        payload: dict[str, Any] = {
+            "name": self.deployment_name,
+            "tags": list(self.tags),
+        }
+        if self.entrypoint is not None:
+            payload["entrypoint"] = self.entrypoint
+        if self.cron is not None:
+            payload["schedules"] = [{"schedule": {"cron": self.cron}}]
+        if self.concurrency_limit is not None:
+            payload["concurrency_limit"] = self.concurrency_limit
+        if self.collision_strategy is not None:
+            payload["concurrency_options"] = {
+                "collision_strategy": self.collision_strategy
+            }
+        return payload

--- a/opsmill_prefect_extras/workflows/validation.py
+++ b/opsmill_prefect_extras/workflows/validation.py
@@ -1,0 +1,310 @@
+"""Aggregate validation of workflow definitions, plus the shipped pytest helper.
+
+One call over a whole catalogue returns one typed report of *every* defect in
+*every* definition, so a rename that breaks a declared reference is caught in
+CI with a single assertion rather than one failure at a time.
+
+Depends *downward* on ``definitions.py`` -- this feature's common internal
+module -- and on the private ``_prefect_input_validation`` adapter beside it;
+never sideways on a sibling feature.
+
+Two things about validity are deliberate:
+
+* **The library invents no validity rules.** A schedule, concurrency or
+  tag value is invalid exactly when Prefect's own client-side
+  deployment-input schema rejects it. At Prefect 3.8.1 that makes an
+  unparseable cron and an unknown collision strategy failures, while a
+  non-positive concurrency limit and coercible non-string tags are *not* --
+  Prefect accepts them.
+* **This module is the facade, not the adapter.** Asking Prefect and reading
+  its verdict -- every ``prefect.client.schemas`` name, every assumption about
+  pydantic's error entries -- lives in the private
+  ``_prefect_input_validation`` module, so the feature's version-sensitive
+  knowledge sits in one file and the report types every consumer touches stay
+  clear of it.
+
+Nothing here contacts a Prefect server or the network: the schema construction
+is a local pydantic parse in that adapter.
+
+A consumer's whole CI check is one import of :func:`assert_valid_definitions`
+and one call on their catalogue; the ``opsmill_prefect_extras.workflows``
+package docstring shows it in place, as part of an example the test suite
+executes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from prefect.flows import Flow
+
+from opsmill_prefect_extras.workflows._prefect_input_validation import (
+    exception_text,
+    rejected_input_messages,
+)
+from opsmill_prefect_extras.workflows.definitions import (
+    WorkflowDefinition,
+    _not_a_flow_message,
+)
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DefinitionFailure:
+    """One invalid definition, with every problem found in it.
+
+    A definition broken several ways appears once, carrying all its messages --
+    the report never splits one definition across entries.
+
+    Attributes:
+        definition: The failing definition itself, so a caller can inspect or
+            re-render it without a second lookup.
+        messages: Every problem found, each a human-readable description naming
+            the missing attribute, the rejected value, or whatever else
+            identifies it: at most one from the resolution axis (the deepest
+            one reachable) plus one per value Prefect rejected. Never empty.
+    """
+
+    definition: WorkflowDefinition
+    messages: tuple[str, ...]
+
+    @property
+    def key(self) -> str:
+        """The failing definition's ``flow_name/deployment_name`` key.
+
+        Derived from :attr:`definition` rather than stored, so the identity
+        :meth:`ValidationReport.summary` prints -- the text
+        :func:`assert_valid_definitions` raises with -- cannot disagree with the
+        definition it reports.
+
+        Returns:
+            ``definition.key``.
+        """
+        return self.definition.key
+
+    def __post_init__(self) -> None:
+        """Reject a failure with nothing wrong in it.
+
+        Raises:
+            ValueError: If ``messages`` is empty. A definition with no problem
+                is not a failure, and an empty entry would make the report lie
+                about which definitions are valid.
+        """
+        if not self.messages:
+            raise ValueError(
+                f"{self.key}: a DefinitionFailure must carry at least one "
+                f"message -- a definition with no problem is not a failure"
+            )
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ValidationReport:
+    """The typed result of validating a group of definitions.
+
+    Attributes:
+        failures: One entry per invalid definition, in the order the
+            definitions were supplied. Empty means everything is valid.
+    """
+
+    failures: tuple[DefinitionFailure, ...]
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether every validated definition was sound.
+
+        Returns:
+            ``True`` when there are no failures -- including the empty-input
+            case, which is valid by definition.
+        """
+        return not self.failures
+
+    def summary(self) -> str:
+        """Render the whole report as human-readable text.
+
+        This is the exact text :func:`assert_valid_definitions` raises with: a
+        header line, then every failing definition's key, then every problem
+        under it.
+
+        Returns:
+            A multi-line string naming every failing definition and each of its
+            problems; a single reassuring line when the report is valid.
+        """
+        if not self.failures:
+            return "all workflow definitions are valid"
+
+        lines = [f"{len(self.failures)} invalid workflow definition(s):"]
+        for failure in self.failures:
+            lines.append(f"  {failure.key}")
+            lines.extend(f"    {message}" for message in failure.messages)
+        return "\n".join(lines)
+
+
+def validate_definitions(
+    definitions: Iterable[WorkflowDefinition],
+) -> ValidationReport:
+    """Validate every definition and report every defect in one pass.
+
+    Each definition is checked on two independent axes, and both contribute:
+
+    1. **Resolution** -- import the module, read the attribute off it, confirm
+       it is a Prefect flow, confirm its name matches the declared one. The
+       deepest reachable problem is reported (a missing module says nothing
+       about the attribute, so only the import failure appears).
+    2. **Deployment input** -- render the definition and let Prefect's own
+       schema judge it, one message per value it rejects.
+
+    Resolution happens fresh on every call: nothing is cached, so a rename or
+    reload inside the process is seen by the next call.
+
+    Args:
+        definitions: Any iterable of definitions -- a
+            :class:`~opsmill_prefect_extras.workflows.catalogue.WorkflowCatalogue`
+            (which iterates definitions), a definition group, a chain of both.
+            Consumed once. An empty iterable is valid input.
+
+    Returns:
+        One :class:`ValidationReport`, with failures in input order. Valid
+        definitions are absent from it.
+
+    Raises:
+        Nothing for an invalid definition -- not even the exception a target
+        module raises while being imported. Raising is
+        :func:`assert_valid_definitions`'s job.
+
+    Example:
+        ::
+
+            report = validate_definitions(CATALOGUE)
+            if not report.is_valid:
+                print(report.summary())
+    """
+    failures: list[DefinitionFailure] = []
+    for definition in definitions:
+        messages: list[str] = []
+        resolution_message = _resolution_message(definition)
+        if resolution_message is not None:
+            messages.append(resolution_message)
+        messages.extend(rejected_input_messages(definition))
+        if messages:
+            failures.append(
+                DefinitionFailure(definition=definition, messages=tuple(messages))
+            )
+    return ValidationReport(failures=tuple(failures))
+
+
+def assert_valid_definitions(definitions: Iterable[WorkflowDefinition]) -> None:
+    """Fail a test run when any definition is invalid -- the shipped CI check.
+
+    Wraps :func:`validate_definitions` so a consumer gets the whole check as
+    one import. The failure is raised explicitly rather than through an
+    ``assert`` statement, so it survives ``python -O`` in a non-pytest CI
+    runner, where ``assert`` statements are stripped out.
+
+    Args:
+        definitions: Any iterable of definitions -- typically the consumer's
+            whole catalogue.
+
+    Returns:
+        ``None`` when every definition is valid.
+
+    Raises:
+        AssertionError: If any definition is invalid. The message is
+            :meth:`ValidationReport.summary` -- every failing definition with
+            every problem, not just the first.
+
+    Example:
+        A consumer's whole test body is one import of this function and one
+        call on their catalogue. The ``opsmill_prefect_extras.workflows``
+        package docstring shows that test module in full, and the suite
+        executes it.
+    """
+    report = validate_definitions(definitions)
+    if not report.is_valid:
+        raise AssertionError(report.summary())
+
+
+def _resolution_message(definition: WorkflowDefinition) -> str | None:
+    """Follow the import reference and describe the deepest problem found.
+
+    Args:
+        definition: The definition whose reference is being resolved.
+
+    Returns:
+        The deepest reachable resolution problem, or ``None`` when the
+        reference resolves to a correctly named Prefect flow.
+    """
+    try:
+        module = importlib.import_module(definition.module)
+    # A module body propagates its own exception type unwrapped, so catching
+    # ImportError alone would let an exploding module crash validation.
+    except Exception as exc:
+        return (
+            f"module {definition.module!r} could not be imported: {exception_text(exc)}"
+        )
+
+    try:
+        resolved = getattr(module, definition.function)
+    except AttributeError as exc:
+        return (
+            f"module {definition.module!r} has no attribute "
+            f"{definition.function!r} -- was the flow function renamed or "
+            f"moved?{_attribute_error_detail(definition, exc)}"
+        )
+    # A module that exports names lazily (a module-level ``__getattr__``,
+    # PEP 562) imports the backing module *here*, so reading an attribute off
+    # it can raise anything at all -- the same failure the import step above
+    # catches, arriving one step later. Letting it through would crash the
+    # whole aggregate report instead of naming this one offender.
+    except Exception as exc:
+        return (
+            f"module {definition.module!r} raised while attribute "
+            f"{definition.function!r} was being read off it: "
+            f"{exception_text(exc)} -- a lazily exported name imports its "
+            f"backing module at this point"
+        )
+
+    if not isinstance(resolved, Flow):
+        # The wording is shared with ``WorkflowDefinition.load``, which
+        # reports the same fact directly; only the key prefix differs.
+        return _not_a_flow_message(
+            module=definition.module,
+            function=definition.function,
+            resolved=resolved,
+        )
+
+    if resolved.name != definition.flow_name:
+        return (
+            f"declared flow name {definition.flow_name!r} does not match "
+            f"the resolved flow's name {resolved.name!r} "
+            f"({definition.module}:{definition.function})"
+        )
+
+    return None
+
+
+def _attribute_error_detail(definition: WorkflowDefinition, exc: AttributeError) -> str:
+    """Render an attribute error's own text, unless it says nothing new.
+
+    Reading a name off a plain module raises with exactly the fact the defect
+    message already states, so repeating it would double-report it. A module that
+    exports names lazily (a module-level ``__getattr__``, PEP 562) raises its own
+    :exc:`AttributeError` instead -- naming the backing module, the export map,
+    or whatever else it knows -- and that text is the only place the real cause
+    appears.
+
+    Args:
+        definition: The definition whose attribute was being read.
+        exc: The attribute error raised while reading it.
+
+    Returns:
+        The exception's text, parenthesized and ready to append to the defect
+        message, or an empty string when it is the interpreter's stock phrasing
+        for a missing module attribute.
+    """
+    text = exception_text(exc)
+    stock = (
+        f"AttributeError: module {definition.module!r} has no attribute "
+        f"{definition.function!r}"
+    )
+    return "" if text == stock else f" ({text})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,13 @@ prefect = [
 # Managed HTTP service and worker profile (Python 3.11-3.13). Every runtime
 # imported directly by `infrahub_sync.managed` is declared here; the reusable
 # Prefect integration is pinned to the reviewed DB-102/103/104 stack exactly.
+# The previous `opsmill-prefect-extras` private Git pin is vendored instead: the
+# package ships from this repository at `opsmill_prefect_extras/`, byte-identical to
+# upstream commit 84688eb8d8db7e17770413640a66481ccdc3e725. See
+# `opsmill_prefect_extras/VENDORED.md` for the freeze and re-adoption rules.
 managed = [
     "fastapi>=0.115,<1; python_version >= '3.11'",
     "httpx>=0.27,<1; python_version >= '3.11'",
-    "opsmill-prefect-extras @ git+https://github.com/opsmill/prefect-extras.git@84688eb8d8db7e17770413640a66481ccdc3e725 ; python_version >= '3.11'",
     "prefect==3.8.1; python_version >= '3.11'",
     "uvicorn>=0.34,<1; python_version >= '3.11'",
 ]
@@ -94,7 +97,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["infrahub_sync"]
+# `opsmill_prefect_extras` is a vendored copy of the private upstream package,
+# byte-identical at its original import name so nothing in this repository or its
+# tests rewrites imports; see `opsmill_prefect_extras/VENDORED.md`.
+packages = ["infrahub_sync", "opsmill_prefect_extras"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -188,6 +194,11 @@ exclude = [
     "build",
     "dist",
     "examples",
+    # Vendored byte-identical upstream code and its upstream tests; the freeze rule in
+    # opsmill_prefect_extras/VENDORED.md forbids local rewrites, so Ruff must not
+    # reformat or lint them to this repository's profile. ty still checks them.
+    "opsmill_prefect_extras",
+    "tests/vendored_prefect_extras",
 ]
 
 
@@ -214,6 +225,9 @@ line-ending = "auto"
 
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub"]
+# The vendored package keeps its upstream (third-party) import classification so
+# consumer import blocks stay byte-stable across vendoring and later re-adoption.
+known-third-party = ["opsmill_prefect_extras"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 150

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,8 @@ exclude = [
     "examples",
     # Vendored byte-identical upstream code and its upstream tests; the freeze rule in
     # opsmill_prefect_extras/VENDORED.md forbids local rewrites, so Ruff must not
-    # reformat or lint them to this repository's profile. ty still checks them.
+    # reformat or lint them to this repository's profile. ty still checks the vendored
+    # package; only the vendored tests are excluded from ty (see [tool.ty.src]).
     "opsmill_prefect_extras",
     "tests/vendored_prefect_extras",
 ]
@@ -365,7 +366,11 @@ max-complexity = 33
 [tool.ty]
 
 [tool.ty.src]
-exclude = ["examples/**"]
+# tests/vendored_prefect_extras is frozen byte-identical upstream test code (see
+# opsmill_prefect_extras/VENDORED.md) and is not held to this repository's checks;
+# the vendored package itself stays type-checked. Configured here so every ty
+# entry point — local, invoke, and CI's inlined commands — agrees.
+exclude = ["examples/**", "tests/vendored_prefect_extras/**"]
 
 [tool.ty.environment]
 python-version = "3.10"

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -27,10 +27,19 @@ PYLINT_BASELINE_MAX_COUNTS = {
 
 
 def _ty_check_command(python_major: int, python_minor: int) -> str:
-    """Return the type-check command for the active supported runtime profile."""
+    """Return the type-check command for the active supported runtime profile.
+
+    The vendored upstream test suite is excluded on every profile: its files are
+    frozen byte-identical to upstream (see opsmill_prefect_extras/VENDORED.md) and
+    may not be edited to satisfy this repository's stricter checks. The vendored
+    package itself stays type-checked.
+    """
     if (python_major, python_minor) == (3, 10):
-        return "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
-    return "uv run ty check ."
+        return (
+            "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed "
+            "--exclude tests/vendored_prefect_extras ."
+        )
+    return "uv run ty check --exclude tests/vendored_prefect_extras ."
 
 
 def _pylint_command(python_major: int, python_minor: int) -> str:

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -27,19 +27,10 @@ PYLINT_BASELINE_MAX_COUNTS = {
 
 
 def _ty_check_command(python_major: int, python_minor: int) -> str:
-    """Return the type-check command for the active supported runtime profile.
-
-    The vendored upstream test suite is excluded on every profile: its files are
-    frozen byte-identical to upstream (see opsmill_prefect_extras/VENDORED.md) and
-    may not be edited to satisfy this repository's stricter checks. The vendored
-    package itself stays type-checked.
-    """
+    """Return the type-check command for the active supported runtime profile."""
     if (python_major, python_minor) == (3, 10):
-        return (
-            "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed "
-            "--exclude tests/vendored_prefect_extras ."
-        )
-    return "uv run ty check --exclude tests/vendored_prefect_extras ."
+        return "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
+    return "uv run ty check ."
 
 
 def _pylint_command(python_major: int, python_minor: int) -> str:

--- a/tests/test_linter_tasks.py
+++ b/tests/test_linter_tasks.py
@@ -3,13 +3,15 @@ from tasks import linter
 
 def test_ty_check_command_excludes_managed_on_python_310() -> None:
     assert linter._ty_check_command(3, 10) == (
-        "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
+        "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed "
+        "--exclude tests/vendored_prefect_extras ."
     )
 
 
 def test_ty_check_command_checks_managed_on_supported_python() -> None:
-    assert linter._ty_check_command(3, 11) == "uv run ty check ."
-    assert linter._ty_check_command(3, 13) == "uv run ty check ."
+    expected = "uv run ty check --exclude tests/vendored_prefect_extras ."
+    assert linter._ty_check_command(3, 11) == expected
+    assert linter._ty_check_command(3, 13) == expected
 
 
 def test_pylint_command_excludes_managed_on_python_310() -> None:

--- a/tests/test_linter_tasks.py
+++ b/tests/test_linter_tasks.py
@@ -3,15 +3,13 @@ from tasks import linter
 
 def test_ty_check_command_excludes_managed_on_python_310() -> None:
     assert linter._ty_check_command(3, 10) == (
-        "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed "
-        "--exclude tests/vendored_prefect_extras ."
+        "uv run ty check --exclude infrahub_sync/managed --exclude tests/managed ."
     )
 
 
 def test_ty_check_command_checks_managed_on_supported_python() -> None:
-    expected = "uv run ty check --exclude tests/vendored_prefect_extras ."
-    assert linter._ty_check_command(3, 11) == expected
-    assert linter._ty_check_command(3, 13) == expected
+    assert linter._ty_check_command(3, 11) == "uv run ty check ."
+    assert linter._ty_check_command(3, 13) == "uv run ty check ."
 
 
 def test_pylint_command_excludes_managed_on_python_310() -> None:

--- a/tests/test_vendoring_consistency.py
+++ b/tests/test_vendoring_consistency.py
@@ -1,0 +1,44 @@
+"""The vendored prefect-extras package must be all-in or all-out.
+
+A half-executed re-adoption — vendored directory removed but the wheel entry or
+the restored Git dependency forgotten, or vice versa — would ship a broken
+package. These assertions pin the three coupled facts together; see
+``opsmill_prefect_extras/VENDORED.md`` for the freeze and re-adoption rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Stdlib only on Python 3.11+; the 3.10 test leg skips this module, and every
+# 3.11+ leg enforces it.
+tomllib = pytest.importorskip("tomllib")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VENDORED_DIR = REPO_ROOT / "opsmill_prefect_extras"
+VENDORED_TESTS_DIR = REPO_ROOT / "tests" / "vendored_prefect_extras"
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_vendored_package_state_is_consistent() -> None:
+    data = _pyproject()
+    vendored = VENDORED_DIR.is_dir()
+
+    wheel_packages = data["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    managed_deps = data["project"]["optional-dependencies"]["managed"]
+    has_git_dep = any("prefect-extras.git" in dep for dep in managed_deps)
+
+    if vendored:
+        assert "opsmill_prefect_extras" in wheel_packages, "vendored dir present but not shipped in the wheel"
+        assert not has_git_dep, "vendored dir present alongside the upstream Git dependency"
+        assert (VENDORED_DIR / "VENDORED.md").is_file(), "vendored dir must carry its freeze/re-adoption record"
+        assert VENDORED_TESTS_DIR.is_dir(), "vendored package present but its upstream test suite is missing"
+    else:
+        assert "opsmill_prefect_extras" not in wheel_packages, "wheel still ships a removed vendored package"
+        assert has_git_dep, "vendored dir removed but the upstream dependency was not restored"
+        assert not VENDORED_TESTS_DIR.exists(), "vendored tests remain after the package was re-adopted"

--- a/tests/vendored_prefect_extras/conftest.py
+++ b/tests/vendored_prefect_extras/conftest.py
@@ -18,6 +18,7 @@ Three adaptations, all confined to this file so no vendored test changes:
 """
 
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -25,7 +26,15 @@ pytest.importorskip("prefect", reason="vendored prefect-extras tests require the
 
 from tests.vendored_prefect_extras import workflows as _vendored_workflows  # noqa: E402
 
-sys.modules.setdefault("tests.workflows", _vendored_workflows)
+_REAL_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / "workflows"
+if _REAL_WORKFLOWS_DIR.exists():
+    msg = (
+        "tests/workflows exists as a real package; the vendored suite aliases that "
+        "module name and the two would shadow each other — rename one of them"
+    )
+    raise RuntimeError(msg)
+
+sys.modules["tests.workflows"] = _vendored_workflows
 
 _UPSTREAM_DOC_TESTS = frozenset({"test_executor_docs_disclose_local_engine_limitations"})
 

--- a/tests/vendored_prefect_extras/conftest.py
+++ b/tests/vendored_prefect_extras/conftest.py
@@ -1,0 +1,38 @@
+"""Local harness for the byte-identical vendored upstream test suite.
+
+Three adaptations, all confined to this file so no vendored test changes:
+
+1. Skip the whole directory when the prefect extra is absent — the vendored
+   package imports prefect at module scope, matching `tests/managed/` guards.
+2. Alias the `tests.workflows` package to the vendored location in
+   `sys.modules`. Upstream fixture definitions reference their flow modules by
+   the dotted paths `tests.workflows.flows` / `tests.workflows.sentinel` and
+   resolve them with `importlib.import_module`; in upstream those resolve from
+   the repository root, while here the package lives at
+   `tests.vendored_prefect_extras.workflows`. Only the package is aliased —
+   submodules resolve through its `__path__` on demand, which matters because
+   the sentinel module raises on import by design and must not be imported here.
+3. Skip the one test that reads the upstream repository's root `README.md`
+   (`test_executor_docs_disclose_local_engine_limitations`) — that file is
+   upstream project documentation and is deliberately not vendored.
+"""
+
+import sys
+
+import pytest
+
+pytest.importorskip("prefect", reason="vendored prefect-extras tests require the prefect extra")
+
+from tests.vendored_prefect_extras import workflows as _vendored_workflows  # noqa: E402
+
+sys.modules.setdefault("tests.workflows", _vendored_workflows)
+
+_UPSTREAM_DOC_TESTS = frozenset({"test_executor_docs_disclose_local_engine_limitations"})
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip vendored tests that assert upstream repository documentation."""
+    marker = pytest.mark.skip(reason="asserts the upstream repository's README.md, which is not vendored")
+    for item in items:
+        if item.name in _UPSTREAM_DOC_TESTS and "vendored_prefect_extras" in str(item.path):
+            item.add_marker(marker)

--- a/tests/vendored_prefect_extras/test_deployments.py
+++ b/tests/vendored_prefect_extras/test_deployments.py
@@ -1,0 +1,525 @@
+"""Offline behavioural tests for deployment apply."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import pytest
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.actions import (
+    DeploymentCreate,
+    DeploymentUpdate,
+    WorkPoolCreate,
+)
+from prefect.client.schemas.responses import DeploymentResponse
+from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
+from prefect.testing.utilities import prefect_test_harness
+
+import opsmill_prefect_extras.deployments as deployments
+from opsmill_prefect_extras.deployments import (
+    DefinitionPreflightError,
+    DeploymentApplyConnectionError,
+    DeploymentApplyReport,
+    DeploymentApplyResult,
+    DeploymentClient,
+    apply_deployments,
+)
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+
+@dataclass
+class FakeDeployment:
+    """A JSON-shaped Prefect deployment response for the client seam."""
+
+    id: UUID
+    payload: Mapping[str, Any]
+
+    def model_dump(self, *, mode: str, exclude_none: bool) -> Mapping[str, Any]:
+        """Return the stored response payload in Prefect's used shape."""
+        assert mode == "json"
+        assert exclude_none is True
+        return self.payload
+
+
+class FakePrefectClient:
+    """Stateful stand-in for Prefect's read-before-write and upsert behavior."""
+
+    def __init__(self, *, fail_flow_names: set[str] | None = None) -> None:
+        self.calls: list[tuple[str, object]] = []
+        self.deployment_payloads: list[dict[str, Any]] = []
+        self.flow_ids: dict[str, UUID] = {}
+        self.deployments: dict[str, FakeDeployment] = {}
+        self.read_overrides: dict[str, DeploymentResponse] = {}
+        self.fail_flow_names = fail_flow_names or set()
+
+    async def create_flow_from_name(self, flow_name: str) -> UUID:
+        self.calls.append(("create_flow_from_name", flow_name))
+        if flow_name in self.fail_flow_names:
+            raise RuntimeError("exception-sentinel-value")
+        return self.flow_ids.setdefault(flow_name, uuid4())
+
+    async def create_deployment(self, flow_id: UUID, **payload: Any) -> UUID:
+        self.calls.append(("create_deployment", (flow_id, payload)))
+        self.deployment_payloads.append(payload)
+        flow_name = next(
+            name for name, identifier in self.flow_ids.items() if identifier == flow_id
+        )
+        key = f"{flow_name}/{payload['name']}"
+        normalized = DeploymentCreate(flow_id=flow_id, **payload).model_dump(
+            mode="json", exclude_none=True
+        )
+        if key in self.deployments:
+            existing = self.deployments[key]
+            existing.payload = normalized
+            return existing.id
+        deployment_id = uuid4()
+        self.deployments[key] = FakeDeployment(id=deployment_id, payload=normalized)
+        return deployment_id
+
+    async def read_deployment_by_name(
+        self, name: str
+    ) -> FakeDeployment | DeploymentResponse:
+        self.calls.append(("read_deployment_by_name", name))
+        if name in self.read_overrides:
+            return self.read_overrides[name]
+        try:
+            return self.deployments[name]
+        except KeyError:
+            raise ObjectNotFound(RuntimeError("missing-deployment")) from None
+
+    async def update_deployment(
+        self, deployment_id: UUID, deployment: DeploymentUpdate
+    ) -> None:
+        self.calls.append(("update_deployment", deployment_id))
+        for existing in self.deployments.values():
+            if existing.id == deployment_id:
+                existing.payload = {
+                    **existing.payload,
+                    **deployment.model_dump(mode="json", exclude_none=True),
+                }
+                return
+        raise AssertionError("unknown fake deployment")
+
+
+def _definition(
+    flow_name: str,
+    deployment_name: str = "run",
+    **kwargs: Any,
+) -> WorkflowDefinition:
+    """Build a definition without resolving a real flow module."""
+    return WorkflowDefinition(
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+        module="tests.workflows.flows",
+        function="my_sync_flow",
+        **kwargs,
+    )
+
+
+def _apply(*args: Any, **kwargs: Any) -> DeploymentApplyReport:
+    """Run the public asynchronous call without adding a pytest plugin."""
+    return asyncio.run(apply_deployments(*args, **kwargs))
+
+
+def test_public_surface_is_explicit() -> None:
+    assert deployments.__all__ == [
+        "ApplyStatus",
+        "DefinitionPreflightError",
+        "DeploymentApplyConnectionError",
+        "DeploymentApplyReport",
+        "DeploymentApplyResult",
+        "DeploymentClient",
+        "DeploymentClientFactory",
+        "DeploymentRecord",
+        "apply_deployments",
+    ]
+
+
+def test_deployments_import_does_not_initialize_workflow_siblings() -> None:
+    script = """
+import sys
+import opsmill_prefect_extras.deployments
+
+for module in (
+    "opsmill_prefect_extras.workflows.catalogue",
+    "opsmill_prefect_extras.workflows.validation",
+):
+    assert module not in sys.modules, module
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_workflow_public_names_are_discoverable_without_eager_imports() -> None:
+    script = """
+import sys
+import opsmill_prefect_extras.workflows as workflows
+
+assert set(workflows.__all__) <= set(dir(workflows))
+for module in (
+    "opsmill_prefect_extras.workflows.catalogue",
+    "opsmill_prefect_extras.workflows.validation",
+):
+    assert module not in sys.modules, module
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_apply_uses_prefects_flow_then_deployment_calls_and_renders_inputs() -> None:
+    client = FakePrefectClient()
+    definitions = (
+        _definition("one"),
+        _definition(
+            "inventory-refresh",
+            "scheduled",
+            cron="0 2 * * *",
+            concurrency_limit=1,
+        ),
+        _definition("three"),
+    )
+
+    report = _apply(
+        definitions,
+        work_pool_name="application-pool",
+        job_variables={"image": "image-sentinel-value", "replicas": 2},
+        client=client,
+    )
+
+    assert [result.status for result in report.results] == ["created"] * 3
+    assert [call[0] for call in client.calls] == [
+        "read_deployment_by_name",
+        "create_flow_from_name",
+        "create_deployment",
+        "read_deployment_by_name",
+        "create_flow_from_name",
+        "create_deployment",
+        "read_deployment_by_name",
+        "create_flow_from_name",
+        "create_deployment",
+    ]
+    payload = client.deployment_payloads[1]
+    assert payload["name"] == "scheduled"
+    assert payload["schedules"] == [{"schedule": {"cron": "0 2 * * *"}}]
+    assert payload["concurrency_limit"] == 1
+    assert "concurrency_options" not in payload
+    assert payload["work_pool_name"] == "application-pool"
+    assert payload["job_variables"] == {
+        "image": "image-sentinel-value",
+        "replicas": 2,
+    }
+    assert "inventory-refresh/scheduled" in client.deployments
+
+
+def test_second_apply_is_unchanged_and_drift_is_updated() -> None:
+    client = FakePrefectClient()
+    definition = _definition("inventory-refresh", "scheduled", tags=("inventory",))
+
+    first = _apply((definition,), work_pool_name="pool", client=client)
+    second = _apply((definition,), work_pool_name="pool", client=client)
+    client.deployments[definition.key].payload = {
+        **client.deployments[definition.key].payload,
+        "tags": ["drifted"],
+    }
+    third = _apply((definition,), work_pool_name="pool", client=client)
+
+    assert [result.status for result in first.results] == ["created"]
+    assert [result.status for result in second.results] == ["unchanged"]
+    assert [result.status for result in third.results] == ["updated"]
+    assert [call[0] for call in client.calls].count("update_deployment") == 1
+
+
+def test_create_race_converges_after_a_defensive_conflict() -> None:
+    class RacingClient(FakePrefectClient):
+        async def create_deployment(self, flow_id: UUID, **payload: Any) -> UUID:
+            await super().create_deployment(flow_id, **payload)
+            raise ObjectAlreadyExists(RuntimeError("concurrent-create"))
+
+    client = RacingClient()
+    definition = _definition("inventory-refresh", "scheduled")
+
+    report = _apply((definition,), work_pool_name="pool", client=client)
+
+    assert [result.status for result in report.results] == ["unchanged"]
+
+
+def test_response_schedule_metadata_converges_without_an_update() -> None:
+    client = FakePrefectClient()
+    definition = _definition("inventory-refresh", "scheduled", cron="0 2 * * *")
+
+    _apply((definition,), work_pool_name="pool", client=client)
+    created = client.deployments[definition.key]
+    client.read_overrides[definition.key] = DeploymentResponse.model_validate(
+        {
+            "id": str(created.id),
+            "name": definition.deployment_name,
+            "flow_id": str(client.flow_ids[definition.flow_name]),
+            "schedules": [
+                {
+                    "id": str(uuid4()),
+                    "deployment_id": str(created.id),
+                    "schedule": {"cron": "0 2 * * *"},
+                    "active": True,
+                    "parameters": {},
+                }
+            ],
+            "job_variables": {},
+            "tags": [],
+            "work_pool_name": "pool",
+        }
+    )
+
+    report = _apply((definition,), work_pool_name="pool", client=client)
+
+    assert [result.status for result in report.results] == ["unchanged"]
+    assert [call[0] for call in client.calls].count("update_deployment") == 0
+
+
+def test_real_prefect_server_second_scheduled_apply_is_unchanged() -> None:
+    definition = _definition("integration-flow", "nightly", cron="0 2 * * *")
+
+    async def scenario() -> tuple[DeploymentApplyReport, DeploymentApplyReport]:
+        async with get_client() as client:
+            await client.create_work_pool(
+                WorkPoolCreate(name="integration-pool", type="process")
+            )
+            first = await apply_deployments(
+                (definition,),
+                work_pool_name="integration-pool",
+                client=cast(DeploymentClient, client),
+            )
+            second = await apply_deployments(
+                (definition,),
+                work_pool_name="integration-pool",
+                client=cast(DeploymentClient, client),
+            )
+            return first, second
+
+    with prefect_test_harness():
+        first, second = asyncio.run(scenario())
+
+    assert [result.status for result in first.results] == ["created"]
+    assert [result.status for result in second.results] == ["unchanged"]
+
+
+@pytest.mark.skipif(
+    "global_concurrency_limit" not in DeploymentResponse.model_fields,
+    reason="this Prefect response schema predates global concurrency limits",
+)
+def test_response_global_concurrency_limit_converges_without_an_update() -> None:
+    client = FakePrefectClient()
+    definition = _definition("inventory-refresh", "scheduled", concurrency_limit=1)
+
+    _apply((definition,), work_pool_name="pool", client=client)
+    created = client.deployments[definition.key]
+    client.read_overrides[definition.key] = DeploymentResponse.model_validate(
+        {
+            "id": str(created.id),
+            "name": definition.deployment_name,
+            "flow_id": str(client.flow_ids[definition.flow_name]),
+            "concurrency_limit": None,
+            "global_concurrency_limit": {
+                "id": str(uuid4()),
+                "name": "deployment-limit",
+                "limit": 1,
+                "active_slots": 0,
+                "slot_decay_per_second": 0.0,
+            },
+            "schedules": [],
+            "job_variables": {},
+            "tags": [],
+            "work_pool_name": "pool",
+        }
+    )
+
+    report = _apply((definition,), work_pool_name="pool", client=client)
+
+    assert [result.status for result in report.results] == ["unchanged"]
+    assert [call[0] for call in client.calls].count("update_deployment") == 0
+
+
+def test_distinct_flow_and_deployment_names_use_the_catalogue_address() -> None:
+    client = FakePrefectClient()
+    definition = _definition("inventory-refresh", "scheduled")
+
+    report = _apply((definition,), work_pool_name="pool", client=client)
+
+    assert report.created[0].key == "inventory-refresh/scheduled"
+    assert "inventory-refresh/scheduled" in client.deployments
+
+
+def test_a_server_failure_is_per_definition_and_later_ones_continue() -> None:
+    client = FakePrefectClient(fail_flow_names={"bad"})
+
+    report = _apply(
+        (_definition("good"), _definition("bad"), _definition("later")),
+        work_pool_name="pool",
+        client=client,
+    )
+
+    assert [
+        (result.key, result.status, result.error_type) for result in report.results
+    ] == [
+        ("good/run", "created", None),
+        ("bad/run", "failed", "RuntimeError"),
+        ("later/run", "created", None),
+    ]
+    assert "later/run" in client.deployments
+
+
+def test_preflight_schema_and_definition_refusals_do_not_call_the_client() -> None:
+    client = FakePrefectClient()
+    malformed = _definition("bad", "run")
+    object.__setattr__(malformed, "deployment_name", "not/a-deployment")
+    bad_schema = _definition("schema", "run", cron="not a cron")
+
+    report = _apply(
+        (malformed, bad_schema, _definition("good")),
+        work_pool_name="pool",
+        client=client,
+    )
+
+    assert [(result.status, result.error_type) for result in report.results] == [
+        ("failed", DefinitionPreflightError.__name__),
+        ("failed", "ValidationError"),
+        ("created", None),
+    ]
+    assert [call[0] for call in client.calls] == [
+        "read_deployment_by_name",
+        "create_flow_from_name",
+        "create_deployment",
+    ]
+
+
+def test_connection_failure_before_processing_is_typed_and_attempts_nothing() -> None:
+    calls: list[str] = []
+
+    @asynccontextmanager
+    async def unavailable() -> AsyncIterator[FakePrefectClient]:
+        calls.append("open")
+        raise RuntimeError("connection-sentinel-value")
+        yield FakePrefectClient()
+
+    with pytest.raises(DeploymentApplyConnectionError) as excinfo:
+        _apply(
+            (_definition("never-attempted"),),
+            work_pool_name="pool",
+            client_factory=unavailable,
+        )
+
+    assert excinfo.value.cause_type == "RuntimeError"
+    assert "connection-sentinel-value" not in str(excinfo.value)
+    assert calls == ["open"]
+
+
+def test_client_context_receives_an_iteration_failure() -> None:
+    exit_types: list[type[BaseException] | None] = []
+
+    class RecordingContext:
+        async def __aenter__(self) -> FakePrefectClient:
+            return FakePrefectClient()
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: object,
+        ) -> bool:
+            exit_types.append(exc_type)
+            return False
+
+    def definitions() -> Iterator[WorkflowDefinition]:
+        yield _definition("first")
+        raise LookupError("iteration-sentinel")
+
+    with pytest.raises(LookupError, match="iteration-sentinel"):
+        _apply(
+            definitions(),
+            work_pool_name="pool",
+            client_factory=RecordingContext,
+        )
+
+    assert exit_types == [LookupError]
+
+
+def test_apply_rejects_ambiguous_client_injection() -> None:
+    client = FakePrefectClient()
+
+    @asynccontextmanager
+    async def client_context() -> AsyncIterator[FakePrefectClient]:
+        yield client
+
+    with pytest.raises(ValueError, match="either client or client_factory"):
+        _apply(
+            (_definition("never-attempted"),),
+            work_pool_name="pool",
+            client=client,
+            client_factory=client_context,
+        )
+
+
+def test_reports_or_logs_do_not_disclose_job_variables_or_exception_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = FakePrefectClient(fail_flow_names={"bad"})
+    secret_job_variables = {
+        "image": "image-sentinel-value",
+        "credential": "credential-sentinel-value",
+    }
+
+    report = _apply(
+        (_definition("bad"),),
+        work_pool_name="pool",
+        job_variables=secret_job_variables,
+        client=client,
+    )
+
+    rendered = f"{report!r}\n{caplog.text}"
+    for secret in (*secret_job_variables.values(), "exception-sentinel-value"):
+        assert secret not in rendered
+    assert report.failed[0].error_type == "RuntimeError"
+    assert report.failed[0].key == "bad/run"
+
+
+def test_report_groups_structured_outcomes_without_storing_failure_values() -> None:
+    definition = _definition("one")
+    report = DeploymentApplyReport(
+        results=(
+            DeploymentApplyResult(definition=definition, status="created"),
+            DeploymentApplyResult(
+                definition=_definition("two"), status="failed", error_type="ValueError"
+            ),
+        )
+    )
+
+    assert [result.key for result in report.created] == ["one/run"]
+    assert [result.key for result in report.failed] == ["two/run"]
+    assert report.updated == ()
+    assert report.unchanged == ()
+    assert report.is_successful is False
+
+
+def test_result_rejects_an_inconsistent_failure_shape() -> None:
+    definition = _definition("one")
+
+    with pytest.raises(ValueError, match="needs an error type"):
+        DeploymentApplyResult(definition=definition, status="failed")
+    with pytest.raises(ValueError, match="cannot have an error type"):
+        DeploymentApplyResult(
+            definition=definition, status="created", error_type="RuntimeError"
+        )

--- a/tests/vendored_prefect_extras/test_executors.py
+++ b/tests/vendored_prefect_extras/test_executors.py
@@ -1,0 +1,846 @@
+"""Offline contract tests for local and remote workflow executors."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from prefect import flow, get_run_logger
+from prefect.client.schemas.objects import FlowRun, State
+from prefect.exceptions import MissingContextError, ObjectNotFound, ParameterTypeError
+from prefect.flows import Flow
+from prefect.states import Cancelled, Completed, Crashed, Failed, Running
+
+import opsmill_prefect_extras.executors as executors_module
+from opsmill_prefect_extras.executors import (
+    CancelledFlowRunError,
+    CrashedFlowRunError,
+    ExecutorClosedError,
+    FailedFlowRunError,
+    FlowRunError,
+    IdempotentWorkflowExecutor,
+    LocalWorkflowExecutor,
+    MissingFlowRunResultError,
+    RemoteWorkflowExecutor,
+    WorkflowExecutor,
+    WorkflowNotFoundError,
+    WorkflowRunHandle,
+)
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+
+def test_public_surface_keeps_concrete_handles_private() -> None:
+    """Concrete handle types remain private implementation details."""
+    assert "WorkflowRunHandle" in executors_module.__all__
+    assert "IdempotentWorkflowExecutor" in executors_module.__all__
+    assert "RemoteFlowRunHandle" not in executors_module.__all__
+    assert not hasattr(executors_module, "RemoteFlowRunHandle")
+
+
+def test_idempotency_capability_is_explicit_and_remote_only() -> None:
+    """The extension and remote implementation expose keys; base and local do not."""
+    for method_name in ("run", "submit"):
+        assert (
+            "idempotency_key"
+            in inspect.signature(
+                getattr(RemoteWorkflowExecutor, method_name)
+            ).parameters
+        )
+        assert (
+            "idempotency_key"
+            in inspect.signature(
+                getattr(IdempotentWorkflowExecutor, method_name)
+            ).parameters
+        )
+        assert (
+            "idempotency_key"
+            not in inspect.signature(
+                getattr(LocalWorkflowExecutor, method_name)
+            ).parameters
+        )
+        assert (
+            "idempotency_key"
+            not in inspect.signature(getattr(WorkflowExecutor, method_name)).parameters
+        )
+
+
+def _definition(
+    # Any: test fixture accommodates Prefect flows with varied user signatures.
+    monkeypatch: pytest.MonkeyPatch,
+    flow_object: Flow[..., Any],
+) -> WorkflowDefinition:
+    """Expose one real Prefect flow through a temporary definition module."""
+    module_name = f"executor_fixture_{uuid4().hex}"
+    module = ModuleType(module_name)
+    module.__dict__["workflow"] = flow_object
+    monkeypatch.setitem(sys.modules, module_name, module)
+    return WorkflowDefinition(
+        flow_name=flow_object.name,
+        deployment_name="run",
+        module=module_name,
+        function="workflow",
+    )
+
+
+@dataclass
+class _Deployment:
+    """Minimal offline Prefect deployment response."""
+
+    id: UUID
+
+
+@dataclass
+class _FlowRun:
+    """Minimal offline Prefect flow-run response."""
+
+    id: UUID
+    state: State[Any] | None
+
+
+class _Client:
+    """A deterministic in-memory seam, never a Prefect server client."""
+
+    def __init__(self, state: State[Any] | None = None) -> None:
+        self.deployment = _Deployment(uuid4())
+        self.flow_run: _FlowRun | FlowRun = _FlowRun(
+            uuid4(), state or Completed(data="remote result")
+        )
+        self.deployment_names: list[str] = []
+        # Any: Prefect validates arbitrary application parameter value types.
+        self.submissions: list[tuple[UUID, dict[str, Any], str | None]] = []
+        self.reads: int = 0
+
+    async def read_deployment_by_name(self, name: str) -> _Deployment:
+        """Record the requested deployment target."""
+        self.deployment_names.append(name)
+        return self.deployment
+
+    async def create_flow_run_from_deployment(
+        self,
+        deployment_id: UUID,
+        *,
+        parameters: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> _FlowRun | FlowRun:
+        """Record one accepted in-memory remote submission."""
+        self.submissions.append((deployment_id, parameters, idempotency_key))
+        return self.flow_run
+
+    async def read_flow_run(self, flow_run_id: UUID) -> _FlowRun | FlowRun:
+        """Return the configured state for the real-looking run identity."""
+        assert flow_run_id == self.flow_run.id
+        self.reads += 1
+        return self.flow_run
+
+    async def set_flow_run_state(self, flow_run_id: UUID, state: State[Any]) -> object:
+        """Apply a requested fake state transition."""
+        assert flow_run_id == self.flow_run.id
+        self.flow_run.state = state
+        return object()
+
+
+class _DeduplicatingClient(_Client):
+    """A fake server that applies Prefect-style creation-key deduplication."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._runs_by_key: dict[str, _FlowRun] = {}
+        self.creation_count = 0
+
+    async def create_flow_run_from_deployment(
+        self,
+        deployment_id: UUID,
+        *,
+        parameters: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> _FlowRun:
+        """Return a prior run for a key, otherwise create one server-side."""
+        self.submissions.append((deployment_id, parameters, idempotency_key))
+        if idempotency_key is not None and idempotency_key in self._runs_by_key:
+            return self._runs_by_key[idempotency_key]
+        flow_run = _FlowRun(uuid4(), Completed(data="remote result"))
+        self.creation_count += 1
+        if idempotency_key is not None:
+            self._runs_by_key[idempotency_key] = flow_run
+        return flow_run
+
+
+def test_remote_executor_structurally_satisfies_idempotency_capability() -> None:
+    """Static checking makes this call fail if the remote surface drifts."""
+
+    def accept(executor: IdempotentWorkflowExecutor) -> IdempotentWorkflowExecutor:
+        return executor
+
+    assert isinstance(accept(RemoteWorkflowExecutor(_Client())), RemoteWorkflowExecutor)
+
+
+@pytest.mark.parametrize("mode", ["local", "remote"])
+def test_shared_executor_contract_returns_results_and_handles(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """Both implementations satisfy the run/submit/result/status contract."""
+
+    @flow(name="contract-flow")
+    def contract_flow(value: int) -> str:
+        return f"value={value}"
+
+    definition = _definition(monkeypatch, contract_flow)
+
+    async def assert_contract(
+        executor: LocalWorkflowExecutor | RemoteWorkflowExecutor,
+    ) -> None:
+        assert await executor.run(definition, {"value": 7}) == "value=7"
+        handle = await executor.submit(definition, {"value": 7})
+        assert await handle.wait() == "completed"
+        assert await handle.status() == "completed"
+        assert await handle.result() == "value=7"
+
+    async def scenario() -> None:
+        if mode == "local":
+            local_executor = LocalWorkflowExecutor()
+            await assert_contract(local_executor)
+            await local_executor.shutdown()
+            return
+        remote_executor = RemoteWorkflowExecutor(_Client(Completed(data="value=7")))
+        await assert_contract(remote_executor)
+
+    asyncio.run(scenario())
+
+
+def test_local_submit_is_immediate_event_gated_and_never_invokes_flow_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local submit starts a managed task without server, process, or queue use."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @flow(name="gated-local-flow")
+    async def gated_local_flow() -> str:
+        started.set()
+        await release.wait()
+        return "released"
+
+    definition = _definition(monkeypatch, gated_local_flow)
+
+    def forbidden_flow_engine(*args: object, **kwargs: object) -> object:
+        raise AssertionError("local executor must not invoke Flow.__call__")
+
+    monkeypatch.setattr(Flow, "__call__", forbidden_flow_engine)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        handle = await executor.submit(definition, {})
+        assert handle.id.startswith("local:")
+        assert await handle.status() == "running"
+        assert not started.is_set()
+        await started.wait()
+        release.set()
+        assert await handle.result() == "released"
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_local_flow_logger_requires_a_consumer_owned_context_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flow.fn does not fabricate a Prefect logger context or start its engine."""
+
+    @flow(name="logger-context-flow")
+    def logger_context_flow() -> None:
+        get_run_logger()
+
+    definition = _definition(monkeypatch, logger_context_flow)
+
+    def forbidden_flow_engine(*args: object, **kwargs: object) -> object:
+        raise AssertionError("local executor must not invoke Flow.__call__")
+
+    monkeypatch.setattr(Flow, "__call__", forbidden_flow_engine)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        with pytest.raises(FailedFlowRunError) as raised:
+            await executor.run(definition, {})
+        assert isinstance(raised.value.__cause__, MissingContextError)
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_executor_docs_disclose_local_engine_limitations() -> None:
+    """The public docs name the unavailable local-engine capabilities."""
+    readme = Path(__file__).parents[1] / "README.md"
+    module_documentation = executors_module.__doc__ or ""
+    readme_documentation = readme.read_text()
+    documentation = f"{module_documentation}\n{readme_documentation}"
+    for required_concept in (
+        "flow-run context",
+        "MissingContextError",
+        "retries",
+        "hooks",
+        "timeouts",
+        "runtime logging",
+        "consumer-owned fallback",
+        "remote mode",
+    ):
+        assert required_concept in documentation
+    logger_annotation = "logging.Logger | logging.LoggerAdapter[logging.Logger]"
+    assert logger_annotation in module_documentation
+    assert logger_annotation in readme_documentation
+
+
+def test_local_async_flow_leaves_the_callers_event_loop_responsive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An async flow yields while its caller can make independent progress."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    caller_progressed = asyncio.Event()
+
+    @flow(name="async-progress-flow")
+    async def async_progress_flow() -> str:
+        started.set()
+        await release.wait()
+        return "done"
+
+    definition = _definition(monkeypatch, async_progress_flow)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        handle = await executor.submit(definition, {})
+        await started.wait()
+        caller_progressed.set()
+        assert caller_progressed.is_set()
+        release.set()
+        assert await handle.result() == "done"
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_local_sync_flow_runs_off_the_callers_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocking synchronous flow runs in a thread while the loop progresses."""
+    started = threading.Event()
+    release = threading.Event()
+    caller_progressed = asyncio.Event()
+
+    @flow(name="sync-progress-flow")
+    def sync_progress_flow() -> str:
+        started.set()
+        release.wait()
+        return "done"
+
+    definition = _definition(monkeypatch, sync_progress_flow)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        handle = await executor.submit(definition, {})
+        await asyncio.to_thread(started.wait)
+        caller_progressed.set()
+        assert caller_progressed.is_set()
+        release.set()
+        assert await handle.result() == "done"
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_local_shutdown_drains_completed_work_and_cancels_pending_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown rejects new work, drains ready work, and cancels the rest."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @flow(name="shutdown-flow")
+    async def shutdown_flow() -> str:
+        started.set()
+        await release.wait()
+        return "done"
+
+    definition = _definition(monkeypatch, shutdown_flow)
+
+    async def scenario() -> None:
+        draining_executor = LocalWorkflowExecutor()
+        draining_handle = await draining_executor.submit(definition, {})
+        await started.wait()
+        release.set()
+        await draining_executor.shutdown(timeout=1)
+        assert await draining_handle.result() == "done"
+
+        never_finishes = asyncio.Event()
+        second_started = asyncio.Event()
+
+        @flow(name="cancelled-by-shutdown")
+        async def blocked_flow() -> None:
+            second_started.set()
+            await never_finishes.wait()
+
+        blocked_definition = _definition(monkeypatch, blocked_flow)
+        cancelling_executor = LocalWorkflowExecutor()
+        cancelled_handle = await cancelling_executor.submit(blocked_definition, {})
+        await second_started.wait()
+        await cancelling_executor.shutdown(timeout=0)
+        assert await cancelled_handle.wait() == "cancelled"
+        with pytest.raises(ExecutorClosedError):
+            await cancelling_executor.submit(blocked_definition, {})
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_local_handle_is_terminal_and_caller_retains_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-held local handle retains cancellation after active tracking."""
+    started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    @flow(name="cancel-local-flow")
+    async def cancel_local_flow() -> None:
+        started.set()
+        await never_finishes.wait()
+
+    definition = _definition(monkeypatch, cancel_local_flow)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        handle = await executor.submit(definition, {})
+        await started.wait()
+        assert await handle.cancel() == "cancelled"
+        assert await handle.status() == "cancelled"
+        with pytest.raises(CancelledFlowRunError) as raised:
+            await handle.result()
+        assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_cancelling_a_handle_waiter_does_not_cancel_the_local_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller cancellation propagates while the shielded local task continues."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @flow(name="caller-cancellation-flow")
+    async def caller_cancellation_flow() -> str:
+        started.set()
+        await release.wait()
+        return "finished"
+
+    definition = _definition(monkeypatch, caller_cancellation_flow)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        handle = await executor.submit(definition, {})
+        await started.wait()
+        result_waiting = asyncio.Event()
+        wait_waiting = asyncio.Event()
+
+        async def await_result() -> object:
+            result_waiting.set()
+            return await handle.result()
+
+        async def await_status() -> str:
+            wait_waiting.set()
+            return await handle.wait()
+
+        result_waiter = asyncio.create_task(await_result())
+        wait_waiter = asyncio.create_task(await_status())
+        await result_waiting.wait()
+        await wait_waiting.wait()
+        result_waiter.cancel()
+        wait_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await result_waiter
+        with pytest.raises(asyncio.CancelledError):
+            await wait_waiter
+        assert await handle.status() == "running"
+        release.set()
+        assert await handle.result() == "finished"
+        await executor.shutdown()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("mode", "error_type"),
+    [
+        ("local-failure", FailedFlowRunError),
+        ("remote-failure", FailedFlowRunError),
+        ("local-cancellation", CancelledFlowRunError),
+        ("remote-cancellation", CancelledFlowRunError),
+    ],
+)
+def test_local_and_remote_terminal_failures_share_the_error_taxonomy(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    error_type: type[FlowRunError],
+) -> None:
+    """Both handle types classify failures identically and preserve local causes."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @flow(name="shared-terminal-flow")
+    async def shared_terminal_flow() -> None:
+        started.set()
+        await release.wait()
+        if mode == "local-failure":
+            raise ValueError("local failure")
+
+    definition = _definition(monkeypatch, shared_terminal_flow)
+
+    async def scenario() -> None:
+        if mode.startswith("local"):
+            executor = LocalWorkflowExecutor()
+            handle = await executor.submit(definition, {})
+            await started.wait()
+            if mode == "local-cancellation":
+                await handle.cancel()
+            else:
+                release.set()
+            with pytest.raises(error_type) as raised:
+                await handle.result()
+            if mode == "local-failure":
+                assert isinstance(raised.value.__cause__, ValueError)
+            if mode == "local-cancellation":
+                assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+            await executor.shutdown()
+            return
+
+        remote_state = (
+            Failed(data=RuntimeError("remote failure"))
+            if mode == "remote-failure"
+            else Cancelled()
+        )
+        handle = await RemoteWorkflowExecutor(_Client(remote_state)).submit(
+            definition, {}
+        )
+        with pytest.raises(error_type):
+            await handle.result()
+
+    asyncio.run(scenario())
+
+
+def test_parameter_rejection_is_identical_before_execution_or_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both modes use Prefect's parameter validator before accepting work."""
+
+    @flow(name="parameter-flow")
+    def parameter_flow(required_number: int) -> int:
+        return required_number
+
+    definition = _definition(monkeypatch, parameter_flow)
+
+    async def scenario() -> None:
+        local = LocalWorkflowExecutor()
+        remote_client = _Client()
+        remote = RemoteWorkflowExecutor(remote_client)
+        with pytest.raises(ParameterTypeError) as local_error:
+            await local.submit(definition, {"required_number": "not-a-number"})
+        with pytest.raises(ParameterTypeError) as remote_error:
+            await remote.submit(definition, {"required_number": "not-a-number"})
+        assert type(local_error.value) is type(remote_error.value)
+        assert not remote_client.deployment_names
+        await local.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_remote_submit_targets_definition_and_returns_real_server_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote submission speaks only the definition's deployment identity."""
+
+    @flow(name="inventory-refresh")
+    def remote_flow(full: bool) -> str:
+        return "not executed remotely"
+
+    definition = _definition(monkeypatch, remote_flow)
+    client = _Client()
+
+    async def scenario() -> None:
+        executor = RemoteWorkflowExecutor(client)
+        handle = await executor.submit(definition, {"full": False})
+        assert handle.id == str(client.flow_run.id)
+        assert client.deployment_names == ["inventory-refresh/run"]
+        assert client.submissions == [(client.deployment.id, {"full": False}, None)]
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("method_name", ["run", "submit"])
+def test_remote_idempotency_key_passes_through_exactly(
+    monkeypatch: pytest.MonkeyPatch, method_name: str
+) -> None:
+    """Both concrete remote entry points pass the consumer key unchanged."""
+
+    @flow(name="idempotent-remote-flow")
+    def remote_flow(full: bool) -> str:
+        return "not executed remotely"
+
+    definition = _definition(monkeypatch, remote_flow)
+    client = _Client(Completed(data="remote result"))
+
+    async def scenario() -> None:
+        executor = RemoteWorkflowExecutor(client)
+        method = getattr(executor, method_name)
+        await method(
+            definition,
+            {"full": False},
+            idempotency_key="consumer-owned/key:001",
+        )
+        assert client.submissions == [
+            (
+                client.deployment.id,
+                {"full": False},
+                "consumer-owned/key:001",
+            )
+        ]
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("keys", "same_run", "creation_count"),
+    [
+        pytest.param(("same-key", "same-key"), True, 1, id="same-key-dedupes"),
+        pytest.param(("key-one", "key-two"), False, 2, id="distinct-keys-create"),
+        pytest.param((None, None), False, 2, id="omission-creates-normally"),
+    ],
+)
+def test_remote_fake_server_idempotency_creation_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    keys: tuple[str | None, str | None],
+    same_run: bool,
+    creation_count: int,
+) -> None:
+    """The server, not the executor, deduplicates only equal supplied keys."""
+
+    @flow(name="idempotency-server-flow")
+    def remote_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, remote_flow)
+    client = _DeduplicatingClient()
+
+    async def scenario() -> None:
+        executor = RemoteWorkflowExecutor(client)
+
+        async def submit(key: str | None) -> WorkflowRunHandle:
+            if key is None:
+                return await executor.submit(definition, {})
+            return await executor.submit(definition, {}, idempotency_key=key)
+
+        first = await submit(keys[0])
+        second = await submit(keys[1])
+        assert (first.id == second.id) is same_run
+        assert client.creation_count == creation_count
+        assert [submission[2] for submission in client.submissions] == list(keys)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("state", "error_type"),
+    [
+        (Crashed(), CrashedFlowRunError),
+        (Failed(data=RuntimeError("failed")), FailedFlowRunError),
+        (Completed(), MissingFlowRunResultError),
+    ],
+)
+def test_remote_terminal_faults_raise_narrow_errors_with_server_id(
+    monkeypatch: pytest.MonkeyPatch, state: State[Any], error_type: type[FlowRunError]
+) -> None:
+    """Crashes, failures, and unavailable results never become generic errors."""
+
+    @flow(name="remote-fault-flow")
+    def remote_fault_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, remote_fault_flow)
+    client = _Client(state)
+
+    async def scenario() -> None:
+        executor = RemoteWorkflowExecutor(client)
+        handle = await executor.submit(definition, {})
+        with pytest.raises(error_type) as raised:
+            await handle.result()
+        assert raised.value.run_id == str(client.flow_run.id)
+
+    asyncio.run(scenario())
+
+
+def test_remote_missing_deployment_is_typed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remote runs name the missing deployment instead of exposing client details."""
+
+    @flow(name="absent-flow")
+    def absent_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, absent_flow)
+
+    class MissingDeploymentClient(_Client):
+        """A seam that reports the deployment as absent."""
+
+        async def read_deployment_by_name(self, name: str) -> _Deployment:
+            raise ObjectNotFound(Exception("not found"))
+
+    async def scenario() -> None:
+        with pytest.raises(WorkflowNotFoundError, match="absent-flow/run"):
+            await RemoteWorkflowExecutor(MissingDeploymentClient()).run(definition, {})
+
+    asyncio.run(scenario())
+
+
+def test_remote_deployment_deleted_between_lookup_and_submit_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deployment deletion race is reported as the same missing target error."""
+
+    @flow(name="deleted-flow")
+    def deleted_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, deleted_flow)
+
+    class DeletionRaceClient(_Client):
+        """Find a deployment, then emulate its removal before submission."""
+
+        async def create_flow_run_from_deployment(
+            self,
+            deployment_id: UUID,
+            *,
+            parameters: dict[str, Any],
+            idempotency_key: str | None = None,
+        ) -> _FlowRun:
+            raise ObjectNotFound(Exception("deleted"))
+
+    async def scenario() -> None:
+        with pytest.raises(WorkflowNotFoundError, match="deleted-flow/run"):
+            await RemoteWorkflowExecutor(DeletionRaceClient()).submit(definition, {})
+
+    asyncio.run(scenario())
+
+
+def test_remote_cancel_requests_cancelling_then_observes_server_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote cancellation is a request, not a fabricated terminal result."""
+
+    @flow(name="cancel-remote-flow")
+    def cancel_remote_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, cancel_remote_flow)
+
+    class CancellingClient(_Client):
+        """Record cancellation state transitions without a Prefect server."""
+
+        def __init__(self) -> None:
+            super().__init__(Running())
+            self.cancellation_request: State[Any] | None = None
+            self.cancellation_requests: int = 0
+
+        async def set_flow_run_state(
+            self, flow_run_id: UUID, state: State[Any]
+        ) -> object:
+            assert flow_run_id == self.flow_run.id
+            self.cancellation_request = state
+            self.cancellation_requests += 1
+            self.flow_run.state = state
+            return object()
+
+    client = CancellingClient()
+
+    async def scenario() -> None:
+        handle = await RemoteWorkflowExecutor(client).submit(definition, {})
+        assert await handle.cancel() == "cancelling"
+        assert client.cancellation_request is not None
+        assert client.cancellation_request.is_cancelling()
+        assert await handle.status() == "cancelling"
+        client.flow_run.state = Cancelled()
+        assert await handle.wait() == "cancelled"
+        assert await handle.cancel() == "cancelled"
+        assert client.cancellation_requests == 1
+
+    asyncio.run(scenario())
+
+
+def test_remote_none_state_from_real_prefect_flow_run_is_typed_and_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server response with no state fails rather than polling forever."""
+
+    @flow(name="missing-state-flow")
+    def missing_state_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, missing_state_flow)
+    client = _Client()
+    # model_construct is offline and exercises Prefect's actual FlowRun shape.
+    client.flow_run = FlowRun.model_construct(id=uuid4(), state=None)
+
+    async def scenario() -> None:
+        handle = await RemoteWorkflowExecutor(client).submit(definition, {})
+        assert await handle.status() == "failed"
+        assert await handle.wait() == "failed"
+        with pytest.raises(MissingFlowRunResultError) as raised:
+            await handle.result()
+        assert raised.value.run_id == str(client.flow_run.id)
+        assert await handle.cancel() == "failed"
+
+    asyncio.run(scenario())
+
+
+def test_discarded_local_failure_is_consumed_but_retained_handle_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Task completion consumes unobserved errors without changing retained handles."""
+    failed = asyncio.Event()
+
+    @flow(name="discarded-failure-flow")
+    async def discarded_failure_flow() -> None:
+        failed.set()
+        raise ValueError("discarded failure")
+
+    definition = _definition(monkeypatch, discarded_failure_flow)
+
+    async def scenario() -> None:
+        executor = LocalWorkflowExecutor()
+        loop = asyncio.get_running_loop()
+        contexts: list[dict[str, object]] = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(
+            lambda current_loop, context: contexts.append(dict(context))
+        )
+        try:
+            discarded_handle = await executor.submit(definition, {})
+            del discarded_handle
+            await failed.wait()
+            turn = loop.create_future()
+            loop.call_soon(turn.set_result, None)
+            await turn
+            assert not contexts
+
+            retained_handle = await executor.submit(definition, {})
+            with pytest.raises(FailedFlowRunError) as raised:
+                await retained_handle.result()
+            assert isinstance(raised.value.__cause__, ValueError)
+        finally:
+            loop.set_exception_handler(previous_handler)
+            await executor.shutdown()
+
+    asyncio.run(scenario())

--- a/tests/vendored_prefect_extras/test_smoke.py
+++ b/tests/vendored_prefect_extras/test_smoke.py
@@ -1,0 +1,5 @@
+import opsmill_prefect_extras
+
+
+def test_version():
+    assert opsmill_prefect_extras.__version__

--- a/tests/vendored_prefect_extras/workflows/conftest.py
+++ b/tests/vendored_prefect_extras/workflows/conftest.py
@@ -1,0 +1,28 @@
+"""Pytest configuration for the workflow-catalogue feature tests.
+
+The fixture modules in this package are referenced *by name* from inside the
+objects under test: a ``WorkflowDefinition`` stores its target as the dotted
+module path ``tests.workflows.sentinel`` / ``tests.workflows.flows`` and
+resolves it with ``importlib.import_module``. The repository has no
+``tests/__init__.py`` and no pytest ``pythonpath`` configuration, so those
+dotted paths resolve only while the repository root is on ``sys.path`` (with
+the root present, ``tests`` resolves as an implicit namespace package and
+``tests.workflows`` as this package). Prepending the root here guarantees the
+references import regardless of how pytest is invoked -- from the repo root,
+from a subdirectory, or against a single test file.
+
+Note for test authors: keep ``ModuleNotFoundError`` and the sentinel's own
+``RuntimeError`` distinct in assertions. A ``ModuleNotFoundError`` means this
+path setup is broken (a test-infrastructure bug); the ``RuntimeError`` is the
+behaviour under test. Asserting only "an exception was raised" would let an
+import-isolation or module-import-failure test pass vacuously because the
+fixture simply failed to import.
+"""
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/vendored_prefect_extras/workflows/flows.py
+++ b/tests/vendored_prefect_extras/workflows/flows.py
@@ -1,0 +1,64 @@
+"""Real Prefect flow fixtures, resolvable offline.
+
+Validation and ``load()`` must be exercised against genuine ``prefect.Flow``
+objects rather than stand-ins, so this module holds the real thing. Importing it
+and applying the ``@flow`` decorator needs no Prefect server, no network, and no
+wall-clock sleeps; nothing here is ever executed by the catalogue, which only
+stores the module and function names as strings.
+
+Fixture targets and the identity each one exposes:
+
+===========================  ======================  ==========================
+Attribute                    ``Flow.name``           Purpose
+===========================  ======================  ==========================
+``my_sync_flow``             ``my-sync-flow``        Sync flow taking the
+                                                     decorator's default name,
+                                                     the dashed function name.
+                                                     The matching ``flow_name``
+                                                     for a valid definition.
+``declared_name_flow``       ``declared-name``       Declared name differs from
+                                                     the dashed function name
+                                                     (``declared-name-flow``),
+                                                     so a definition naming
+                                                     either the function or the
+                                                     declared name can produce
+                                                     or avoid a flow-name
+                                                     mismatch.
+``my_async_flow``            ``my-async-flow``       Async flow -- ``isinstance``
+                                                     identifies it as a
+                                                     ``Flow`` just like the sync
+                                                     one.
+``plain_function``           n/a -- not a ``Flow``   Undecorated function, for
+                                                     the not-a-flow message
+                                                     and ``load()``'s
+                                                     ``TypeError``.
+===========================  ======================  ==========================
+
+There is deliberately no missing attribute to reference: tests exercising
+the missing-attribute path name an attribute this module does not define.
+"""
+
+from prefect import flow
+
+
+@flow
+def my_sync_flow() -> str:
+    """Sync flow whose ``Flow.name`` defaults to the dashed function name."""
+    return "my_sync_flow"
+
+
+@flow(name="declared-name")
+def declared_name_flow() -> str:
+    """Flow whose declared name differs from its dashed function name."""
+    return "declared_name_flow"
+
+
+@flow
+async def my_async_flow() -> str:
+    """Async flow -- covered by the same ``isinstance(_, Flow)`` check."""
+    return "my_async_flow"
+
+
+def plain_function() -> str:
+    """Undecorated function: a resolvable attribute that is not a ``Flow``."""
+    return "plain_function"

--- a/tests/vendored_prefect_extras/workflows/sentinel.py
+++ b/tests/vendored_prefect_extras/workflows/sentinel.py
@@ -1,0 +1,24 @@
+"""Fixture module that explodes on import -- the import-isolation proof.
+
+Catalogue construction, key lookup, iteration, key derivation, and
+``to_deployment_input()`` must never import a workflow implementation module. A
+definition pointing at ``tests.workflows.sentinel`` turns that guarantee into an
+executable proof: if any of those operations resolved the reference, the
+``RuntimeError`` below would surface immediately, so a passing test is itself
+evidence the module stayed unimported. Tests pair this with an explicit
+``"tests.workflows.sentinel" not in sys.modules`` assertion.
+
+The explicit resolution paths -- ``WorkflowDefinition.load()`` and
+``validate_definitions`` -- are expected to trip it: ``load()`` propagates this
+very ``RuntimeError`` unwrapped, and validation maps it to a
+module-import failure message.
+
+Assertions MUST match on the ``RuntimeError`` below, never merely on "some
+exception": a ``ModuleNotFoundError`` here would mean the repo root is missing
+from ``sys.path`` (see ``conftest.py``) and would let a test pass vacuously.
+
+Named ``sentinel.py`` rather than ``test_*.py`` so pytest's default collection
+never imports it.
+"""
+
+raise RuntimeError("sentinel module must never be imported by the catalogue")

--- a/tests/vendored_prefect_extras/workflows/test_catalogue.py
+++ b/tests/vendored_prefect_extras/workflows/test_catalogue.py
@@ -1,0 +1,507 @@
+"""Unit tests for ``WorkflowCatalogue``.
+
+Composition and ordering; lookup; membership, immutability, and the deliberate
+non-``Mapping`` shape; import isolation proved against the sentinel module that
+explodes on import; the ``inventory-refresh``/``scheduled`` split-identity round
+trip; and
+construction-time refusal of a duplicate deployment identity. Everything runs
+offline against the fixture modules in this package.
+
+Note for test authors: ``KeyError`` applies ``repr`` to its argument, so
+``str(excinfo.value)`` is the *quoted* message. Substring assertions on
+it therefore work only because the implementation keeps the lookup-miss
+message on a single line -- a newline would come back escaped as ``\\n``.
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+import sys
+from collections.abc import Callable, Iterable, Iterator, Mapping
+
+import pytest
+
+from opsmill_prefect_extras.workflows.catalogue import WorkflowCatalogue
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+FLOWS_MODULE = "tests.workflows.flows"
+SENTINEL_MODULE = "tests.workflows.sentinel"
+
+
+def _definition(
+    flow_name: str,
+    deployment_name: str | None = None,
+    *,
+    module: str = FLOWS_MODULE,
+    function: str = "my_sync_flow",
+    tags: Iterable[str] = (),
+) -> WorkflowDefinition:
+    """Build a definition from this file's fixture defaults."""
+    return WorkflowDefinition(
+        flow_name=flow_name,
+        deployment_name=deployment_name,
+        module=module,
+        function=function,
+        tags=tags,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composition and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_composition_accepts_bare_definitions_and_iterable_groups() -> None:
+    alone = _definition("alone")
+    grouped = (_definition("grouped-first"), _definition("grouped-second"))
+
+    catalogue = WorkflowCatalogue(alone, grouped)
+
+    assert len(catalogue) == 3
+    assert catalogue["alone/alone"] is alone
+    assert catalogue["grouped-first/grouped-first"] is grouped[0]
+
+
+def test_iteration_yields_definitions_in_composition_order() -> None:
+    """Bare definitions and groups are interleaved on purpose: both halves of
+    the ordering rule are exercised in one composition.
+    """
+    first = _definition("first")
+    group = (_definition("group-a"), _definition("group-b"))
+    middle = _definition("middle")
+    tail_group = (_definition("tail-a"), _definition("tail-b"))
+
+    catalogue = WorkflowCatalogue(first, group, middle, tail_group)
+
+    assert list(catalogue) == [first, *group, middle, *tail_group]
+
+
+def test_iteration_yields_definitions_rather_than_keys() -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    items = list(catalogue)
+
+    assert items == [catalogue["infrahub-sync/run"]]
+    for item in items:
+        assert isinstance(item, WorkflowDefinition)
+
+
+def test_composition_order_is_not_sorted_order() -> None:
+    reversed_group = (_definition("zulu"), _definition("mike"), _definition("alfa"))
+
+    catalogue = WorkflowCatalogue(reversed_group)
+
+    assert catalogue.keys() == ("zulu/zulu", "mike/mike", "alfa/alfa")
+
+
+def test_a_group_may_be_any_iterable_including_a_generator() -> None:
+    definitions = (_definition("generated-first"), _definition("generated-second"))
+
+    catalogue = WorkflowCatalogue(definition for definition in definitions)
+
+    assert list(catalogue) == list(definitions)
+
+
+def test_keys_returns_a_tuple_in_composition_order() -> None:
+    catalogue = WorkflowCatalogue(
+        _definition("infrahub-sync", "run"),
+        (_definition("reports", "nightly"), _definition("reports", "weekly")),
+    )
+
+    keys = catalogue.keys()
+
+    assert keys == ("infrahub-sync/run", "reports/nightly", "reports/weekly")
+    assert isinstance(keys, tuple)
+
+
+def test_len_counts_every_composed_definition() -> None:
+    catalogue = WorkflowCatalogue(
+        _definition("one"),
+        (_definition("two"), _definition("three")),
+        _definition("four"),
+    )
+
+    assert len(catalogue) == 4
+
+
+def test_an_empty_catalogue_constructs_and_is_valid() -> None:
+    catalogue = WorkflowCatalogue()
+
+    assert len(catalogue) == 0
+    assert catalogue.keys() == ()
+    assert list(catalogue) == []
+    assert "anything/at-all" not in catalogue
+
+
+def test_an_empty_group_contributes_nothing() -> None:
+    catalogue = WorkflowCatalogue((), _definition("only"), [])
+
+    assert catalogue.keys() == ("only/only",)
+
+
+# ---------------------------------------------------------------------------
+# Lookup by key
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_by_key_returns_the_definition() -> None:
+    definition = _definition("infrahub-sync", "run")
+    catalogue = WorkflowCatalogue(definition)
+
+    assert catalogue[definition.key] is definition
+    assert catalogue["infrahub-sync/run"] is definition
+
+
+def test_lookup_of_a_missing_key_raises_key_error_naming_the_key() -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    with pytest.raises(KeyError) as excinfo:
+        catalogue["no-such-flow/no-such-deployment"]
+
+    assert "no-such-flow/no-such-deployment" in str(excinfo.value)
+
+
+def test_lookup_miss_states_the_key_convention_and_lists_known_keys() -> None:
+    """``KeyError`` reprs its argument, so the assertions read the quoted message."""
+    catalogue = WorkflowCatalogue(
+        _definition("infrahub-sync", "run"),
+        _definition("reports", "nightly"),
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        catalogue["infrahub-sync"]
+
+    message = str(excinfo.value)
+    assert "infrahub-sync" in message
+    assert "flow_name/deployment_name" in message
+    assert "infrahub-sync/run" in message
+    assert "reports/nightly" in message
+
+
+def test_lookup_miss_caps_the_known_keys_listing_and_reports_the_total() -> None:
+    """The count is asserted with its own wording rather than as a bare ``"12"``,
+    which any key happening to contain those digits would satisfy; the
+    summarizing suffix is asserted too -- it is the whole reason the listing is
+    allowed to be incomplete.
+    """
+    definitions = tuple(_definition(f"flow-{index:02d}", "run") for index in range(12))
+    catalogue = WorkflowCatalogue(definitions)
+
+    with pytest.raises(KeyError) as excinfo:
+        catalogue["flow-00"]
+
+    message = str(excinfo.value)
+    listed = [definition.key for definition in definitions if definition.key in message]
+    assert listed == [definition.key for definition in definitions[:10]]
+    assert "flow-10/run" not in message
+    assert "flow-11/run" not in message
+    assert "12 known key(s)" in message
+    assert "(+2 more)" in message
+
+
+def test_lookup_miss_at_the_cap_lists_every_key_without_summarizing() -> None:
+    definitions = tuple(_definition(f"flow-{index:02d}", "run") for index in range(10))
+    catalogue = WorkflowCatalogue(definitions)
+
+    with pytest.raises(KeyError) as excinfo:
+        catalogue["flow-00"]
+
+    message = str(excinfo.value)
+    for definition in definitions:
+        assert definition.key in message
+    assert "10 known key(s)" in message
+    assert "more)" not in message
+
+
+def test_lookup_on_an_empty_catalogue_raises_key_error() -> None:
+    """An empty catalogue has no keys to list, and "0 known key(s): " trailing
+    off into nothing reads like a truncated message -- so the emptiness is
+    stated.
+    """
+    catalogue = WorkflowCatalogue()
+
+    with pytest.raises(KeyError) as excinfo:
+        catalogue["infrahub-sync/run"]
+
+    message = str(excinfo.value)
+    assert "infrahub-sync/run" in message
+    assert "0 known key(s)" in message
+    assert "<none -- this catalogue is empty>" in message
+
+
+# ---------------------------------------------------------------------------
+# Membership, immutability, and the non-Mapping shape
+# ---------------------------------------------------------------------------
+
+
+def test_a_string_tests_key_membership() -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    assert "infrahub-sync/run" in catalogue
+    assert "infrahub-sync" not in catalogue
+    assert "reports/nightly" not in catalogue
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(b"infrahub-sync/run", id="bytes-key"),
+    ],
+)
+def test_other_object_types_are_simply_not_contained(item: object) -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    assert item not in catalogue
+
+
+@pytest.mark.parametrize("name", ["__setitem__", "update", "register"])
+def test_no_mutator_methods_exist(name: str) -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    assert not hasattr(catalogue, name)
+
+
+def test_the_catalogue_is_deliberately_not_a_mapping() -> None:
+    catalogue = WorkflowCatalogue(_definition("infrahub-sync", "run"))
+
+    assert not isinstance(catalogue, Mapping)
+    assert isinstance(iter(catalogue), Iterator)
+
+
+def test_a_catalogue_survives_copy_and_pickle_round_trips() -> None:
+    """Consumer structures holding a catalogue can be deep-copied and pickled."""
+    definitions = (
+        _definition("infrahub-sync", "run", tags=("sync",)),
+        _definition("reports", "nightly"),
+    )
+    catalogue = WorkflowCatalogue(definitions)
+
+    for clone in (
+        copy.deepcopy(catalogue),
+        pickle.loads(pickle.dumps(catalogue)),
+    ):
+        assert clone.keys() == catalogue.keys()
+        assert list(clone) == list(definitions)
+        assert clone["infrahub-sync/run"] == definitions[0]
+
+
+# ---------------------------------------------------------------------------
+# Import isolation
+# ---------------------------------------------------------------------------
+#
+# Every test below pairs a ``sys.modules`` assertion with the sentinel itself:
+# the sentinel raises at import time, so a *passing* test is already proof the
+# operation never resolved the reference. A failed import leaves nothing behind
+# in ``sys.modules``, so the
+# absence assertion holds even after the explicit-load test has tripped it.
+
+
+def _sentinel_definition() -> WorkflowDefinition:
+    """A definition pointing at the module that explodes on import."""
+    return _definition(
+        "explodes-on-import",
+        "run",
+        module=SENTINEL_MODULE,
+        function="anything",
+        tags=("sync",),
+    )
+
+
+def test_construction_does_not_import_the_workflow_module() -> None:
+    assert SENTINEL_MODULE not in sys.modules
+
+    catalogue = WorkflowCatalogue(
+        _sentinel_definition(),
+        (_definition("also-explodes", module=SENTINEL_MODULE, function="anything"),),
+    )
+
+    assert len(catalogue) == 2
+    assert SENTINEL_MODULE not in sys.modules
+
+
+def test_reads_do_not_import_the_workflow_module() -> None:
+    """Lookup, iteration, keys, membership, length, a lookup miss, and
+    rendering the found definition all leave the reference unresolved.
+    """
+    assert SENTINEL_MODULE not in sys.modules
+    definition = _sentinel_definition()
+    catalogue = WorkflowCatalogue(definition)
+
+    found = catalogue["explodes-on-import/run"]
+
+    assert found is definition
+    assert [item.module for item in catalogue] == [SENTINEL_MODULE]
+    assert catalogue.keys() == ("explodes-on-import/run",)
+    assert "explodes-on-import/run" in catalogue
+    assert len(catalogue) == 1
+    with pytest.raises(KeyError):
+        catalogue["explodes-on-import"]
+    assert found.to_deployment_input() == {"name": "run", "tags": ["sync"]}
+    assert SENTINEL_MODULE not in sys.modules
+
+
+def test_only_an_explicit_load_imports_the_workflow_module() -> None:
+    """The other half of the proof: the explicit path *does* resolve.
+
+    Matching the sentinel's own message is what stops this passing vacuously
+    on a ``ModuleNotFoundError`` from a broken fixture path, and ``ImportError``
+    is ruled out explicitly because ``load()`` propagates the target module's
+    own exception unwrapped rather than re-raising it as an import error.
+    """
+    assert SENTINEL_MODULE not in sys.modules
+    catalogue = WorkflowCatalogue(_sentinel_definition())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        catalogue["explodes-on-import/run"].load()
+
+    assert "sentinel module must never be imported by the catalogue" in str(
+        excinfo.value
+    )
+    assert not isinstance(excinfo.value, ImportError)
+    assert SENTINEL_MODULE not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Split-identity round trip
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_refresh_round_trips_through_lookup_and_rendering() -> None:
+    definition = WorkflowDefinition(
+        flow_name="inventory-refresh",
+        deployment_name="scheduled",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=("inventory",),
+        cron="0 2 * * *",
+    )
+    catalogue = WorkflowCatalogue((definition,))
+
+    found = catalogue["inventory-refresh/scheduled"]
+    payload = found.to_deployment_input()
+
+    assert found is definition
+    assert found.flow_name == "inventory-refresh"
+    assert found.deployment_name == "scheduled"
+    assert found.key == "inventory-refresh/scheduled"
+    assert catalogue.keys() == ("inventory-refresh/scheduled",)
+    assert payload["name"] == "scheduled"
+    assert "inventory-refresh" not in payload.values()
+    assert definition.flow_name == "inventory-refresh"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate deployment identity refused
+# ---------------------------------------------------------------------------
+#
+# ``DuplicateWorkflowError`` is imported inside each test function rather than at
+# module level: a module-level import of a name that has gone missing fails
+# collection of the whole file, which masks which individual tests fail.
+
+
+def _compose_individually(
+    first: WorkflowDefinition, second: WorkflowDefinition
+) -> WorkflowCatalogue:
+    """Supply both definitions as separate positional arguments."""
+    return WorkflowCatalogue(first, second)
+
+
+def _compose_within_one_group(
+    first: WorkflowDefinition, second: WorkflowDefinition
+) -> WorkflowCatalogue:
+    """Supply both definitions inside a single definition group."""
+    return WorkflowCatalogue((first, second))
+
+
+def _compose_across_groups(
+    first: WorkflowDefinition, second: WorkflowDefinition
+) -> WorkflowCatalogue:
+    """Supply each definition in a group of its own."""
+    return WorkflowCatalogue((first,), (second,))
+
+
+@pytest.mark.parametrize(
+    "compose",
+    [
+        pytest.param(_compose_individually, id="supplied-individually"),
+        pytest.param(_compose_within_one_group, id="within-one-group"),
+        pytest.param(_compose_across_groups, id="across-groups"),
+    ],
+)
+def test_a_duplicate_identity_is_refused_however_it_is_composed(
+    compose: Callable[[WorkflowDefinition, WorkflowDefinition], WorkflowCatalogue],
+) -> None:
+    from opsmill_prefect_extras.workflows.catalogue import DuplicateWorkflowError
+
+    first = _definition("infrahub-sync", "run")
+    second = _definition("infrahub-sync", "run", function="my_async_flow")
+
+    with pytest.raises(DuplicateWorkflowError) as excinfo:
+        compose(first, second)
+
+    assert excinfo.value.key == "infrahub-sync/run"
+    assert "infrahub-sync/run" in str(excinfo.value)
+
+
+def test_the_duplicate_error_is_a_value_error_naming_the_collision() -> None:
+    """The same definition supplied twice is a duplicate too: composition never
+    silently de-duplicates.
+    """
+    from opsmill_prefect_extras.workflows.catalogue import DuplicateWorkflowError
+
+    definition = _definition("infrahub-sync", "run")
+
+    # Caught as a plain ValueError on purpose: untyped callers must still be
+    # able to catch this conventionally.
+    with pytest.raises(ValueError) as excinfo:
+        WorkflowCatalogue(definition, definition)
+
+    error = excinfo.value
+    assert isinstance(error, DuplicateWorkflowError)
+    assert issubclass(DuplicateWorkflowError, ValueError)
+    assert error.key == "infrahub-sync/run"
+    message = str(error)
+    assert "infrahub-sync/run" in message
+    assert "flow_name/deployment_name" in message
+
+
+def test_a_defaulted_deployment_name_collides_with_the_explicit_one() -> None:
+    """Detection reads the resolved identity, not what was typed."""
+    from opsmill_prefect_extras.workflows.catalogue import DuplicateWorkflowError
+
+    defaulted = _definition("x")
+    explicit = _definition("x", "x")
+
+    with pytest.raises(DuplicateWorkflowError) as excinfo:
+        WorkflowCatalogue(defaulted, explicit)
+    assert excinfo.value.key == "x/x"
+
+
+def test_definitions_differing_in_either_identity_half_compose_freely() -> None:
+    catalogue = WorkflowCatalogue(
+        _definition("reports", "nightly"),
+        _definition("reports", "weekly"),
+        _definition("infrahub-sync", "run"),
+        _definition("ipam-sync", "run"),
+    )
+
+    assert catalogue.keys() == (
+        "reports/nightly",
+        "reports/weekly",
+        "infrahub-sync/run",
+        "ipam-sync/run",
+    )
+
+
+def test_refusing_a_duplicate_does_not_import_the_workflow_module() -> None:
+    from opsmill_prefect_extras.workflows.catalogue import DuplicateWorkflowError
+
+    assert SENTINEL_MODULE not in sys.modules
+
+    with pytest.raises(DuplicateWorkflowError) as excinfo:
+        WorkflowCatalogue(_sentinel_definition(), (_sentinel_definition(),))
+
+    assert excinfo.value.key == "explodes-on-import/run"
+    assert SENTINEL_MODULE not in sys.modules

--- a/tests/vendored_prefect_extras/workflows/test_definitions.py
+++ b/tests/vendored_prefect_extras/workflows/test_definitions.py
@@ -1,0 +1,509 @@
+"""Unit tests for ``WorkflowDefinition``.
+
+Three groups, mirroring the public contract: the value object itself
+(construction, normalization, immutability, key derivation), ``load()``
+resolution, and ``to_deployment_input()`` rendering. Everything runs offline
+against the fixture modules in this package.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Iterable
+from dataclasses import FrozenInstanceError
+from typing import Any, cast
+
+import pytest
+from prefect import flow
+from prefect.flows import Flow
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+
+FLOWS_MODULE = "tests.workflows.flows"
+SENTINEL_MODULE = "tests.workflows.sentinel"
+MISSING_MODULE = "tests.workflows.no_such_module"
+
+
+# ---------------------------------------------------------------------------
+# Value object: construction, normalization, immutability, key
+# ---------------------------------------------------------------------------
+
+
+def _construct_freely(*args: Any, **kwargs: Any) -> WorkflowDefinition:
+    """Construct a definition from arbitrary arguments.
+
+    Any: a deliberately malformed call must reach the constructor's runtime
+    signature, so its argument shape stays opaque to the type gate here.
+    """
+    return WorkflowDefinition(*args, **kwargs)
+
+
+def test_construction_is_keyword_only() -> None:
+    """Positional arguments are refused: the two-name model invites mixups."""
+    with pytest.raises(TypeError):
+        _construct_freely("my-sync-flow", FLOWS_MODULE, "my_sync_flow")
+
+
+def test_instances_are_immutable() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+    # Any: the assignment must dodge the static gate to reach the frozen guard.
+    frozen: Any = definition
+
+    with pytest.raises(FrozenInstanceError):
+        frozen.flow_name = "renamed"
+
+    assert definition.flow_name == "my-sync-flow"
+
+
+def test_omitted_deployment_name_defaults_to_flow_name() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    assert definition.deployment_name == "my-sync-flow"
+    assert definition.key == "my-sync-flow/my-sync-flow"
+
+
+def test_supplied_deployment_name_stays_distinct_from_flow_name() -> None:
+    definition = WorkflowDefinition(
+        flow_name="inventory-refresh",
+        deployment_name="scheduled",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    assert definition.flow_name == "inventory-refresh"
+    assert definition.deployment_name == "scheduled"
+    assert definition.key == "inventory-refresh/scheduled"
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        pytest.param(["sync", "nightly"], id="list"),
+        pytest.param((tag for tag in ("sync", "nightly")), id="generator"),
+    ],
+)
+def test_tags_accept_any_iterable_and_normalize_to_a_tuple(
+    tags: Iterable[str],
+) -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=tags,
+    )
+
+    assert definition.tags == ("sync", "nightly")
+    assert isinstance(definition.tags, tuple)
+
+
+def test_tags_default_to_an_empty_tuple() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    assert definition.tags == ()
+    assert isinstance(definition.tags, tuple)
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        pytest.param("sync", id="str"),
+        pytest.param(b"sync", id="bytes"),
+    ],
+)
+def test_bare_string_tags_raise_type_error_naming_the_field(
+    tags: str | bytes,
+) -> None:
+    """A bare ``str`` or ``bytes`` would char-split silently, so it is refused."""
+    with pytest.raises(TypeError) as excinfo:
+        WorkflowDefinition(
+            flow_name="my-sync-flow",
+            module=FLOWS_MODULE,
+            function="my_sync_flow",
+            # cast: the wrong element type is exactly what is under test.
+            tags=cast("Iterable[str]", tags),
+        )
+
+    message = str(excinfo.value)
+    assert "tags" in message
+    assert "did you mean tags=" in message
+
+
+@pytest.mark.parametrize(
+    ("flow_name", "deployment_name", "offending_field"),
+    [
+        pytest.param("flows/sync", None, "flow_name", id="flow-name"),
+        pytest.param(
+            "infrahub-sync", "run/now", "deployment_name", id="deployment-name"
+        ),
+    ],
+)
+def test_slash_in_either_name_raises_value_error(
+    flow_name: str, deployment_name: str | None, offending_field: str
+) -> None:
+    """``/`` is the key separator, so it is banned in both halves."""
+    with pytest.raises(ValueError) as excinfo:
+        WorkflowDefinition(
+            flow_name=flow_name,
+            deployment_name=deployment_name,
+            module=FLOWS_MODULE,
+            function="my_sync_flow",
+        )
+
+    assert offending_field in str(excinfo.value)
+
+
+def test_a_defaulted_deployment_name_inherits_the_slash_ban() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        WorkflowDefinition(
+            flow_name="flows/sync",
+            module=FLOWS_MODULE,
+            function="my_sync_flow",
+        )
+
+    assert "/" in str(excinfo.value)
+
+
+def test_optional_settings_default_to_none() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    assert definition.cron is None
+    assert definition.concurrency_limit is None
+    assert definition.collision_strategy is None
+    assert definition.entrypoint is None
+
+
+def test_construction_does_not_import_the_target_module() -> None:
+    assert SENTINEL_MODULE not in sys.modules
+
+    definition = WorkflowDefinition(
+        flow_name="explodes-on-import",
+        module=SENTINEL_MODULE,
+        function="anything",
+    )
+
+    assert definition.key == "explodes-on-import/explodes-on-import"
+    assert definition.module == SENTINEL_MODULE
+    assert SENTINEL_MODULE not in sys.modules
+
+
+def test_construction_applies_no_value_validation() -> None:
+    """Validity is Prefect's call, not the library's.
+
+    An unparseable cron, a non-positive concurrency limit, an unknown collision
+    strategy and non-string tags all construct without complaint. Prefect 3.8.1
+    then *accepts* the non-positive concurrency limit and the non-string tags
+    outright, so treating either as a defect would be a validity rule of the
+    library's own; the unparseable cron and the unknown collision strategy are
+    the two that surface through validation -- never through construction.
+    """
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        # cast: a non-string tag element is the point of this assertion.
+        tags=cast("Iterable[str]", (123,)),
+        cron="not a cron",
+        concurrency_limit=0,
+        collision_strategy="NOT_A_STRATEGY",
+    )
+
+    assert definition.tags == (123,)
+    assert definition.cron == "not a cron"
+    assert definition.concurrency_limit == 0
+    assert definition.collision_strategy == "NOT_A_STRATEGY"
+
+
+def test_construction_accepts_a_negative_concurrency_limit() -> None:
+    """No positivity rule of our own -- Prefect 3.8.1 accepts it."""
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        concurrency_limit=-1,
+    )
+
+    assert definition.concurrency_limit == -1
+
+
+# ---------------------------------------------------------------------------
+# Resolution: load()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("function", "expected_flow_name"),
+    [
+        pytest.param("my_sync_flow", "my-sync-flow", id="sync"),
+        pytest.param("declared_name_flow", "declared-name", id="declared-name"),
+        pytest.param("my_async_flow", "my-async-flow", id="async"),
+    ],
+)
+def test_load_returns_the_real_prefect_flow(
+    function: str, expected_flow_name: str
+) -> None:
+    """The definition carries an ``entrypoint`` on purpose: it is deployment-input
+    data only, and resolution must go on following ``module``/``function``. An
+    implementation that substituted the entrypoint would fail to import here.
+    """
+    definition = WorkflowDefinition(
+        flow_name=expected_flow_name,
+        module=FLOWS_MODULE,
+        function=function,
+        entrypoint="whatever/format.py:my_sync_flow",
+    )
+
+    resolved = definition.load()
+
+    assert isinstance(resolved, Flow)
+    assert resolved.name == expected_flow_name
+    assert resolved is getattr(importlib.import_module(FLOWS_MODULE), function)
+
+
+def test_load_missing_module_raises_module_not_found_error() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=MISSING_MODULE,
+        function="my_sync_flow",
+    )
+
+    with pytest.raises(ModuleNotFoundError):
+        definition.load()
+
+
+def test_load_propagates_an_import_time_exception_unwrapped() -> None:
+    """The module's own exception escapes, never wrapped in ``ImportError``.
+
+    Matching the sentinel's message (not merely "some exception") is what stops
+    this passing vacuously on a ``ModuleNotFoundError`` from a broken fixture
+    path -- and ``ImportError`` is asserted against explicitly, since wrapping
+    would hide the target module's real failure from the caller.
+    """
+    definition = WorkflowDefinition(
+        flow_name="explodes-on-import",
+        module=SENTINEL_MODULE,
+        function="anything",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        definition.load()
+
+    assert "sentinel module must never be imported by the catalogue" in str(
+        excinfo.value
+    )
+    assert not isinstance(excinfo.value, ImportError)
+
+
+def test_load_missing_attribute_raises_attribute_error() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="renamed_away",
+    )
+
+    with pytest.raises(AttributeError) as excinfo:
+        definition.load()
+
+    assert "renamed_away" in str(excinfo.value)
+
+
+def test_load_non_flow_target_raises_type_error_naming_key_and_type() -> None:
+    definition = WorkflowDefinition(
+        flow_name="not-a-flow",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="plain_function",
+    )
+
+    with pytest.raises(TypeError) as excinfo:
+        definition.load()
+
+    message = str(excinfo.value)
+    assert "not-a-flow/run" in message
+    # The rendered form in full: the bare word "function" is already a substring
+    # of "plain_function", so matching it would say nothing about the *type* of
+    # the object that resolved -- which is the whole claim of the message.
+    plain_function = importlib.import_module(FLOWS_MODULE).plain_function
+    assert f"resolved a {type(plain_function).__name__} instead" in message
+
+
+def test_load_resolves_fresh_on_every_call() -> None:
+    module_name = "opsmill_prefect_extras_dynamic_fixture"
+
+    @flow(name="dynamic-flow")
+    def dynamic_flow() -> str:
+        return "dynamic_flow"
+
+    module = types.ModuleType(module_name)
+    module.__dict__["dynamic_flow"] = dynamic_flow
+    sys.modules[module_name] = module
+    try:
+        definition = WorkflowDefinition(
+            flow_name="dynamic-flow",
+            module=module_name,
+            function="dynamic_flow",
+        )
+
+        assert definition.load() is dynamic_flow
+
+        del module.__dict__["dynamic_flow"]
+
+        with pytest.raises(AttributeError):
+            definition.load()
+    finally:
+        del sys.modules[module_name]
+
+
+# ---------------------------------------------------------------------------
+# Rendering: to_deployment_input()
+# ---------------------------------------------------------------------------
+
+
+def test_rendering_omits_optional_settings_that_were_not_supplied() -> None:
+    """``name`` and ``tags`` are always present -- ``name`` is the *deployment*
+    name -- and everything unsupplied is an absent key, not an invented default.
+    """
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    payload = definition.to_deployment_input()
+
+    assert payload == {"name": "my-sync-flow", "tags": []}
+    for absent in (
+        "entrypoint",
+        "schedules",
+        "concurrency_limit",
+        "concurrency_options",
+    ):
+        assert absent not in payload
+
+
+def test_rendering_carries_supplied_settings_verbatim() -> None:
+    definition = WorkflowDefinition(
+        flow_name="infrahub-sync",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=("sync",),
+        cron="0 2 * * *",
+        concurrency_limit=4,
+        collision_strategy="CANCEL_NEW",
+        entrypoint="whatever/format.py:my_sync_flow",
+    )
+
+    payload = definition.to_deployment_input()
+
+    assert payload == {
+        "name": "run",
+        "tags": ["sync"],
+        "entrypoint": "whatever/format.py:my_sync_flow",
+        "schedules": [{"schedule": {"cron": "0 2 * * *"}}],
+        "concurrency_limit": 4,
+        "concurrency_options": {"collision_strategy": "CANCEL_NEW"},
+    }
+
+
+def test_rendering_is_plain_data_with_no_prefect_model_instances() -> None:
+    """Only builtin containers and scalars, so the payload stays splattable."""
+    definition = WorkflowDefinition(
+        flow_name="infrahub-sync",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=("sync",),
+        cron="0 2 * * *",
+        concurrency_limit=4,
+        collision_strategy="CANCEL_NEW",
+        entrypoint="whatever/format.py:my_sync_flow",
+    )
+
+    _assert_plain_data(definition.to_deployment_input())
+
+
+def test_rendering_omits_flow_name_but_the_definition_keeps_it() -> None:
+    """``create_deployment`` has no flow-name parameter."""
+    definition = WorkflowDefinition(
+        flow_name="infrahub-sync",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+    payload = definition.to_deployment_input()
+
+    assert "flow_name" not in payload
+    assert "infrahub-sync" not in payload.values()
+    assert definition.flow_name == "infrahub-sync"
+    assert definition.key == "infrahub-sync/run"
+
+
+def test_rendering_returns_a_fresh_dict_per_call() -> None:
+    """Callers may mutate the payload without corrupting the definition."""
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=("sync",),
+    )
+
+    first = definition.to_deployment_input()
+    second = definition.to_deployment_input()
+
+    assert first == second
+    assert first is not second
+    first["name"] = "mutated"
+    first["tags"].append("added")
+
+    assert definition.to_deployment_input() == second
+    assert definition.tags == ("sync",)
+
+
+def test_rendering_never_raises_and_never_imports() -> None:
+    assert SENTINEL_MODULE not in sys.modules
+    definition = WorkflowDefinition(
+        flow_name="explodes-on-import",
+        module=SENTINEL_MODULE,
+        function="anything",
+        cron="not a cron",
+        concurrency_limit=0,
+        collision_strategy="NOT_A_STRATEGY",
+    )
+
+    payload = definition.to_deployment_input()
+
+    assert payload["schedules"] == [{"schedule": {"cron": "not a cron"}}]
+    assert payload["concurrency_limit"] == 0
+    assert payload["concurrency_options"] == {"collision_strategy": "NOT_A_STRATEGY"}
+    assert SENTINEL_MODULE not in sys.modules
+
+
+def _assert_plain_data(value: object) -> None:
+    """Recursively assert ``value`` is built from builtins only."""
+    assert type(value) in (str, int, bool, list, dict), value
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert type(key) is str, key
+            _assert_plain_data(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_plain_data(item)

--- a/tests/vendored_prefect_extras/workflows/test_example.py
+++ b/tests/vendored_prefect_extras/workflows/test_example.py
@@ -1,0 +1,246 @@
+"""The documented example, executed exactly as it is written.
+
+A documented example that no longer runs is a defect, so the example is not
+retyped here. Every module of the tour is parsed straight out of
+``opsmill_prefect_extras.workflows.__doc__``, written to disk verbatim, and
+imported -- the text in the docstring *is* the code under test, so the two
+cannot drift apart: a docstring edit that breaks the tour fails this file, and
+an API change that breaks the tour fails it too.
+
+Each documented module is introduced by a comment naming its path (e.g.
+``# example_app/inventory/workflows.py``), and that marker delimits the blocks.
+Renaming or removing a marker changes what this file executes, which
+:func:`test_the_example_documents_every_module_of_the_tour` is there to catch.
+
+Two mechanics worth knowing:
+
+* ``example_app`` needs no ``__init__.py`` files -- it imports as an implicit
+  namespace package -- so nothing is written that the example does not show.
+* The example's own test module is loaded from its file rather than imported by
+  its documented dotted path, because this repository already has a ``tests``
+  package of its own on ``sys.path``.
+
+Everything runs offline: constructing Prefect ``Flow`` objects and validating
+deployment input are local operations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import re
+import sys
+from ast import literal_eval
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from prefect.flows import Flow
+
+import opsmill_prefect_extras.workflows as workflows_package
+
+EXAMPLE_MODULES = (
+    "example_app/inventory/flows.py",
+    "example_app/inventory/workflows.py",
+    "example_app/reports/flows.py",
+    "example_app/reports/workflows.py",
+    "example_app/composition.py",
+    "tests/test_workflow_catalogue.py",
+)
+"""Every module the tour documents, in the order the docstring presents them."""
+
+FLOW_MODULES = ("example_app.inventory.flows", "example_app.reports.flows")
+"""The example's flow modules -- the ones nothing but resolution may import."""
+
+CONSUMER_TEST_MODULE = "tests/test_workflow_catalogue.py"
+"""The documented path of the example's own CI check."""
+
+EXPECTED_PAYLOAD = {
+    "name": "scheduled",
+    "tags": ["inventory"],
+    "schedules": [{"schedule": {"cron": "0 2 * * *"}}],
+    "concurrency_limit": 1,
+    "concurrency_options": {"collision_strategy": "CANCEL_NEW"},
+}
+"""The rendering the tour promises -- asserted independently of the docstring."""
+
+_MARKER = re.compile(r"^(?P<indent> +)# (?P<path>(?:example_app|tests)/[\w/]+\.py)$")
+_PAYLOAD_LINE = "payload = definition.to_deployment_input()"
+
+
+def _documented_modules() -> dict[str, str]:
+    """Parse the docstring's example into ``documented path -> module source``.
+
+    Returns:
+        One entry per marked block, in docstring order, dedented to column
+        zero and ready to write to disk.
+    """
+    docstring = workflows_package.__doc__
+    assert docstring is not None, "the example lives in the package docstring"
+
+    sources: dict[str, str] = {}
+    lines = docstring.splitlines()
+    index = 0
+    while index < len(lines):
+        marker = _MARKER.match(lines[index])
+        if marker is None:
+            index += 1
+            continue
+        indent = len(marker["indent"])
+        body = [lines[index][indent:]]
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if _MARKER.match(line):
+                break
+            if line.strip() and len(line) - len(line.lstrip()) < indent:
+                break
+            body.append(line[indent:] if line.strip() else "")
+            index += 1
+        sources[marker["path"]] = "\n".join(body).strip("\n") + "\n"
+    return sources
+
+
+def _documented_payload() -> object:
+    """Read back the rendered payload the docstring claims, as an object.
+
+    The tour shows the payload as a commented dict literal directly under the
+    ``to_deployment_input()`` call, so the claim can be compared against what
+    rendering actually produces instead of being taken on trust.
+
+    Returns:
+        The commented dict literal, evaluated.
+    """
+    lines = _documented_modules()["example_app/composition.py"].splitlines()
+    commented = []
+    for line in lines[lines.index(_PAYLOAD_LINE) + 1 :]:
+        if not line.startswith("#"):
+            break
+        commented.append(line[1:].strip())
+    return literal_eval(" ".join(commented))
+
+
+def _load_consumer_test_module(root: Path) -> ModuleType:
+    """Load the example's own test module from its file.
+
+    Args:
+        root: Directory the documented modules were written into.
+
+    Returns:
+        The executed module, with its test function ready to call.
+    """
+    path = root / CONSUMER_TEST_MODULE
+    spec = importlib.util.spec_from_file_location("example_app_consumer_tests", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def example_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Write the documented modules out and make ``example_app`` importable.
+
+    Yields:
+        The directory holding the example, laid out at the documented paths.
+    """
+    for path, source in _documented_modules().items():
+        target = tmp_path / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    yield tmp_path
+
+    for name in [
+        name
+        for name in sys.modules
+        if name == "example_app"
+        or name.startswith(("example_app.", "example_app_consumer_tests"))
+    ]:
+        del sys.modules[name]
+
+
+def test_the_example_documents_every_module_of_the_tour() -> None:
+    assert tuple(_documented_modules()) == EXAMPLE_MODULES
+
+
+def test_declaring_definitions_imports_no_flow_module(example_app: Path) -> None:
+    for name in FLOW_MODULES:
+        assert name not in sys.modules
+
+    inventory = importlib.import_module("example_app.inventory.workflows")
+
+    assert [definition.key for definition in inventory.INVENTORY_WORKFLOWS] == [
+        "inventory-refresh/scheduled"
+    ]
+    assert inventory.INVENTORY_REFRESH.module == "example_app.inventory.flows"
+    for name in FLOW_MODULES:
+        assert name not in sys.modules
+
+
+def test_the_composition_root_composes_both_groups(example_app: Path) -> None:
+    for name in FLOW_MODULES:
+        assert name not in sys.modules
+
+    composition = importlib.import_module("example_app.composition")
+
+    assert composition.CATALOGUE.keys() == (
+        "inventory-refresh/scheduled",
+        "reports/nightly",
+    )
+    assert len(composition.CATALOGUE) == 2
+    for name in FLOW_MODULES:
+        assert name not in sys.modules
+
+
+def test_lookup_returns_the_split_identity_definition(example_app: Path) -> None:
+    composition = importlib.import_module("example_app.composition")
+
+    definition = composition.definition
+
+    assert definition is composition.CATALOGUE["inventory-refresh/scheduled"]
+    assert definition.flow_name == "inventory-refresh"
+    assert definition.deployment_name == "scheduled"
+    assert definition.key == "inventory-refresh/scheduled"
+
+
+def test_the_documented_payload_is_what_rendering_produces(example_app: Path) -> None:
+    composition = importlib.import_module("example_app.composition")
+
+    payload = composition.payload
+
+    assert payload == EXPECTED_PAYLOAD
+    assert payload == _documented_payload()
+    assert "entrypoint" not in payload
+
+
+def test_the_documented_definition_loads_its_real_prefect_flow(
+    example_app: Path,
+) -> None:
+    composition = importlib.import_module("example_app.composition")
+
+    resolved = composition.definition.load()
+
+    assert isinstance(resolved, Flow)
+    assert resolved.name == "inventory-refresh"
+
+
+def test_the_shipped_ci_check_passes_and_resolves_every_flow(
+    example_app: Path,
+) -> None:
+    """The one-import CI check runs green -- and provably did the resolving.
+
+    Asserting the flow modules are in ``sys.modules`` afterwards is what stops
+    this passing vacuously: a check that resolved nothing would leave them
+    absent, exactly as the composition tests above require.
+    """
+    for name in FLOW_MODULES:
+        assert name not in sys.modules
+    consumer_tests = _load_consumer_test_module(example_app)
+
+    consumer_tests.test_workflow_catalogue_resolves()
+
+    for name in FLOW_MODULES:
+        assert name in sys.modules

--- a/tests/vendored_prefect_extras/workflows/test_validation.py
+++ b/tests/vendored_prefect_extras/workflows/test_validation.py
@@ -1,0 +1,1126 @@
+"""Unit tests for aggregate validation and the shipped pytest helper.
+
+Three groups, mirroring the public contract: the typed report objects
+(``DefinitionFailure``, ``ValidationReport``), aggregate
+``validate_definitions`` over both failure axes, and the shipped
+``assert_valid_definitions`` helper consumers wire into their own CI.
+
+Everything runs offline against the fixture modules in this package and real
+``prefect.Flow`` objects -- no Prefect server, no network, no wall-clock sleeps.
+The input axis is exercised only with values Prefect 3.8.1 actually rejects: an
+unparseable cron and an unknown collision strategy. A non-positive
+``concurrency_limit`` and non-string tags are *accepted* by that version, so
+asserting them as defects would invent a validity rule of the library's own --
+validity is Prefect's judgment, not this library's -- and they are asserted here
+as *non*-defects instead.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import FrozenInstanceError, fields
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+import opsmill_prefect_extras.workflows as workflows_package
+from opsmill_prefect_extras.workflows import (
+    _prefect_input_validation as prefect_input_validation,
+)
+from opsmill_prefect_extras.workflows.catalogue import (
+    DuplicateWorkflowError,
+    WorkflowCatalogue,
+)
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+from opsmill_prefect_extras.workflows.validation import (
+    DefinitionFailure,
+    ValidationReport,
+    assert_valid_definitions,
+    validate_definitions,
+)
+
+FLOWS_MODULE = "tests.workflows.flows"
+SENTINEL_MODULE = "tests.workflows.sentinel"
+MISSING_MODULE = "tests.workflows.no_such_module"
+SENTINEL_MESSAGE = "sentinel module must never be imported by the catalogue"
+
+
+def _any_definition() -> WorkflowDefinition:
+    """A definition to hang report objects off; never resolved by these tests."""
+    return WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+
+def _definition_keyed(flow_name: str) -> WorkflowDefinition:
+    """A definition whose key is ``flow_name/run``.
+
+    A :class:`DefinitionFailure` must be keyed by the definition it reports, so
+    a test needing a particular key builds the definition that renders it.
+    """
+    return WorkflowDefinition(
+        flow_name=flow_name,
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+
+
+def _failure(definition: WorkflowDefinition, message: str) -> DefinitionFailure:
+    """One single-message failure for ``definition``."""
+    return DefinitionFailure(definition=definition, messages=(message,))
+
+
+# ---------------------------------------------------------------------------
+# Report types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "instance_factory",
+    [
+        pytest.param(
+            lambda: DefinitionFailure(definition=_any_definition(), messages=("m",)),
+            id="definition-failure",
+        ),
+        pytest.param(lambda: ValidationReport(failures=()), id="validation-report"),
+    ],
+)
+def test_report_types_are_frozen(
+    # Any: the factories build unrelated report types with no supertype.
+    instance_factory: Any,
+) -> None:
+    instance = instance_factory()
+
+    # Frozenness is asserted through the behaviour it exists for -- assignment
+    # raising -- rather than by reading ``__dataclass_params__``, an undocumented
+    # CPython internal.
+    frozen: Any = instance
+    first_field = fields(instance)[0].name
+    with pytest.raises(FrozenInstanceError):
+        setattr(frozen, first_field, None)
+
+
+def test_definition_failure_carries_key_definition_and_messages() -> None:
+    """``key`` is derived from the definition, so the identity ``summary()``
+    prints cannot disagree with the definition it reports.
+    """
+    definition = _any_definition()
+    messages = ("gone", "bad cron")
+
+    failure = DefinitionFailure(definition=definition, messages=messages)
+
+    assert failure.key == "my-sync-flow/run"
+    assert failure.key == definition.key
+    assert failure.definition is definition
+    assert failure.messages == messages
+    assert isinstance(failure.messages, tuple)
+    backfill = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="backfill",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+    )
+    assert _failure(backfill, "m").key == "my-sync-flow/backfill"
+
+
+def test_definition_failure_rejects_an_empty_messages_tuple() -> None:
+    with pytest.raises(ValueError):
+        DefinitionFailure(definition=_any_definition(), messages=())
+
+
+def test_validation_report_of_no_failures_is_valid() -> None:
+    report = ValidationReport(failures=())
+
+    assert report.failures == ()
+    assert report.is_valid is True
+
+
+def test_validation_report_with_failures_is_invalid() -> None:
+    failure = DefinitionFailure(definition=_any_definition(), messages=("m",))
+
+    report = ValidationReport(failures=(failure,))
+
+    assert report.is_valid is False
+    assert report.failures == (failure,)
+
+
+def test_validation_report_keeps_failures_in_the_order_given() -> None:
+    failures = tuple(
+        _failure(_definition_keyed(f"flow-{index}"), f"m{index}") for index in (2, 0, 1)
+    )
+
+    report = ValidationReport(failures=failures)
+
+    assert [failure.key for failure in report.failures] == [
+        "flow-2/run",
+        "flow-0/run",
+        "flow-1/run",
+    ]
+
+
+def test_summary_is_multi_line_and_names_every_failure_and_message() -> None:
+    """The exact text the helper raises with: nothing is summarized away."""
+    definition = _any_definition()
+    gone = _definition_keyed("gone-module")
+    first = DefinitionFailure(definition=gone, messages=("no such module",))
+    second = DefinitionFailure(
+        definition=definition,
+        messages=("renamed_away is gone", "bad cron here"),
+    )
+
+    summary = ValidationReport(failures=(first, second)).summary()
+
+    assert summary.count("\n") >= 4
+    for failure in (first, second):
+        assert failure.key in summary
+        for message in failure.messages:
+            assert message in summary
+
+
+def test_summary_of_a_valid_report_names_nothing() -> None:
+    summary = ValidationReport(failures=()).summary()
+
+    assert isinstance(summary, str)
+    assert summary.strip() != ""
+    assert "/" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Aggregate validation
+# ---------------------------------------------------------------------------
+#
+# Offender builders. Each returns a definition broken in exactly one way,
+# with a key distinct from every other builder's so a mixed catalogue can hold
+# them all at once. The "valid" builders resolve against the real ``Flow``
+# objects in ``tests/workflows/flows.py``.
+
+
+def _valid(deployment_name: str = "run") -> WorkflowDefinition:
+    """A definition that resolves to the real ``my-sync-flow`` flow."""
+    return WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name=deployment_name,
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        tags=("sync",),
+        cron="0 2 * * *",
+        concurrency_limit=4,
+        collision_strategy="CANCEL_NEW",
+    )
+
+
+def _valid_async() -> WorkflowDefinition:
+    """An async flow is a ``Flow`` like any other."""
+    return WorkflowDefinition(
+        flow_name="my-async-flow",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="my_async_flow",
+    )
+
+
+def _valid_declared_name() -> WorkflowDefinition:
+    """Declared ``@flow(name=...)`` matched exactly -- no mismatch."""
+    return WorkflowDefinition(
+        flow_name="declared-name",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="declared_name_flow",
+    )
+
+
+def _missing_module() -> WorkflowDefinition:
+    """The module was moved or deleted."""
+    return WorkflowDefinition(
+        flow_name="gone-module",
+        deployment_name="run",
+        module=MISSING_MODULE,
+        function="my_sync_flow",
+    )
+
+
+def _exploding_module() -> WorkflowDefinition:
+    """The module imports, and raises its own ``RuntimeError`` doing it."""
+    return WorkflowDefinition(
+        flow_name="explodes-on-import",
+        deployment_name="run",
+        module=SENTINEL_MODULE,
+        function="anything",
+    )
+
+
+def _missing_attribute() -> WorkflowDefinition:
+    """The headline case: the implementing function was renamed."""
+    return WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="renamed",
+        module=FLOWS_MODULE,
+        function="renamed_away",
+    )
+
+
+def _not_a_flow() -> WorkflowDefinition:
+    """The attribute resolves, but the ``@flow`` decorator is missing."""
+    return WorkflowDefinition(
+        flow_name="not-a-flow",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="plain_function",
+    )
+
+
+def _name_mismatch() -> WorkflowDefinition:
+    """Declared ``declared-name-flow``; the real flow is ``declared-name``."""
+    return WorkflowDefinition(
+        flow_name="declared-name-flow",
+        deployment_name="run",
+        module=FLOWS_MODULE,
+        function="declared_name_flow",
+    )
+
+
+def _bad_cron() -> WorkflowDefinition:
+    """Resolves fine; Prefect 3.8.1 rejects the cron."""
+    return WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="bad-cron",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        cron="not a cron",
+    )
+
+
+def _bad_collision_strategy() -> WorkflowDefinition:
+    """Resolves fine; the strategy is not a ``ConcurrencyLimitStrategy``."""
+    return WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="bad-strategy",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        concurrency_limit=1,
+        collision_strategy="NOT_A_STRATEGY",
+    )
+
+
+OFFENDERS = (
+    pytest.param(
+        _missing_module,
+        (MISSING_MODULE, "could not be imported"),
+        id="missing-module",
+    ),
+    pytest.param(
+        _exploding_module,
+        (SENTINEL_MODULE, SENTINEL_MESSAGE),
+        id="module-raises-at-import",
+    ),
+    pytest.param(
+        _missing_attribute,
+        ("renamed_away", FLOWS_MODULE, "has no attribute"),
+        id="missing-attribute",
+    ),
+    pytest.param(
+        _not_a_flow,
+        # "resolved a function instead" in full: the bare word "function" is
+        # already a substring of "plain_function", so matching it would prove
+        # nothing about the *type* of the object that resolved.
+        ("plain_function", "resolved a function instead"),
+        id="plain-function-target",
+    ),
+    pytest.param(
+        _name_mismatch,
+        ("'declared-name-flow'", "'declared-name'", "does not match"),
+        id="flow-name-mismatch",
+    ),
+    pytest.param(
+        _bad_cron,
+        ("cron", "not a cron"),
+        id="unparseable-cron",
+    ),
+    pytest.param(
+        _bad_collision_strategy,
+        ("collision_strategy", "NOT_A_STRATEGY"),
+        id="unknown-collision-strategy",
+    ),
+)
+"""The seven offenders, one message each.
+
+The input axis is exercised only via an unparseable cron and an unknown
+collision strategy -- deliberately *not* via a non-positive
+``concurrency_limit`` or non-string tags, which Prefect 3.8.1 accepts.
+"""
+
+
+@pytest.mark.parametrize(("builder", "fragments"), OFFENDERS)
+def test_each_offender_is_reported_with_its_cause(
+    builder: Callable[[], WorkflowDefinition],
+    fragments: tuple[str, ...],
+) -> None:
+    definition = builder()
+
+    report = validate_definitions([definition])
+
+    assert report.is_valid is False
+    assert len(report.failures) == 1
+    failure = report.failures[0]
+    assert failure.key == definition.key
+    assert failure.definition is definition
+    assert len(failure.messages) == 1
+    for fragment in fragments:
+        assert fragment in failure.messages[0]
+
+
+def test_a_module_raising_at_import_is_module_not_importable_not_a_crash() -> None:
+    """The import step catches ``Exception``, not just ``ImportError``.
+
+    A module body propagates its own exception type unwrapped, so an exploding
+    module would crash validation if only ``ImportError`` were caught. Matching
+    the sentinel's own message is what stops this passing vacuously on a
+    ``ModuleNotFoundError`` from a broken fixture path -- which would be the
+    *other* module-import failure and would prove nothing about the broad
+    handler.
+    """
+    assert SENTINEL_MODULE not in sys.modules
+
+    report = validate_definitions([_exploding_module()])
+
+    message = report.failures[0].messages[0]
+    assert "could not be imported" in message
+    assert SENTINEL_MESSAGE in message
+    assert "RuntimeError" in message
+    assert "ModuleNotFoundError" not in message
+
+
+def test_one_call_over_a_mixed_catalogue_reports_every_offender() -> None:
+    """The offenders are interleaved with valid definitions and supplied both
+    individually and inside a group, so nothing about ordering or composition
+    shape can hide a failure.
+    """
+    valid_keys = ("my-sync-flow/nightly", "my-sync-flow/weekly", "my-async-flow/run")
+    catalogue = WorkflowCatalogue(
+        _valid("nightly"),
+        _missing_module(),
+        _valid("weekly"),
+        (_missing_attribute(), _not_a_flow()),
+        _valid_async(),
+        _name_mismatch(),
+        (_bad_cron(), _bad_collision_strategy()),
+        _exploding_module(),
+    )
+
+    report = validate_definitions(catalogue)
+
+    assert [failure.key for failure in report.failures] == [
+        "gone-module/run",
+        "my-sync-flow/renamed",
+        "not-a-flow/run",
+        "declared-name-flow/run",
+        "my-sync-flow/bad-cron",
+        "my-sync-flow/bad-strategy",
+        "explodes-on-import/run",
+    ]
+    assert all(len(failure.messages) == 1 for failure in report.failures)
+    for key in valid_keys:
+        assert key not in [failure.key for failure in report.failures]
+
+
+def test_a_definition_broken_on_both_axes_reports_both_in_one_entry() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="both-axes",
+        module=FLOWS_MODULE,
+        function="renamed_away",
+        cron="not a cron",
+    )
+
+    report = validate_definitions([definition])
+
+    assert len(report.failures) == 1
+    messages = report.failures[0].messages
+    assert len(messages) == 2
+    assert "renamed_away" in messages[0]
+    assert "not a cron" in messages[1]
+
+
+def test_every_rejected_value_gets_its_own_input_axis_message() -> None:
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="two-bad-values",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        cron="not a cron",
+        collision_strategy="NOT_A_STRATEGY",
+    )
+
+    report = validate_definitions([definition])
+
+    messages = report.failures[0].messages
+    assert len(messages) == 2
+    joined = " ".join(messages)
+    assert "not a cron" in joined
+    assert "NOT_A_STRATEGY" in joined
+
+
+def test_schedule_union_noise_is_filtered_out_of_the_report() -> None:
+    """One unparseable cron, one defect -- the union's branch noise is dropped.
+
+    At Prefect 3.8.1 the schedule union answers a single unparseable cron with
+    six errors, of which one is the cron branch's real verdict: three of the
+    other five reject ``cron`` as an extra input (the interval, rrule and
+    no-schedule branches), and two demand the ``interval`` and ``rrule`` fields
+    the payload never carried. Reporting them would bury the real defect.
+
+    The rendered path is asserted in full because the cron branch's own tag is
+    the one thing the renderer strips: leaving it in would put an internal schema
+    branch name in a message about the consumer's payload.
+    """
+    report = validate_definitions([_bad_cron()])
+
+    messages = report.failures[0].messages
+    assert len(messages) == 1
+    message = messages[0]
+    assert message.startswith("schedules.0.schedule.cron: ")
+    assert "not a cron" in message
+    for noise in (
+        "CronSchedule",
+        "IntervalSchedule",
+        "RRuleSchedule",
+        "NoSchedule",
+        "Extra inputs are not permitted",
+        "Field required",
+    ):
+        assert noise not in message
+
+
+def test_schedule_branch_is_located_by_shape_not_a_fixed_path_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A surrounding schema path must not expose union noise or its branch tag."""
+    rejection = _StandInRejection(
+        lambda: [
+            {
+                "loc": (
+                    "request",
+                    "schedules",
+                    0,
+                    "schedule",
+                    "IntervalSchedule",
+                    "cron",
+                ),
+                "msg": "Extra inputs are not permitted",
+                "input": "not a cron",
+            },
+            {
+                "loc": (
+                    "request",
+                    "schedules",
+                    0,
+                    "schedule",
+                    "CronSchedule",
+                    "cron",
+                ),
+                "msg": "Input should be a valid cron expression",
+                "input": "not a cron",
+            },
+        ]
+    )
+    _reject_with(monkeypatch, rejection)
+
+    report = validate_definitions([_bad_cron()])
+
+    messages = report.failures[0].messages
+    assert messages == (
+        "request.schedules.0.schedule.cron: Input should be a valid cron expression "
+        "(got 'not a cron')",
+    )
+
+
+def test_an_all_valid_catalogue_yields_an_empty_valid_report() -> None:
+    catalogue = WorkflowCatalogue(
+        _valid("nightly"), _valid_async(), _valid_declared_name()
+    )
+
+    report = validate_definitions(catalogue)
+
+    assert report.failures == ()
+    assert report.is_valid is True
+
+
+@pytest.mark.parametrize(
+    "definitions",
+    [
+        pytest.param(WorkflowCatalogue(), id="empty-catalogue"),
+        pytest.param(iter(()), id="empty-iterator"),
+    ],
+)
+def test_an_empty_input_yields_an_empty_valid_report(
+    definitions: Iterable[WorkflowDefinition],
+) -> None:
+    report = validate_definitions(definitions)
+
+    assert report.failures == ()
+    assert report.is_valid is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("concurrency_limit", 0, id="zero-concurrency-limit"),
+        pytest.param("concurrency_limit", -1, id="negative-concurrency-limit"),
+        pytest.param("cron", "0 2 * * *", id="valid-cron"),
+        pytest.param("collision_strategy", "ENQUEUE", id="enqueue"),
+        pytest.param("collision_strategy", "CANCEL_NEW", id="cancel-new"),
+        pytest.param(
+            "entrypoint", "whatever/format.py:my_sync_flow", id="free-form-entrypoint"
+        ),
+    ],
+)
+def test_values_prefect_accepts_are_not_defects(
+    field: str,
+    # Any: the parametrized values span differently typed definition fields.
+    value: Any,
+) -> None:
+    """Validity is Prefect's judgment, and Prefect 3.8.1 accepts these.
+
+    A non-positive concurrency limit is the headline case: it looks like an
+    invalid value, but Prefect 3.8.1 stores it as given, so reporting it would
+    be a validity rule of the library's own.
+    """
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        **{field: value},
+    )
+
+    report = validate_definitions([definition])
+
+    assert report.failures == ()
+    assert report.is_valid is True
+
+
+def test_non_string_tags_are_not_defects() -> None:
+    """Prefect 3.8.1 coerces them rather than rejecting them."""
+    definition = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        module=FLOWS_MODULE,
+        function="my_sync_flow",
+        # cast: a non-string tag element is exactly the point of this test.
+        tags=cast("Iterable[str]", (123, object())),
+    )
+
+    report = validate_definitions([definition])
+
+    assert report.failures == ()
+    assert report.is_valid is True
+
+
+def test_validation_resolves_fresh_on_every_call() -> None:
+    module_name = "opsmill_prefect_extras_validation_fixture"
+    module = types.ModuleType(module_name)
+    module.__dict__["dynamic_flow"] = _flows_module().my_sync_flow
+    sys.modules[module_name] = module
+    try:
+        definition = WorkflowDefinition(
+            flow_name="my-sync-flow",
+            module=module_name,
+            function="dynamic_flow",
+        )
+
+        assert validate_definitions([definition]).is_valid is True
+
+        del module.__dict__["dynamic_flow"]
+        second = validate_definitions([definition])
+
+        assert second.is_valid is False
+        assert "has no attribute" in second.failures[0].messages[0]
+        assert "dynamic_flow" in second.failures[0].messages[0]
+    finally:
+        del sys.modules[module_name]
+
+
+def test_validation_sees_a_renamed_flow_across_distinct_modules() -> None:
+    module_name = "opsmill_prefect_extras_rename_fixture"
+    flows = _flows_module()
+    module = types.ModuleType(module_name)
+    module.__dict__["target"] = flows.my_sync_flow
+    sys.modules[module_name] = module
+    try:
+        definition = WorkflowDefinition(
+            flow_name="my-sync-flow", module=module_name, function="target"
+        )
+
+        assert validate_definitions([definition]).is_valid is True
+
+        module.__dict__["target"] = flows.declared_name_flow
+        second = validate_definitions([definition])
+
+        assert "does not match" in second.failures[0].messages[0]
+    finally:
+        del sys.modules[module_name]
+
+
+@pytest.mark.parametrize(
+    "make_definitions",
+    [
+        pytest.param(lambda offenders: WorkflowCatalogue(*offenders), id="catalogue"),
+        pytest.param(list, id="list-group"),
+        pytest.param(
+            lambda offenders: (offender for offender in offenders), id="generator"
+        ),
+    ],
+)
+def test_validate_definitions_accepts_any_iterable(
+    # Any: the parametrized values return deliberately different iterable types.
+    make_definitions: Any,
+) -> None:
+    offenders = (_valid("nightly"), _missing_module(), _missing_attribute())
+
+    report = validate_definitions(make_definitions(offenders))
+
+    assert [failure.key for failure in report.failures] == [
+        "gone-module/run",
+        "my-sync-flow/renamed",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The two halves of the same guarantee: never raise, never silently pass
+# ---------------------------------------------------------------------------
+#
+# ``validate_definitions`` promises both that it never raises for an invalid
+# definition and that it never reports an invalid one as valid, and the two hold
+# together: a crash names no offender at all, and a rejection quietly dropped
+# turns a consumer's CI green on a payload Prefect will refuse at deploy time.
+# The tests below drive the defensive paths that keep both true, with hand-built
+# stand-ins standing where a future Prefect or pydantic would.
+
+LAZY_MODULE = "opsmill_prefect_extras_lazy_export_fixture"
+UNPRINTABLE_MODULE = "opsmill_prefect_extras_unprintable_import_fixture"
+
+UNPRINTABLE_MODULE_SOURCE = '''
+"""A module that fails to import, with an exception that cannot be printed."""
+
+
+class Unprintable(RuntimeError):
+    """An exception whose own ``__str__`` raises."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("message rendering failed")
+
+
+raise Unprintable()
+'''
+"""Fixture source for the unprintable-import case, written out per test."""
+
+
+@contextmanager
+def _lazy_export_module(exc: BaseException) -> Iterator[str]:
+    """Register a module that exports names lazily and fails while doing it.
+
+    The mainstream lazy-export pattern -- a module-level ``__getattr__``
+    (PEP 562) importing a backing module on demand -- means reading a name off
+    the module runs import machinery, so it can raise anything at all instead of
+    the ``AttributeError`` a plain module would.
+
+    Args:
+        exc: What the module raises when a name is read off it.
+
+    Yields:
+        The registered module's dotted name.
+    """
+    module = types.ModuleType(LAZY_MODULE)
+
+    def _module_getattr(name: str) -> object:
+        raise exc
+
+    module.__dict__["__getattr__"] = _module_getattr
+    sys.modules[LAZY_MODULE] = module
+    try:
+        yield LAZY_MODULE
+    finally:
+        del sys.modules[LAZY_MODULE]
+
+
+class _RejectionWithoutErrors(Exception):
+    """A schema rejection carrying no ``errors`` attribute at all."""
+
+
+class _StandInRejection(Exception):
+    """A schema rejection whose ``errors`` is whatever a test needs it to be.
+
+    Stands in for a future Prefect or pydantic whose rejection is not shaped the
+    way this library reads it by duck typing today.
+    """
+
+    def __init__(self, errors: Any) -> None:
+        """Carry ``errors`` verbatim.
+
+        Args:
+            errors: What the stand-in exposes as its ``errors`` attribute.
+                Any: a malformed shape is the whole point, so no narrower
+                type describes the values passed here.
+        """
+        super().__init__("stand-in rejection")
+        self.errors = errors
+
+
+def _reject_with(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Make Prefect's schema construction raise ``exc`` for this test.
+
+    Args:
+        monkeypatch: The active pytest patcher, which undoes this afterwards.
+        exc: The stand-in rejection to raise instead of Prefect's own.
+    """
+
+    # Any: stands in for ``DeploymentCreate``, which refuses every call unread.
+    def _refuse(**_kwargs: Any) -> None:
+        raise exc
+
+    monkeypatch.setattr(prefect_input_validation, "DeploymentCreate", _refuse)
+
+
+def test_a_lazy_export_failure_is_reported_rather_than_raised() -> None:
+    """Reading a lazily exported name can fail with anything, not just AttributeError.
+
+    Catching only ``AttributeError`` at the attribute step would let one such
+    definition in a consumer's catalogue crash the whole aggregate report,
+    naming no offender at all -- the opposite of the one-CI-failure-names-every-
+    offender guarantee. The exception's type is carried into the message so the
+    cause is not lost.
+    """
+    exc = RuntimeError("impl blew up")
+    with _lazy_export_module(exc) as module_name:
+        definition = WorkflowDefinition(
+            flow_name="lazily-exported",
+            module=module_name,
+            function="not_exported_yet",
+        )
+
+        report = validate_definitions([definition])
+
+    assert report.is_valid is False
+    assert len(report.failures) == 1
+    messages = report.failures[0].messages
+    assert len(messages) == 1
+    assert type(exc).__name__ in messages[0]
+    assert "not_exported_yet" in messages[0]
+
+
+def test_a_lazy_export_attribute_error_keeps_its_own_diagnostic() -> None:
+    """A lazily exported name's ``AttributeError`` carries the only real cause.
+
+    A module-level ``__getattr__`` (PEP 562) raising :exc:`AttributeError` is the
+    one attribute failure whose exception text says more than "the name is not
+    there" -- it knows which backing module or export map let the name go
+    missing. Discarding that text would leave an operator with nothing but the
+    stock "was the flow function renamed or moved?", which is the wrong lead
+    entirely here.
+    """
+    diagnostic = "lazy export map has no entry for it since the 2.0 split"
+    with _lazy_export_module(AttributeError(diagnostic)) as module_name:
+        definition = WorkflowDefinition(
+            flow_name="lazily-exported",
+            module=module_name,
+            function="not_exported_yet",
+        )
+
+        report = validate_definitions([definition])
+
+    assert report.is_valid is False
+    messages = report.failures[0].messages
+    assert len(messages) == 1
+    message = messages[0]
+    assert diagnostic in message
+    assert "AttributeError" in message
+    # The actionable sentence is still there: the name really is unreadable.
+    assert "not_exported_yet" in message
+    assert "renamed or moved?" in message
+
+
+def test_an_ordinary_missing_attribute_is_not_reported_twice() -> None:
+    """The stock phrasing states what the message already says.
+
+    The interpreter's own text for a missing module attribute is the defect
+    message's first clause almost word for word, so appending it would print the
+    same fact twice in the report a consumer reads.
+    """
+    definition = _missing_attribute()
+
+    report = validate_definitions([definition])
+
+    message = report.failures[0].messages[0]
+    assert message.count("has no attribute") == 1
+    assert "AttributeError" not in message
+
+
+def test_an_import_failure_that_cannot_be_printed_is_still_a_defect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rendering the defect message runs inside the broad import handler.
+
+    ``str()`` on a target module's own exception is third-party code and can
+    itself raise. The message then has to degrade to naming the exception's type
+    rather than escaping the report.
+    """
+    (tmp_path / f"{UNPRINTABLE_MODULE}.py").write_text(
+        UNPRINTABLE_MODULE_SOURCE, encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    definition = WorkflowDefinition(
+        flow_name="unprintable-import",
+        module=UNPRINTABLE_MODULE,
+        function="anything",
+    )
+
+    report = validate_definitions([definition])
+
+    assert len(report.failures) == 1
+    messages = report.failures[0].messages
+    assert len(messages) == 1
+    assert "could not be imported" in messages[0]
+    assert "Unprintable" in messages[0]
+    assert UNPRINTABLE_MODULE not in sys.modules
+
+
+@pytest.mark.parametrize(
+    "make_rejection",
+    [
+        pytest.param(_RejectionWithoutErrors, id="no-errors-attribute"),
+        pytest.param(
+            lambda: _StandInRejection(lambda: [42, "entry", None]),
+            id="errors-returns-non-mappings",
+        ),
+    ],
+)
+def test_a_rejection_this_library_cannot_read_is_still_one_defect(
+    monkeypatch: pytest.MonkeyPatch,
+    # Any: each parametrized value builds a differently malformed stand-in.
+    make_rejection: Any,
+) -> None:
+    """A rejection is never dropped, however unreadable -- dropping it says "valid".
+
+    Both shapes defeat the entry read: a rejection with no ``errors()`` at all,
+    and one whose entries are not the mappings pydantic documents. In each case
+    Prefect *did* refuse the payload, so the report must still show one defect
+    naming the refusing exception -- silence here is the false pass this report
+    exists to prevent, and an escape is the crash it exists to prevent.
+    """
+    rejection = make_rejection()
+    _reject_with(monkeypatch, rejection)
+
+    report = validate_definitions([_valid_async()])
+
+    assert report.is_valid is False
+    assert len(report.failures) == 1
+    messages = report.failures[0].messages
+    assert len(messages) == 1
+    assert type(rejection).__name__ in messages[0]
+
+
+def _flows_module() -> Any:
+    """Import the real-``Flow`` fixture module.
+
+    Any: a module object's attributes are dynamic by nature.
+    """
+    return __import__(FLOWS_MODULE, fromlist=["my_sync_flow"])
+
+
+# ---------------------------------------------------------------------------
+# The shipped pytest helper
+# ---------------------------------------------------------------------------
+
+OPTIMIZED_HELPER_SCRIPT = '''
+"""Run the shipped helper against a broken definition under ``python -O``.
+
+Deliberately free of ``assert`` statements: under ``-O`` they would vanish,
+which is the very failure mode this script exists to detect.
+"""
+
+if __debug__:
+    raise SystemExit("python -O did not take effect: __debug__ is True")
+
+from opsmill_prefect_extras.workflows.definitions import WorkflowDefinition
+from opsmill_prefect_extras.workflows.validation import assert_valid_definitions
+
+BROKEN = WorkflowDefinition(
+    flow_name="gone-module",
+    module="tests.workflows.no_such_module",
+    function="my_sync_flow",
+)
+
+try:
+    assert_valid_definitions([BROKEN])
+except AssertionError as exc:
+    print("RAISED AssertionError")
+    print("MENTIONS_MODULE", "tests.workflows.no_such_module" in str(exc))
+else:
+    raise SystemExit("the helper did not raise under python -O")
+'''
+"""The optimization-safety check, run in a subprocess with ``-O``."""
+
+
+def test_helper_returns_none_on_valid_and_empty_catalogues() -> None:
+    catalogue = WorkflowCatalogue(
+        _valid("nightly"), _valid_async(), _valid_declared_name()
+    )
+
+    assert assert_valid_definitions(catalogue) is None
+    assert assert_valid_definitions(WorkflowCatalogue()) is None
+
+
+def test_helper_raises_assertion_error_whose_message_is_the_summary() -> None:
+    catalogue = WorkflowCatalogue(_valid("nightly"), _missing_attribute(), _bad_cron())
+    expected = validate_definitions(catalogue).summary()
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_valid_definitions(catalogue)
+
+    assert str(excinfo.value) == expected
+
+
+def test_helper_message_names_every_failing_definition_and_defect() -> None:
+    """The renamed-attribute definition is also broken on the input axis, so the
+    message has to carry two defects for that one entry as well.
+    """
+    two_defects = WorkflowDefinition(
+        flow_name="my-sync-flow",
+        deployment_name="both-axes",
+        module=FLOWS_MODULE,
+        function="renamed_away",
+        cron="not a cron",
+    )
+    catalogue = WorkflowCatalogue(
+        _valid("nightly"),
+        _missing_module(),
+        _exploding_module(),
+        _not_a_flow(),
+        _name_mismatch(),
+        _bad_collision_strategy(),
+        two_defects,
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_valid_definitions(catalogue)
+
+    message = str(excinfo.value)
+    for key in (
+        "gone-module/run",
+        "explodes-on-import/run",
+        "not-a-flow/run",
+        "declared-name-flow/run",
+        "my-sync-flow/bad-strategy",
+        "my-sync-flow/both-axes",
+    ):
+        assert key in message
+    for fragment in (
+        MISSING_MODULE,
+        SENTINEL_MESSAGE,
+        "plain_function",
+        "'declared-name'",
+        "NOT_A_STRATEGY",
+        "renamed_away",
+        "not a cron",
+    ):
+        assert fragment in message
+    assert "my-sync-flow/nightly" not in message
+
+
+def test_helper_raises_for_a_rejection_this_library_cannot_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable rejection reaches the helper as the failure it is.
+
+    ``AssertionError`` is what a consumer's CI is written against. An exception
+    escaping the read of a third-party error shape would surface as itself
+    instead, from a call the consumer made on their own catalogue.
+    """
+    _reject_with(monkeypatch, _RejectionWithoutErrors("schema said no"))
+
+    with pytest.raises(AssertionError) as excinfo:
+        assert_valid_definitions(WorkflowCatalogue(_valid_async()))
+
+    message = str(excinfo.value)
+    assert "my-async-flow/run" in message
+    assert _RejectionWithoutErrors.__name__ in message
+
+
+def test_a_consumer_gets_the_ci_check_from_one_import() -> None:
+    """This is a consumer's whole test body: import the helper from
+    ``opsmill_prefect_extras.workflows`` and hand it the catalogue.
+    """
+    from opsmill_prefect_extras.workflows import (
+        assert_valid_definitions as public_helper,
+    )
+
+    catalogue = WorkflowCatalogue(_valid("nightly"), _valid_async())
+
+    assert public_helper(catalogue) is None
+
+    with pytest.raises(AssertionError):
+        public_helper(WorkflowCatalogue(_missing_attribute()))
+
+
+def test_helper_still_raises_under_python_optimization() -> None:
+    """``python -O`` strips ``assert`` statements; the helper must survive.
+
+    A consumer's non-pytest CI runner may well use ``-O``. An ``assert``-based
+    implementation would silently pass every broken catalogue there, which is
+    why the helper raises ``AssertionError`` explicitly.
+    """
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", OPTIMIZED_HELPER_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "RAISED AssertionError" in result.stdout
+    assert "MENTIONS_MODULE True" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# The public import surface
+# ---------------------------------------------------------------------------
+
+CONTRACT_IMPORT_SURFACE: dict[str, object] = {
+    "WorkflowDefinition": WorkflowDefinition,
+    "WorkflowCatalogue": WorkflowCatalogue,
+    "DuplicateWorkflowError": DuplicateWorkflowError,
+    "DefinitionFailure": DefinitionFailure,
+    "ValidationReport": ValidationReport,
+    "validate_definitions": validate_definitions,
+    "assert_valid_definitions": assert_valid_definitions,
+}
+"""The seven names the contract's import block promises, and what each one is.
+
+These are the names of the single ``from opsmill_prefect_extras.workflows
+import (...)`` block the public API promises, whose whole premise is that one
+import *is* the surface. Every other test in this suite reaches into the
+submodules, so without the two tests below the re-export layer is unguarded: a
+name dropped from it would break every consumer while the suite stayed green.
+"""
+
+
+def test_the_package_exports_exactly_the_contract_import_block() -> None:
+    exported = workflows_package.__all__
+
+    assert set(exported) == set(CONTRACT_IMPORT_SURFACE)
+    assert len(exported) == len(CONTRACT_IMPORT_SURFACE)
+
+
+@pytest.mark.parametrize(("name", "expected"), sorted(CONTRACT_IMPORT_SURFACE.items()))
+def test_each_exported_name_is_the_submodule_object(
+    name: str, expected: object
+) -> None:
+    assert getattr(workflows_package, name) is expected

--- a/uv.lock
+++ b/uv.lock
@@ -1105,7 +1105,6 @@ dev = [
 managed = [
     { name = "fastapi", marker = "python_full_version >= '3.11'" },
     { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "opsmill-prefect-extras", marker = "python_full_version >= '3.11'" },
     { name = "prefect", marker = "python_full_version >= '3.11'" },
     { name = "uvicorn", marker = "python_full_version >= '3.11'" },
 ]
@@ -1124,7 +1123,6 @@ requires-dist = [
     { name = "invoke", marker = "extra == 'dev'", specifier = ">=2.2.1,<3" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "netutils", specifier = ">=1.9,<2.0" },
-    { name = "opsmill-prefect-extras", marker = "python_full_version >= '3.11' and extra == 'managed'", git = "https://github.com/opsmill/prefect-extras.git?rev=84688eb8d8db7e17770413640a66481ccdc3e725" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0,<5.0" },
     { name = "prefect", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = "==3.8.1" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = "==3.8.1" },
@@ -1653,14 +1651,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
-]
-
-[[package]]
-name = "opsmill-prefect-extras"
-version = "0.1.0"
-source = { git = "https://github.com/opsmill/prefect-extras.git?rev=84688eb8d8db7e17770413640a66481ccdc3e725#84688eb8d8db7e17770413640a66481ccdc3e725" }
-dependencies = [
-    { name = "prefect", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Prefect workflow definition, catalogue, and validation capabilities.
  - Added deployment management that creates, updates, and reports deployment status.
  - Added local and remote workflow execution with monitoring, cancellation, idempotent submission, and typed errors.
  - Included the Prefect integration package directly with version information.

- **Documentation**
  - Updated installation, setup, quality, and vendoring guidance.

- **Tests**
  - Added comprehensive coverage for workflows, deployments, executors, packaging, and documented examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

`feature/v3-develop` currently depends on the private `opsmill/prefect-extras` repository at an exact commit on an unmerged branch. Every clone without access to that repository — including CI itself — fails at `uv sync`, which blocks the tests job, keeps the branch's checks red, and forces contributors to request access before they can even install.

This PR vendors the package in-tree and removes the Git dependency. It changes no runtime behavior: the managed execution path runs the same bytes it ran before, from a new location.

## Approach: byte-identical at the original import name

The package ships from this repository at `opsmill_prefect_extras/`, byte-identical (verified file-by-file) to upstream commit `84688eb8d8db7e17770413640a66481ccdc3e725`. Because the upstream modules use absolute internal imports, keeping the original top-level name means:

- zero import rewrites in product code, tests, or the vendored files themselves;
- `diff -r` against the upstream commit is empty, so any local edit is immediately visible as divergence; and
- re-adoption, when upstream is merged and published, is pure deletion plus restoring the dependency line.

The freeze rule and re-adoption condition are recorded in `opsmill_prefect_extras/VENDORED.md`: the directory must not be modified — a change goes upstream first and is re-copied, or the re-adoption plan is explicitly ended.

## Before and after

```bash
# before: requires read access to a private repository, fails in CI
uv sync --extra dev --extra prefect --extra managed

# after: works from any clone
uv sync --extra dev --extra prefect --extra managed
```

## What changed

- `opsmill_prefect_extras/` — byte-identical vendored package (8 files + `VENDORED.md`).
- `tests/vendored_prefect_extras/` — upstream's unit suite, byte-identical, plus a local `conftest.py` that guards on the prefect extra, aliases the `tests.workflows` fixture path to the vendored location, and skips the one test asserting upstream's repository README (178 passed, 1 skipped with reason).
- `pyproject.toml` — Git dependency removed from the `managed` extra; second wheel package declared; vendored dirs excluded from Ruff; `opsmill_prefect_extras` pinned as third-party for import sorting so consumer import blocks stay byte-stable across vendoring and re-adoption.
- `tasks/linter.py` — ty excludes the frozen vendored tests on every profile; the vendored package itself stays type-checked (it passes ty clean).
- `.github/workflows/workflow-tests.yml` — the base-install leg no longer asserts `opsmill_prefect_extras` is unimportable (it is first-party now); the guarantee that the base package never imports it is enforced by `tests/test_no_prefect_import.py`, unchanged.
- `AGENTS.md`, `docs/docs/reference/managed-http-api.mdx` — access-requirement wording removed.

## Validation

- Full suite: **1,523 passed, 15 skipped, 1 xfailed** (previous baseline 1,345 + the 178 vendored tests; the one new skip is the upstream-README test, with its reason in the output)
- `invoke format` and full `invoke lint`: pass (ty's 4 known inherited warn-level unused-ignores remain)
- `uv lock --check`: clean; lockfile no longer references the private repository
- Managed modules import against the vendored package; CLI help/list pass
- Byte-identity verified with `cmp` per file against upstream `84688eb`

## Follow-ups this unblocks (recorded in the program plan)

CI can now install on every leg. The next step wires the gates in: enable a pylint leg, confirm the tests job (including the committed-example byte-identity test) executes, and retire the pylint count baseline. That is a recorded hard gate before any CF-* PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)