### PR TITLE
fix: keep interface-to-LAG relationships readable after sync

### DIFF
--- a/changelog/167.fixed.md
+++ b/changelog/167.fixed.md
@@ -1,0 +1,1 @@
+Fixed destination loading when relationship peers arrive without relationship-valued identifiers: bounded per-UUID hydration repairs the identity, and recoverable peers are retained under `continue_on_error` instead of being dropped.

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -7,6 +7,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from diffsync import Adapter, DiffSyncModel
+from diffsync.exceptions import ObjectNotFound
 from infrahub_sdk import (
     Config,
     InfrahubClientSync,
@@ -291,10 +292,51 @@ class PeerIdentifierError(ValueError):
         super().__init__(msg)
 
 
+def _sdk_node_has_identifiers(node: object, identifiers: tuple[str, ...]) -> bool:
+    """Return whether an SDK node carries every DiffSync identifier value."""
+    schema = getattr(node, "_schema", None)
+    attributes = {attribute.name for attribute in getattr(schema, "attributes", ())}
+    relationships = {relationship.name: relationship for relationship in getattr(schema, "relationships", ())}
+    for identifier in identifiers:
+        if identifier in attributes:
+            attribute = getattr(node, identifier, None)
+            if attribute is None or getattr(attribute, "value", None) is None:
+                return False
+            continue
+
+        relationship = relationships.get(identifier)
+        # Fail closed for unknown fields and cardinality-many relationship
+        # identifiers instead of guessing an identity from an ambiguous value.
+        if relationship is None or relationship.cardinality != "one":
+            return False
+        related_node = getattr(node, identifier, None)
+        if related_node is None or getattr(related_node, "id", None) is None:
+            return False
+    return True
+
+
+def _unresolved_peer_identifiers(
+    peer_data: Mapping[str, Any],
+    identifiers: tuple[str, ...],
+    *,
+    verified_null_identifiers: frozenset[str],
+) -> tuple[str, ...]:
+    """Return identifiers absent from peer data or carrying an unverified null."""
+    return tuple(
+        identifier
+        for identifier in identifiers
+        if identifier not in peer_data
+        or (peer_data[identifier] is None and identifier not in verified_null_identifiers)
+    )
+
+
 class InfrahubAdapter(DiffSyncMixin, Adapter):
     type = "Infrahub"
 
     continue_on_error: bool = False
+    # Cache state: absent means hydration has not been attempted; None means
+    # one attempt was exhausted; a string is the resolved DiffSync identity.
+    _peer_unique_ids: dict[tuple[str, str], str | None]
 
     def __init__(
         self,
@@ -308,6 +350,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         super().__init__(*args, **kwargs)
         self.target = target
         self.config = config
+        self._peer_unique_ids = {}
 
         settings = adapter.settings or {}
         infrahub_url = os.environ.get("INFRAHUB_ADDRESS") or os.environ.get("INFRAHUB_URL") or settings.get("url")
@@ -491,9 +534,32 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
             logger.warning("Unable to map '%s' with kind '%s' - Ignored", peer_node, peer_kind)
             return None
 
-        peer_data = self.infrahub_node_to_diffsync(peer_node)
+        peer_id = str(peer_node.id)
+        cache_key = (peer_kind, peer_id)
+        hydration_attempted = cache_key in self._peer_unique_ids
         identifiers = tuple(peer_model._identifiers)
-        missing = tuple(k for k in identifiers if k not in peer_data)
+        if hydration_attempted:
+            cached_unique_id = self._peer_unique_ids[cache_key]
+            if cached_unique_id is not None:
+                self._reconcile_peer_sdk_alias(
+                    peer_kind=peer_kind,
+                    peer_id=peer_id,
+                    unique_id=cached_unique_id,
+                    identifiers=identifiers,
+                )
+                return cached_unique_id
+
+        peer_data, hydrated, verified_null_identifiers = self._peer_data_with_hydration(
+            peer_node=peer_node,
+            peer_kind=peer_kind,
+            identifiers=identifiers,
+            hydration_attempted=hydration_attempted,
+        )
+        missing = _unresolved_peer_identifiers(
+            peer_data,
+            identifiers,
+            verified_null_identifiers=verified_null_identifiers,
+        )
         if missing:
             err = PeerIdentifierError(
                 parent_kind=parent_node._schema.kind,
@@ -505,18 +571,120 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
                 missing_keys=missing,
                 present_keys=tuple(peer_data.keys()),
             )
+            self._peer_unique_ids[cache_key] = None
             if self.continue_on_error:
-                logger.warning("Skipping peer relationship: %s", err)
+                if not hydration_attempted:
+                    logger.warning("Skipping peer relationship: %s", err)
                 return None
             raise err
 
         unique_id = peer_model.create_unique_id(**{k: peer_data[k] for k in identifiers})
-        peer_item = self.store.get(model=peer_kind, identifier=unique_id)
-        if not peer_item:
+        try:
+            peer_item = self.store.get(model=peer_kind, identifier=unique_id)
+        except ObjectNotFound:
             peer_item = peer_model(**peer_data)
             self.update_or_add_model_instance(peer_item)
-            self.client.store.set(key=unique_id, node=peer_node)
-        return peer_item.get_unique_id()
+
+        # Identifier-only hydration is deliberately adapter-local: inserting its
+        # narrow result into the shared SDK store can replace a fuller node that
+        # was loaded earlier. Reconciliation chooses only nodes that carry the
+        # complete DiffSync identity.
+        self._reconcile_peer_sdk_alias(
+            peer_kind=peer_kind,
+            peer_id=peer_id,
+            unique_id=unique_id,
+            identifiers=identifiers,
+            fallback_node=None if hydrated else peer_node,
+        )
+        resolved_unique_id = peer_item.get_unique_id()
+        self._peer_unique_ids[cache_key] = resolved_unique_id
+        if verified_null_identifiers:
+            logger.warning(
+                "Resolved peer %s[%s] with verified null attribute identifier(s): %s",
+                peer_kind,
+                peer_id,
+                sorted(verified_null_identifiers),
+            )
+        return resolved_unique_id
+
+    def _peer_data_with_hydration(
+        self,
+        *,
+        peer_node: InfrahubNodeSync,
+        peer_kind: str,
+        identifiers: tuple[str, ...],
+        hydration_attempted: bool,
+    ) -> tuple[dict[str, Any], bool, frozenset[str]]:
+        """Read peer data and perform at most one bounded hydration attempt."""
+        peer_data = self.infrahub_node_to_diffsync(peer_node)
+        unresolved_identifiers = _unresolved_peer_identifiers(
+            peer_data,
+            identifiers,
+            verified_null_identifiers=frozenset(),
+        )
+        if not unresolved_identifiers:
+            return peer_data, False, frozenset()
+
+        if hydration_attempted:
+            return peer_data, False, frozenset()
+
+        try:
+            hydrated_peer = self.client.get(
+                id=peer_node.id,
+                kind=peer_kind,
+                include=list(identifiers),
+                populate_store=False,
+            )
+        except NodeNotFoundError:
+            hydrated_peer = None
+        if hydrated_peer is None:
+            return peer_data, False, frozenset()
+
+        hydrated_peer_data = self.infrahub_node_to_diffsync(hydrated_peer)
+        attribute_names = {attribute.name for attribute in getattr(hydrated_peer._schema, "attributes", ())}
+        # Top-level model loads are full fetches. Peer payloads may be shallow,
+        # so only this successful hydration can verify a nullable attribute.
+        verified_null_identifiers = frozenset(
+            identifier
+            for identifier in unresolved_identifiers
+            if identifier in attribute_names
+            and identifier in hydrated_peer_data
+            and hydrated_peer_data[identifier] is None
+        )
+        hydrated_identifiers = {
+            identifier: hydrated_peer_data[identifier]
+            for identifier in identifiers
+            if hydrated_peer_data.get(identifier) is not None or identifier in verified_null_identifiers
+        }
+        return {**peer_data, **hydrated_identifiers}, True, verified_null_identifiers
+
+    def _reconcile_peer_sdk_alias(
+        self,
+        *,
+        peer_kind: str,
+        peer_id: str,
+        unique_id: str,
+        identifiers: tuple[str, ...],
+        fallback_node: InfrahubNodeSync | None = None,
+    ) -> None:
+        """Alias the peer identity key to an identity-complete SDK node, if one exists."""
+        sdk_peer_by_uuid = self.client.store.get(key=peer_id, kind=peer_kind, raise_when_missing=False)
+        sdk_peer_by_identity = self.client.store.get(key=unique_id, kind=peer_kind, raise_when_missing=False)
+        sdk_peer = next(
+            (
+                peer
+                for peer in (sdk_peer_by_uuid, sdk_peer_by_identity, fallback_node)
+                if peer is not None and _sdk_node_has_identifiers(peer, identifiers)
+            ),
+            None,
+        )
+        if sdk_peer is None:
+            # This is the hydration-only path: a non-hydrated success supplies
+            # an identity-complete fallback. Leave two shallow store entries untouched.
+            return
+        if sdk_peer_by_uuid is sdk_peer and sdk_peer_by_identity is sdk_peer:
+            return
+        self.client.store.set(key=unique_id, node=sdk_peer)
 
     def infrahub_node_to_diffsync(self, node: InfrahubNodeSync) -> dict[str, Any]:
         """

--- a/tests/adapters/test_infrahub_incremental.py
+++ b/tests/adapters/test_infrahub_incremental.py
@@ -126,3 +126,28 @@ def test_list_existing_ids_raises_for_unknown_model() -> None:
     adapter = _make_adapter(["InfraDevice"])
     with pytest.raises(NotImplementedError):
         list(adapter.list_existing_ids("MissingKind"))
+
+
+def test_model_loader_requests_mapped_attributes_only() -> None:
+    adapter = _make_adapter(["InfraDevice"])
+    fake_node = MagicMock()
+    adapter.client.all.return_value = [fake_node]  # ty: ignore[unresolved-attribute]
+    adapter.infrahub_node_to_diffsync = MagicMock(  # ty: ignore[invalid-assignment]
+        return_value={"local_id": "device-id", "device": "leaf1", "name": "eth0", "description": "test"}
+    )
+    adapter.update_or_add_model_instance = MagicMock()  # ty: ignore[invalid-assignment]
+
+    fake_model = MagicMock()
+    fake_model._identifiers = ("device", "name")
+    fake_model._attributes = ("description", "name")
+    fake_item = MagicMock()
+    fake_item.get_unique_id.return_value = "leaf1"
+    fake_model.return_value = fake_item
+
+    adapter.model_loader("InfraDevice", fake_model)
+
+    adapter.client.all.assert_called_once_with(  # ty: ignore[unresolved-attribute]
+        kind="InfraDevice",
+        include=["description", "name"],
+        populate_store=True,
+    )

--- a/tests/adapters/test_infrahub_peer_identifier.py
+++ b/tests/adapters/test_infrahub_peer_identifier.py
@@ -1,11 +1,15 @@
 """Unit tests for InfrahubAdapter._resolve_peer_unique_id error and skip paths.
 
 The full adapter touches an Infrahub server, so these tests build a minimal
-stand-in adapter that reuses the real helper. We only care about three things:
+stand-in adapter that reuses the real helper. The focused cases cover:
 
-  1. Missing peer identifier keys raise PeerIdentifierError with rich context.
-  2. continue_on_error=True logs a warning and returns None instead of raising.
-  3. Successful path returns the peer's unique_id.
+- Rich errors for missing peer identifier keys.
+- Skipping missing identifiers when continue_on_error=True.
+- Bounded hydration of missing relationship identifiers.
+- Cache preservation and reuse for repeated peer references.
+- Propagation of unexpected hydration errors.
+- Rich errors after incomplete hydration.
+- Unique ID resolution for complete peers.
 """
 
 from __future__ import annotations
@@ -15,24 +19,70 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from diffsync.exceptions import ObjectNotFound
+from infrahub_sdk.exceptions import NodeNotFoundError
 
-from infrahub_sync.adapters.infrahub import InfrahubAdapter, PeerIdentifierError
+from infrahub_sync import SchemaMappingField, SchemaMappingModel, SyncAdapter, SyncConfig
+from infrahub_sync.adapters.infrahub import InfrahubAdapter, PeerIdentifierError, resolve_peer_node
 
 
 class _FakeStore:
     def __init__(self) -> None:
         self._items: dict[tuple[str, str], object] = {}
+        self.get_error: Exception | None = None
+        self.set_calls: list[tuple[str, object]] = []
 
-    def get(self, *, model: str, identifier: str) -> object:
-        return self._items.get((model, identifier))
+    def get(
+        self,
+        *,
+        model: str | None = None,
+        identifier: str | None = None,
+        kind: str | None = None,
+        key: str | None = None,
+        raise_when_missing: bool = True,
+    ) -> object | None:
+        if self.get_error is not None:
+            raise self.get_error
+        store_key = (model or kind or "", identifier or key or "")
+        if store_key not in self._items:
+            if raise_when_missing:
+                msg = f"{store_key} not present in fake store"
+                raise ObjectNotFound(msg)
+            return None
+        return self._items[store_key]
+
+    def seed(self, *, model: str, identifier: str, item: object) -> None:
+        self._items[model, identifier] = item
 
     def set(self, *, key: str, node: object) -> None:  # match client.store.set signature
-        self._items[getattr(node, "_schema", SimpleNamespace(kind="?")).kind, key] = node
+        self.set_calls.append((key, node))
+        kind = getattr(node, "_schema", SimpleNamespace(kind="?")).kind
+        self._items[kind, key] = node
+        if node_id := getattr(node, "id", None):
+            self._items[kind, node_id] = node
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        rehydrated_peer: object | None = None,
+        *,
+        raise_not_found: bool = False,
+        get_error: Exception | None = None,
+    ) -> None:
         self.store = _FakeStore()
+        self.rehydrated_peer = rehydrated_peer
+        self.raise_not_found = raise_not_found
+        self.get_error = get_error
+        self.get_calls: list[dict[str, object]] = []
+
+    def get(self, **kwargs: object) -> object | None:
+        self.get_calls.append(kwargs)
+        if self.get_error is not None:
+            raise self.get_error
+        if self.raise_not_found:
+            raise NodeNotFoundError(identifier={"id": [str(kwargs["id"])]})
+        return self.rehydrated_peer
 
 
 class _FakePeerModel:
@@ -49,36 +99,167 @@ class _FakePeerModel:
         return type(self).create_unique_id(**self._kwargs)
 
 
+class _FakeLagModel(_FakePeerModel):
+    _identifiers = ("device", "name")
+
+
+class _FakeDeviceModel(_FakePeerModel):
+    _identifiers = ("name",)
+
+
 class _Harness(InfrahubAdapter):
     """Skip the heavy __init__ that needs a real Infrahub server."""
 
-    def __init__(self, *, continue_on_error: bool = False) -> None:
+    client: _FakeClient
+
+    def __init__(
+        self,
+        *,
+        continue_on_error: bool = False,
+        rehydrated_peer: object | None = None,
+        raise_not_found: bool = False,
+        get_error: Exception | None = None,
+    ) -> None:
         # bypass the parent chain entirely
-        self.client = _FakeClient()
-        self.store = _FakeStore()  # ty: ignore[invalid-assignment]
+        self.client = _FakeClient(
+            rehydrated_peer=rehydrated_peer,
+            raise_not_found=raise_not_found,
+            get_error=get_error,
+        )
+        self._diffsync_store = _FakeStore()
+        self.store = self._diffsync_store  # ty: ignore[invalid-assignment]
         self.continue_on_error = continue_on_error
+        self._peer_unique_ids = {}
         self._instances: list[object] = []
         # Register the fake peer model under its kind so getattr(self, kind) works.
         self.LocationGeneric = _FakePeerModel
 
     def update_or_add_model_instance(self, item: object) -> None:  # ty: ignore[invalid-method-override]
         self._instances.append(item)
+        self._diffsync_store.seed(
+            model="LocationGeneric",
+            identifier=item.get_unique_id(),  # ty: ignore[unresolved-attribute]
+            item=item,
+        )
 
     def infrahub_node_to_diffsync(self, node: object) -> dict[str, Any]:  # noqa: PLR6301
         # Return whatever fake data the test attached to the node.
         return dict(node._fake_diffsync_data)  # ty: ignore[unresolved-attribute]
 
 
+class _RelationshipHarness(InfrahubAdapter):
+    """Exercise production conversion without initializing a live client."""
+
+    client: _FakeClient
+
+    def __init__(self, *, rehydrated_peer: object) -> None:
+        self.client = _FakeClient(rehydrated_peer=rehydrated_peer)
+        self._diffsync_store = _FakeStore()
+        self.store = self._diffsync_store  # ty: ignore[invalid-assignment]
+        self.continue_on_error = False
+        self._peer_unique_ids = {}
+        self._instances: list[object] = []
+        self.InterfaceLag = _FakeLagModel
+        self.InfraDevice = _FakeDeviceModel
+        self.schema = {"InfraDevice": SimpleNamespace(kind="InfraDevice")}  # ty: ignore[invalid-assignment]
+        self.config = SyncConfig(
+            name="test",
+            source=SyncAdapter(name="source", adapter="x:x"),
+            destination=SyncAdapter(name="destination", adapter="x:x"),
+            order=["InfraDevice", "InterfaceLag"],
+            schema_mapping=[
+                SchemaMappingModel(
+                    name="InfraDevice",
+                    mapping="InfraDevice",
+                    identifiers=["name"],
+                    fields=[SchemaMappingField(name="name", mapping="name")],
+                ),
+                SchemaMappingModel(
+                    name="InterfaceLag",
+                    mapping="InterfaceLag",
+                    identifiers=["device", "name"],
+                    fields=[
+                        SchemaMappingField(name="device", mapping="device"),
+                        SchemaMappingField(name="name", mapping="name"),
+                        SchemaMappingField(name="description", mapping="description"),
+                    ],
+                ),
+            ],
+        )
+
+    def update_or_add_model_instance(self, item: object) -> None:  # ty: ignore[invalid-method-override]
+        self._instances.append(item)
+
+
 def _make_node(kind: str, node_id: str, diffsync_data: dict[str, object]) -> SimpleNamespace:
-    return SimpleNamespace(
+    node = SimpleNamespace(
         id=node_id,
-        _schema=SimpleNamespace(kind=kind),
+        _schema=SimpleNamespace(
+            kind=kind,
+            attributes=[SimpleNamespace(name=name, optional=False) for name in diffsync_data],
+            relationships=[],
+        ),
         _fake_diffsync_data=diffsync_data,
+    )
+    for name, value in diffsync_data.items():
+        setattr(node, name, SimpleNamespace(value=value))
+    return node
+
+
+def _make_sdk_node(
+    kind: str,
+    node_id: str,
+    attrs: dict[str, object],
+    relationships: dict[str, tuple[str, str]] | None = None,
+) -> SimpleNamespace:
+    relationship_data = relationships or {}
+    node = SimpleNamespace(
+        id=node_id,
+        _schema=SimpleNamespace(
+            kind=kind,
+            attribute_names=list(attrs),
+            attributes=[SimpleNamespace(name=name, optional=False) for name in attrs],
+            relationships=[
+                SimpleNamespace(name=name, peer=peer_kind, cardinality="one")
+                for name, (peer_kind, _peer_id) in relationship_data.items()
+            ],
+        ),
+    )
+    for name, value in attrs.items():
+        setattr(node, name, SimpleNamespace(value=value))
+    for name, (_peer_kind, peer_id) in relationship_data.items():
+        setattr(node, name, SimpleNamespace(id=peer_id))
+    return node
+
+
+def _seed_relationship_stores(harness: _RelationshipHarness, *, peer: object, peer_key: str) -> None:
+    device = _make_sdk_node("InfraDevice", "device-id", {"name": "router-1"})
+    harness.client.store.set(key="router-1", node=device)
+    harness.client.store.set(key=peer_key, node=peer)
+    harness._diffsync_store.seed(
+        model="InfraDevice",
+        identifier="router-1",
+        item=_FakeDeviceModel(name="router-1"),
+    )
+    harness._diffsync_store.seed(
+        model="InterfaceLag",
+        identifier="router-1|lag-1",
+        item=_FakeLagModel(device="router-1", name="lag-1"),
+    )
+
+
+def _resolve_cached_sdk_peer(harness: InfrahubAdapter, *, kind: str, unique_id: str) -> object | None:
+    return resolve_peer_node(
+        key=unique_id,
+        rel_schema=SimpleNamespace(peer=kind),  # ty: ignore[invalid-argument-type]
+        peer_schema=SimpleNamespace(kind=kind),  # ty: ignore[invalid-argument-type]
+        store=harness.client.store,
+        fallback=False,
     )
 
 
 def test_missing_identifier_raises_with_rich_context() -> None:
-    harness = _Harness(continue_on_error=False)
+    harness = _Harness(continue_on_error=False, raise_not_found=True)
     parent = _make_node("InfraDevice", "parent-id", {})
     peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})  # 'organization' missing
 
@@ -109,6 +290,522 @@ def test_missing_identifier_skipped_when_continue_on_error(caplog: pytest.LogCap
     assert any("Skipping peer relationship" in rec.message for rec in caplog.records)
 
 
+def test_missing_relationship_identifier_is_rehydrated_by_uuid() -> None:
+    hydrated_peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"organization": "acme"},
+    )
+    harness = _Harness(rehydrated_peer=hydrated_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"name": "dc-east", "organization": None},
+    )
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="location",
+        peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "dc-east|acme"
+    assert harness.client.get_calls == [
+        {
+            "id": "peer-id",
+            "kind": "LocationGeneric",
+            "include": ["name", "organization"],
+            "populate_store": False,
+        }
+    ]
+    assert len(harness._instances) == 1
+    assert harness.store.get(model="LocationGeneric", identifier="dc-east|acme") is harness._instances[0]
+    assert harness.client.store.get(kind="LocationGeneric", key="peer-id", raise_when_missing=False) is None
+    assert harness.client.store.get(kind="LocationGeneric", key="dc-east|acme", raise_when_missing=False) is None
+    assert _resolve_cached_sdk_peer(harness, kind="LocationGeneric", unique_id="dc-east|acme") is None
+
+
+def test_production_converter_hydration_preserves_stub_non_identifiers() -> None:
+    hydrated_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": None, "description": None},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=hydrated_peer)
+    device = _make_sdk_node("InfraDevice", "device-id", {"name": "router-1"})
+    harness.client.store.set(key="router-1", node=device)
+    harness._diffsync_store.seed(
+        model="InfraDevice",
+        identifier="router-1",
+        item=_FakeDeviceModel(name="router-1"),
+    )
+    stub_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "from relationship stub"},
+    )
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=_make_node("InfraDevice", "parent-id", {}),  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=stub_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "router-1|lag-1"
+    assert len(harness._instances) == 1
+    assert harness._instances[0]._kwargs["description"] == "from relationship stub"  # ty: ignore[unresolved-attribute]
+
+
+def test_partial_sdk_converter_and_fake_store_contracts() -> None:
+    partial_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": None, "description": None},
+        {"device": ("InfraDevice", "")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=partial_peer)
+
+    converted = harness.infrahub_node_to_diffsync(partial_peer)  # ty: ignore[invalid-argument-type]
+
+    assert converted == {"local_id": "lag-id", "name": None, "description": None}
+    with pytest.raises(ObjectNotFound):
+        harness.client.store.get(kind="InterfaceLag", key="missing")
+
+
+def test_relationship_hydration_preserves_rich_sdk_node() -> None:
+    rich_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "rich SDK node"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    identifier_only_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=identifier_only_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    _seed_relationship_stores(harness, peer=rich_peer, peer_key="router-1|lag-1")
+    harness.client.store.set(key="later-shallow", node=shallow_peer)
+
+    results = []
+    for _ in range(2):
+        cached_peer = harness.client.store.get(kind="InterfaceLag", key="lag-id")
+        results.append(
+            harness._resolve_peer_unique_id(
+                parent_node=parent,  # ty: ignore[invalid-argument-type]
+                rel_name="bundle",
+                peer_node=cached_peer,  # ty: ignore[invalid-argument-type]
+            )
+        )
+
+    assert results == ["router-1|lag-1", "router-1|lag-1"]
+    assert harness.client.get_calls == [
+        {
+            "id": "lag-id",
+            "kind": "InterfaceLag",
+            "include": ["device", "name"],
+            "populate_store": False,
+        }
+    ]
+    cached_by_uuid = harness.client.store.get(kind="InterfaceLag", key="lag-id")
+    cached_by_key = harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1")
+    assert cached_by_uuid is rich_peer
+    assert cached_by_key is rich_peer
+    assert cached_by_uuid.description.value == "rich SDK node"
+    assert _resolve_cached_sdk_peer(harness, kind="InterfaceLag", unique_id="router-1|lag-1") is rich_peer
+
+
+def test_relationship_hydration_adds_alias_for_rich_uuid_only_node() -> None:
+    rich_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "rich SDK node"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    identifier_only_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=identifier_only_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    _seed_relationship_stores(harness, peer=rich_peer, peer_key="rich-uuid-only")
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "router-1|lag-1"
+    assert len(harness.client.get_calls) == 1
+    assert harness.client.store.get(kind="InterfaceLag", key="lag-id") is rich_peer
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1") is rich_peer
+    assert _resolve_cached_sdk_peer(harness, kind="InterfaceLag", unique_id="router-1|lag-1") is rich_peer
+
+
+def test_relationship_hydration_prefers_rich_uuid_over_shallow_identity_alias() -> None:
+    rich_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "rich SDK node"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    identifier_only_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=identifier_only_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    _seed_relationship_stores(harness, peer=identifier_only_peer, peer_key="router-1|lag-1")
+    harness.client.store.set(key="later-rich", node=rich_peer)
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "router-1|lag-1"
+    assert len(harness.client.get_calls) == 1
+    assert harness.client.store.get(kind="InterfaceLag", key="lag-id") is rich_peer
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1") is rich_peer
+    assert _resolve_cached_sdk_peer(harness, kind="InterfaceLag", unique_id="router-1|lag-1") is rich_peer
+
+
+def test_reconciliation_prefers_identity_alias_over_complete_fallback() -> None:
+    identity_alias = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "identity alias"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    fallback_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "fallback"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=fallback_peer)
+    device = _make_sdk_node("InfraDevice", "device-id", {"name": "router-1"})
+    harness.client.store.set(key="router-1", node=device)
+    harness.client.store.seed(model="InterfaceLag", identifier="router-1|lag-1", item=identity_alias)
+    harness._diffsync_store.seed(
+        model="InfraDevice",
+        identifier="router-1",
+        item=_FakeDeviceModel(name="router-1"),
+    )
+    harness._diffsync_store.seed(
+        model="InterfaceLag",
+        identifier="router-1|lag-1",
+        item=_FakeLagModel(device="router-1", name="lag-1"),
+    )
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=_make_node("InfraDevice", "parent-id", {}),  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=fallback_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "router-1|lag-1"
+    assert harness.client.store.get(kind="InterfaceLag", key="lag-id") is identity_alias
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1") is identity_alias
+
+
+def test_cached_relationship_identity_repairs_later_shallow_uuid_entry() -> None:
+    rich_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1", "description": "rich SDK node"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=rich_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    _seed_relationship_stores(harness, peer=rich_peer, peer_key="router-1|lag-1")
+
+    first_result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=rich_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    harness.client.store.set(key="later-shallow", node=shallow_peer)
+    second_result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert [first_result, second_result] == ["router-1|lag-1", "router-1|lag-1"]
+    assert not harness.client.get_calls
+    assert harness.client.store.get(kind="InterfaceLag", key="lag-id") is rich_peer
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1") is rich_peer
+    assert _resolve_cached_sdk_peer(harness, kind="InterfaceLag", unique_id="router-1|lag-1") is rich_peer
+
+
+def test_relationship_hydration_is_reused_for_shared_store_references() -> None:
+    identifier_only_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=identifier_only_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    _seed_relationship_stores(harness, peer=shallow_peer, peer_key="initial-shallow")
+
+    results = []
+    for _ in range(2):
+        cached_peer = harness.client.store.get(kind="InterfaceLag", key="lag-id")
+        results.append(
+            harness._resolve_peer_unique_id(
+                parent_node=parent,  # ty: ignore[invalid-argument-type]
+                rel_name="bundle",
+                peer_node=cached_peer,  # ty: ignore[invalid-argument-type]
+            )
+        )
+
+    assert results == ["router-1|lag-1", "router-1|lag-1"]
+    assert harness.client.get_calls == [
+        {
+            "id": "lag-id",
+            "kind": "InterfaceLag",
+            "include": ["device", "name"],
+            "populate_store": False,
+        }
+    ]
+
+
+def test_unexpected_hydration_error_propagates_with_continue_on_error() -> None:
+    get_error = RuntimeError("unexpected hydration failure")
+    harness = _Harness(continue_on_error=True, get_error=get_error)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+        )
+
+    assert excinfo.value is get_error
+
+
+def test_verified_null_attribute_identifier_succeeds_once_and_is_cached(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    hydrated_peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"organization": None},
+    )
+    harness = _Harness(rehydrated_peer=hydrated_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"name": "dc-east", "organization": None},
+    )
+
+    with caplog.at_level(logging.WARNING, logger="infrahub_sync.adapters.infrahub"):
+        results = [
+            harness._resolve_peer_unique_id(
+                parent_node=parent,  # ty: ignore[invalid-argument-type]
+                rel_name="location",
+                peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+            )
+            for _ in range(2)
+        ]
+
+    assert results == ["dc-east|None", "dc-east|None"]
+    assert len(harness.client.get_calls) == 1
+    assert sum("verified null attribute identifier" in record.message for record in caplog.records) == 1
+    assert harness._peer_unique_ids["LocationGeneric", "peer-id"] == "dc-east|None"
+
+
+@pytest.mark.parametrize("hydration_result", ["not-found", "incomplete"])
+def test_unverifiable_null_after_exhausted_hydration_still_errors(hydration_result: str) -> None:
+    harness = _Harness(
+        rehydrated_peer=_make_node("LocationGeneric", "peer-id", {"name": "dc-east"}),
+        raise_not_found=hydration_result == "not-found",
+    )
+    parent = _make_node("InfraDevice", "parent-id", {})
+
+    with pytest.raises(PeerIdentifierError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=_make_node(  # ty: ignore[invalid-argument-type]
+                "LocationGeneric",
+                "peer-id",
+                {"name": "dc-east"},
+            ),
+        )
+    assert excinfo.value.missing_keys == ("organization",)
+
+    with pytest.raises(PeerIdentifierError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=_make_node(  # ty: ignore[invalid-argument-type]
+                "LocationGeneric",
+                "peer-id",
+                {"name": "dc-east", "organization": None},
+            ),
+        )
+
+    assert excinfo.value.missing_keys == ("organization",)
+    assert excinfo.value.parent_kind == "InfraDevice"
+    assert excinfo.value.parent_id == "parent-id"
+    assert excinfo.value.rel_name == "location"
+    assert len(harness.client.get_calls) == 1
+
+
+def test_null_relationship_identifier_is_not_verified_by_hydration() -> None:
+    hydrated_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=hydrated_peer)
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+
+    with pytest.raises(PeerIdentifierError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=_make_node("InfraDevice", "parent-id", {}),  # ty: ignore[invalid-argument-type]
+            rel_name="bundle",
+            peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+        )
+
+    assert excinfo.value.missing_keys == ("device",)
+    assert len(harness.client.get_calls) == 1
+
+
+def test_incomplete_hydration_does_not_merge_with_later_partial_peer() -> None:
+    incomplete_peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})
+    harness = _Harness(rehydrated_peer=incomplete_peer)
+    shallow_peer = _make_node("LocationGeneric", "peer-id", {})
+
+    first_parent = _make_node("InfraDevice", "parent-1", {})
+    with pytest.raises(PeerIdentifierError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=first_parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+        )
+    assert excinfo.value.missing_keys == ("organization",)
+    assert excinfo.value.present_keys == ("name",)
+    assert len(harness.client.get_calls) == 1
+
+    second_parent = _make_node("OtherParent", "parent-2", {})
+    later_partial_peer = _make_node("LocationGeneric", "peer-id", {"organization": "acme"})
+    with pytest.raises(PeerIdentifierError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=second_parent,  # ty: ignore[invalid-argument-type]
+            rel_name="site",
+            peer_node=later_partial_peer,  # ty: ignore[invalid-argument-type]
+        )
+    assert excinfo.value.missing_keys == ("name",)
+    assert excinfo.value.present_keys == ("organization",)
+    assert excinfo.value.parent_kind == "OtherParent"
+    assert excinfo.value.parent_id == "parent-2"
+    assert excinfo.value.rel_name == "site"
+    assert len(harness.client.get_calls) == 1
+
+
+def test_hydration_does_not_alias_identity_incomplete_store_candidates() -> None:
+    identifier_only_peer = _make_sdk_node(
+        "InterfaceLag",
+        "lag-id",
+        {"name": "lag-1"},
+        {"device": ("InfraDevice", "device-id")},
+    )
+    harness = _RelationshipHarness(rehydrated_peer=identifier_only_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_sdk_node("InterfaceLag", "lag-id", {"name": "lag-1"})
+    _seed_relationship_stores(harness, peer=shallow_peer, peer_key="initial-shallow")
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="bundle",
+        peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "router-1|lag-1"
+    assert harness.client.store.get(kind="InterfaceLag", key="lag-id") is shallow_peer
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1", raise_when_missing=False) is None
+
+
+def test_later_complete_peer_recovers_without_second_hydration() -> None:
+    incomplete_peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})
+    harness = _Harness(rehydrated_peer=incomplete_peer)
+    parent = _make_node("InfraDevice", "parent-id", {})
+
+    with pytest.raises(PeerIdentifierError):
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=_make_node("LocationGeneric", "peer-id", {}),  # ty: ignore[invalid-argument-type]
+        )
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="location",
+        peer_node=_make_node(  # ty: ignore[invalid-argument-type]
+            "LocationGeneric",
+            "peer-id",
+            {"name": "dc-east", "organization": "acme"},
+        ),
+    )
+
+    assert result == "dc-east|acme"
+    assert len(harness.client.get_calls) == 1
+
+
+@pytest.mark.parametrize("hydration_result", ["not-found", "incomplete"])
+def test_unresolvable_peer_logs_once_when_continue_on_error(
+    hydration_result: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    incomplete_peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})
+    harness = _Harness(
+        continue_on_error=True,
+        rehydrated_peer=incomplete_peer,
+        raise_not_found=hydration_result == "not-found",
+    )
+    parent = _make_node("InfraDevice", "parent-id", {})
+    shallow_peer = _make_node("LocationGeneric", "peer-id", {"name": "dc-east"})
+
+    with caplog.at_level(logging.WARNING, logger="infrahub_sync.adapters.infrahub"):
+        results = [
+            harness._resolve_peer_unique_id(
+                parent_node=parent,  # ty: ignore[invalid-argument-type]
+                rel_name="location",
+                peer_node=shallow_peer,  # ty: ignore[invalid-argument-type]
+            )
+            for _ in range(2)
+        ]
+
+    assert results == [None, None]
+    assert len(harness.client.get_calls) == 1
+    assert sum("Skipping peer relationship" in record.message for record in caplog.records) == 1
+
+
 def test_complete_peer_returns_unique_id() -> None:
     harness = _Harness()
     parent = _make_node("InfraDevice", "parent-id", {})
@@ -121,3 +818,133 @@ def test_complete_peer_returns_unique_id() -> None:
     result = harness._resolve_peer_unique_id(parent_node=parent, rel_name="location", peer_node=peer)  # ty: ignore[invalid-argument-type]
 
     assert result == "dc-east|acme"
+    assert not harness.client.get_calls
+    assert harness.client.store.get(kind="LocationGeneric", key="peer-id") is peer
+    assert harness.client.store.get(kind="LocationGeneric", key="dc-east|acme") is peer
+
+
+def test_reconciliation_rejects_null_attribute_identifier() -> None:
+    harness = _Harness()
+    incomplete_peer = _make_sdk_node(
+        "LocationGeneric",
+        "peer-id",
+        {"name": None, "organization": "acme"},
+    )
+    harness.client.store.set(key="peer-id", node=incomplete_peer)
+    set_call_count = len(harness.client.store.set_calls)
+
+    harness._reconcile_peer_sdk_alias(
+        peer_kind="LocationGeneric",
+        peer_id="peer-id",
+        unique_id="none|acme",
+        identifiers=("name", "organization"),
+    )
+
+    assert len(harness.client.store.set_calls) == set_call_count
+    assert harness.client.store.get(kind="LocationGeneric", key="none|acme", raise_when_missing=False) is None
+
+
+def test_reconciliation_rejects_null_cardinality_one_relationship_identifier() -> None:
+    harness = _Harness()
+    incomplete_peer = SimpleNamespace(
+        id="lag-id",
+        _schema=SimpleNamespace(
+            kind="InterfaceLag",
+            attributes=[SimpleNamespace(name="name", optional=False)],
+            relationships=[SimpleNamespace(name="device", cardinality="one")],
+        ),
+        name=SimpleNamespace(value="lag-1"),
+        device=SimpleNamespace(id=None),
+    )
+    harness.client.store.set(key="lag-id", node=incomplete_peer)
+    set_call_count = len(harness.client.store.set_calls)
+
+    harness._reconcile_peer_sdk_alias(
+        peer_kind="InterfaceLag",
+        peer_id="lag-id",
+        unique_id="none|lag-1",
+        identifiers=("device", "name"),
+    )
+
+    assert len(harness.client.store.set_calls) == set_call_count
+    assert harness.client.store.get(kind="InterfaceLag", key="none|lag-1", raise_when_missing=False) is None
+
+
+def test_reconciliation_rejects_cardinality_many_relationship_identifier() -> None:
+    harness = _Harness()
+    incomplete_peer = SimpleNamespace(
+        id="lag-id",
+        _schema=SimpleNamespace(
+            kind="InterfaceLag",
+            attributes=[SimpleNamespace(name="name", optional=False)],
+            relationships=[SimpleNamespace(name="device", cardinality="many")],
+        ),
+        name=SimpleNamespace(value="lag-1"),
+        device=SimpleNamespace(id="device-id"),
+    )
+    harness.client.store.set(key="lag-id", node=incomplete_peer)
+    set_call_count = len(harness.client.store.set_calls)
+
+    harness._reconcile_peer_sdk_alias(
+        peer_kind="InterfaceLag",
+        peer_id="lag-id",
+        unique_id="router-1|lag-1",
+        identifiers=("device", "name"),
+    )
+
+    assert len(harness.client.store.set_calls) == set_call_count
+    assert harness.client.store.get(kind="InterfaceLag", key="router-1|lag-1", raise_when_missing=False) is None
+
+
+def test_unexpected_diffsync_store_error_propagates() -> None:
+    harness = _Harness()
+    store_error = RuntimeError("unexpected store failure")
+    harness._diffsync_store.get_error = store_error
+    parent = _make_node("InfraDevice", "parent-id", {})
+    peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"name": "dc-east", "organization": "acme"},
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=peer,  # ty: ignore[invalid-argument-type]
+        )
+
+    assert excinfo.value is store_error
+
+
+def test_complete_peer_adds_identity_alias_without_replacing_uuid_entry() -> None:
+    harness = _Harness()
+    parent = _make_node("InfraDevice", "parent-id", {})
+    rich_peer = _make_node(
+        "LocationGeneric",
+        "peer-id",
+        {"name": "dc-east", "organization": "acme", "description": "rich SDK node"},
+    )
+    harness.client.store.set(key="peer-id", node=rich_peer)
+
+    result = harness._resolve_peer_unique_id(
+        parent_node=parent,  # ty: ignore[invalid-argument-type]
+        rel_name="location",
+        peer_node=rich_peer,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == "dc-east|acme"
+    assert not harness.client.get_calls
+    assert harness.client.store.get(kind="LocationGeneric", key="peer-id") is rich_peer
+    assert harness.client.store.get(kind="LocationGeneric", key="dc-east|acme") is rich_peer
+
+    set_call_count = len(harness.client.store.set_calls)
+    assert (
+        harness._resolve_peer_unique_id(
+            parent_node=parent,  # ty: ignore[invalid-argument-type]
+            rel_name="location",
+            peer_node=rich_peer,  # ty: ignore[invalid-argument-type]
+        )
+        == "dc-east|acme"
+    )
+    assert len(harness.client.store.set_calls) == set_call_count


### PR DESCRIPTION
After syncing a physical interface into a link aggregation group (LAG), the next `diff` or
`sync` can fail before producing a plan. A partial LAG record replaces its complete cached
record, leaving out the device needed to identify it.

When a peer is missing part of its identity, fetch it once by ID and reuse the result during
that load. The targeted response does not overwrite a fuller cached record. Complete peers
need no extra request.

The regression fails before the fix and passes with it; 34 focused tests pass with SDK 1.23.2.
Earlier live testing confirmed an empty second diff, but that run predates the latest branch
update. Current Python CI passes.

Closes #167.
