### PR TITLE
fix: make the v3 preview ready for evaluation

### DIFF
--- a/changelog/+preview-usability.fixed.md
+++ b/changelog/+preview-usability.fixed.md
@@ -1,0 +1,3 @@
+Fixed the disposable preview environment so the Prefect UI connects through its
+published host port, automated smoke writes stay on an isolated Infrahub branch,
+and the NetBox tutorial installs code and configuration from the same preview tag.

--- a/development/README.md
+++ b/development/README.md
@@ -11,6 +11,10 @@ Infrahub branch. `main` stays empty, so the custom-example CLI walkthrough
 starts with five creates; after applying that reviewed plan, the next plan has
 zero operations.
 
+`preview.up` checks that pristine `main` state during startup. After completing
+the walkthrough, rerun `preview.smoke`, or reset volumes before running
+`preview.up` again.
+
 ## Start
 
 ```bash

--- a/development/README.md
+++ b/development/README.md
@@ -6,6 +6,11 @@ HTTP API, a Prefect worker running the managed deployment, a loaded example
 schema, and a first saved plan — finished with an automatic smoke run across
 every preview surface so you never start from a broken environment.
 
+The smoke run writes its five example devices only to the `preview-smoke`
+Infrahub branch. `main` stays empty, so the custom-example CLI walkthrough
+starts with five creates; after applying that reviewed plan, the next plan has
+zero operations.
+
 ## Start
 
 ```bash

--- a/development/docker-compose.preview.yml
+++ b/development/docker-compose.preview.yml
@@ -23,6 +23,8 @@ services:
   sync-prefect:
     image: "prefecthq/prefect:${PREVIEW_PREFECT_IMAGE_TAG:-3.8.1-python3.12}"
     command: prefect server start --host 0.0.0.0 --port 4200
+    environment:
+      PREFECT_SERVER_UI_API_URL: "http://localhost:${PREVIEW_PREFECT_PORT:-4210}/api"
     ports:
       - "${PREVIEW_PREFECT_PORT:-4210}:4200"
     healthcheck:

--- a/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
+++ b/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
@@ -85,12 +85,11 @@ You should see the Infrahub web interface with a navigation menu on the left sid
 
 ## Install infrahub-sync
 
-1. Install the Python dependencies with uv. This tutorial documents behavior from the
-   v3 development branch, which is not yet published to PyPI, so install directly from
-   the repository:
+1. Install the Python dependencies with uv. This tutorial documents the experimental
+   `v3-preview.1` release, which is not published to PyPI, so install its Git tag directly:
 
 ```bash
-uv add "infrahub-sync @ git+https://github.com/opsmill/infrahub-sync.git@feature/v3-develop" pynetbox
+uv add "infrahub-sync @ git+https://github.com/opsmill/infrahub-sync.git@v3-preview.1" pynetbox
 ```
 
 This installs the `infrahub-sync` command. `pynetbox` is required by the NetBox adapter.
@@ -197,7 +196,7 @@ From your project directory (`infrahub-automation`), create a sync project direc
 ```bash
 mkdir -p sync-projects/netbox-demo
 curl -L \
-  https://raw.githubusercontent.com/opsmill/infrahub-sync/refs/heads/main/examples/netbox_to_infrahub/config.yml \
+  https://raw.githubusercontent.com/opsmill/infrahub-sync/refs/tags/v3-preview.1/examples/netbox_to_infrahub/config.yml \
   -o sync-projects/netbox-demo/config.yml
 ```
 

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -39,6 +39,7 @@ COMPOSE_FILES = (
 )
 SCHEMA_FILE = REPO_ROOT / "examples" / "prefect_remote_run" / "schemas" / "infra_device.yml"
 SMOKE_BRANCH = "preview-smoke"
+EXPECT_MAIN_EMPTY_ENV = "INFRAHUB_SYNC_PREVIEW_EXPECT_MAIN_EMPTY"
 # Process name -> substring its command line must contain before a recorded pid
 # is treated as ours (guards against pid recycling by unrelated processes).
 MANAGED_PROCESSES = {
@@ -281,7 +282,7 @@ def up(context: Context) -> None:
     print(f" - [{NAMESPACE}] Creating a first saved plan (custom-example)")
     context.run("uv run infrahub-sync diff --name custom-example --directory examples/", env=env)
 
-    smoke(context)
+    _run_smoke(context, expect_main_empty=True)
 
     tokens = json.loads(values["PREVIEW_BEARER_TOKENS"])
     print(f" - [{NAMESPACE}] Preview environment ready")
@@ -293,15 +294,18 @@ def up(context: Context) -> None:
     print("     Next: docs/docs/reference/managed-http-api.mdx and `uv run invoke preview.status`")
 
 
-@task
-def smoke(context: Context) -> None:
-    """Run the preview smoke suite against the running environment."""
+def _run_smoke(context: Context, *, expect_main_empty: bool) -> None:
+    """Run reusable smoke checks, optionally including startup acceptance."""
     from infrahub_sdk.exceptions import (  # noqa: PLC0415 -- keep Invoke task imports lightweight
         ServerNotReachableError,
     )
 
     values = load_preview_env()
     env = _runtime_env(values)
+    if expect_main_empty:
+        env[EXPECT_MAIN_EMPTY_ENV] = "1"
+    else:
+        env.pop(EXPECT_MAIN_EMPTY_ENV, None)
     print(f" - [{NAMESPACE}] Ensuring the {SMOKE_BRANCH} Infrahub branch exists")
     try:
         ensure_smoke_branch(env)
@@ -312,6 +316,12 @@ def smoke(context: Context) -> None:
     print(f" - [{NAMESPACE}] Running the preview smoke suite")
     with context.cd(ESCAPED_REPO_PATH):
         context.run("uv run pytest -m preview tests/preview -q", env=env)
+
+
+@task
+def smoke(context: Context) -> None:
+    """Run reusable smoke checks against the running environment."""
+    _run_smoke(context, expect_main_empty=False)
 
 
 @task

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -38,6 +38,7 @@ COMPOSE_FILES = (
     DEV_DIR / "docker-compose.preview.yml",
 )
 SCHEMA_FILE = REPO_ROOT / "examples" / "prefect_remote_run" / "schemas" / "infra_device.yml"
+SMOKE_BRANCH = "preview-smoke"
 # Process name -> substring its command line must contain before a recorded pid
 # is treated as ours (guards against pid recycling by unrelated processes).
 MANAGED_PROCESSES = {
@@ -115,7 +116,21 @@ def _compose(context: Context, arguments: str, values: dict[str, str]) -> None:
         f"--env-file {shlex.quote(str(ENV_FILE))} {files} {arguments}"
     )
     with context.cd(ESCAPED_REPO_PATH):
-        context.run(command, pty=False)
+        # Compose reads the shipped file itself; inject the merged values so
+        # preview.local.env overrides drive containers and task URLs together.
+        context.run(command, env=values, pty=False)
+
+
+def ensure_smoke_branch(env: dict[str, str]) -> None:
+    """Create the disposable smoke branch when it is not already present."""
+    from infrahub_sdk import InfrahubClientSync  # noqa: PLC0415 -- keep Invoke task imports lightweight
+
+    client = InfrahubClientSync(
+        address=env["INFRAHUB_ADDRESS"],
+        config={"api_token": env["INFRAHUB_API_TOKEN"]},
+    )
+    if SMOKE_BRANCH not in client.branch.all():
+        client.branch.create(SMOKE_BRANCH, sync_with_git=False)
 
 
 _SERVER_ERROR_FLOOR = 500
@@ -281,10 +296,22 @@ def up(context: Context) -> None:
 @task
 def smoke(context: Context) -> None:
     """Run the preview smoke suite against the running environment."""
+    from infrahub_sdk.exceptions import (  # noqa: PLC0415 -- keep Invoke task imports lightweight
+        ServerNotReachableError,
+    )
+
     values = load_preview_env()
+    env = _runtime_env(values)
+    print(f" - [{NAMESPACE}] Ensuring the {SMOKE_BRANCH} Infrahub branch exists")
+    try:
+        ensure_smoke_branch(env)
+    except ServerNotReachableError:
+        # Preserve the suite's polite stopped-environment behavior: its session
+        # fixture reports the unavailable endpoint and skips the preview tests.
+        print(f" - [{NAMESPACE}] Infrahub is not reachable; smoke tests will report the environment state")
     print(f" - [{NAMESPACE}] Running the preview smoke suite")
     with context.cd(ESCAPED_REPO_PATH):
-        context.run("uv run pytest -m preview tests/preview -q", env=_runtime_env(values))
+        context.run("uv run pytest -m preview tests/preview -q", env=env)
 
 
 @task

--- a/tests/preview/test_cli_cycle.py
+++ b/tests/preview/test_cli_cycle.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from infrahub_sync.cli import app
+from tasks.preview import SMOKE_BRANCH
 
 pytestmark = pytest.mark.preview
 
@@ -36,7 +37,10 @@ def test_cli_plan_review_apply_refusal_and_convergence(cli_environment: dict[str
     examples = cli_environment["examples_dir"]
 
     before = _run_ids(cache_dir)
-    planned = runner.invoke(app, ["diff", "--name", "custom-example", "--directory", examples])
+    planned = runner.invoke(
+        app,
+        ["diff", "--name", "custom-example", "--directory", examples, "--branch", SMOKE_BRANCH],
+    )
     assert planned.exit_code == 0, planned.output
     created = _run_ids(cache_dir) - before
     assert len(created) == 1, f"expected exactly one new run, got {created}"
@@ -62,6 +66,8 @@ def test_cli_plan_review_apply_refusal_and_convergence(cli_environment: dict[str
             run_id,
             "--expected-checksum",
             WRONG_CHECKSUM,
+            "--branch",
+            SMOKE_BRANCH,
         ],
     )
     assert refused.exit_code != 0, "apply must refuse a checksum that does not match the reviewed plan"
@@ -78,11 +84,16 @@ def test_cli_plan_review_apply_refusal_and_convergence(cli_environment: dict[str
             run_id,
             "--expected-checksum",
             checksum,
+            "--branch",
+            SMOKE_BRANCH,
         ],
     )
     assert applied.exit_code == 0, applied.output
 
-    convergence = runner.invoke(app, ["diff", "--name", "custom-example", "--directory", examples])
+    convergence = runner.invoke(
+        app,
+        ["diff", "--name", "custom-example", "--directory", examples, "--branch", SMOKE_BRANCH],
+    )
     assert convergence.exit_code == 0, convergence.output
     new_run = (_run_ids(cache_dir) - before) - {run_id}
     assert len(new_run) == 1

--- a/tests/preview/test_managed_api.py
+++ b/tests/preview/test_managed_api.py
@@ -9,6 +9,8 @@ from typing import Any
 import httpx
 import pytest
 
+from tasks.preview import SMOKE_BRANCH
+
 pytestmark = pytest.mark.preview
 
 POLL_TIMEOUT_SECONDS = 240
@@ -58,6 +60,7 @@ def test_managed_plan_and_apply_lifecycle(preview_env: dict[str, Any]) -> None:
                 "sync_name": "custom-example",
                 "operation": "plan",
                 "configuration_reference": "preview-smoke",
+                "branch": SMOKE_BRANCH,
                 "reason": "preview smoke: create a managed plan",
             },
         )
@@ -79,6 +82,7 @@ def test_managed_plan_and_apply_lifecycle(preview_env: dict[str, Any]) -> None:
             json={
                 "expected_checksum": checksum,
                 "confirm_writes": True,
+                "branch": SMOKE_BRANCH,
                 "reason": "preview smoke: apply the reviewed plan",
             },
         )

--- a/tests/preview/test_preview_configuration.py
+++ b/tests/preview/test_preview_configuration.py
@@ -1,0 +1,134 @@
+"""Regression checks for the disposable preview environment."""
+
+from contextlib import nullcontext
+from typing import TYPE_CHECKING, cast
+
+import infrahub_sdk
+import pytest
+from infrahub_sdk.exceptions import ServerNotReachableError
+from invoke import Context
+
+from tasks import preview
+from tasks.preview import (
+    COMPOSE_FILES,
+    DEV_DIR,
+    ENV_FILE,
+    REPO_ROOT,
+    SMOKE_BRANCH,
+    ensure_smoke_branch,
+)
+
+if TYPE_CHECKING:
+    from invoke.tasks import Task
+
+
+def test_preview_routes_prefect_ui_to_the_published_host_port() -> None:
+    compose = (DEV_DIR / "docker-compose.preview.yml").read_text(encoding="utf-8")
+
+    assert 'PREFECT_SERVER_UI_API_URL: "http://localhost:${PREVIEW_PREFECT_PORT:-4210}/api"' in compose
+
+
+def test_compose_receives_merged_local_preview_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, str], bool]] = []
+    context = Context()
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(context, "run", lambda command, *, env, pty: calls.append((command, env, pty)))
+
+    values = {
+        "COMPOSE_PROJECT_NAME": "preview-test",
+        "PREVIEW_PREFECT_PORT": "4321",
+    }
+    preview._compose(context, "config", values)
+
+    assert calls == [
+        (
+            "docker compose --project-name preview-test "
+            f"--env-file {ENV_FILE} " + " ".join(f"-f {path}" for path in COMPOSE_FILES) + " config",
+            values,
+            False,
+        )
+    ]
+
+
+def test_smoke_branch_creation_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: list[tuple[str, bool]] = []
+
+    class BranchManager:
+        def __init__(self) -> None:
+            self.branches: dict[str, object] = {}
+
+        def all(self) -> dict[str, object]:
+            return self.branches
+
+        def create(self, branch_name: str, *, sync_with_git: bool) -> None:
+            created.append((branch_name, sync_with_git))
+            self.branches[branch_name] = object()
+
+    branch_manager = BranchManager()
+
+    class Client:
+        branch = branch_manager
+
+    monkeypatch.setattr(infrahub_sdk, "InfrahubClientSync", lambda **_kwargs: Client())
+    environment = {"INFRAHUB_ADDRESS": "http://127.0.0.1:8080", "INFRAHUB_API_TOKEN": "local-token"}
+
+    ensure_smoke_branch(environment)
+    ensure_smoke_branch(environment)
+
+    assert created == [(SMOKE_BRANCH, False)]
+
+
+def test_standalone_smoke_ensures_its_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[object] = []
+    context = Context()
+    values = {"COMPOSE_PROJECT_NAME": "preview-test"}
+    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
+
+    monkeypatch.setattr(preview, "load_preview_env", lambda: values)
+    monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
+    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda env: events.append(("branch", env)))
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(
+        context,
+        "run",
+        lambda command, *, env: events.append(("run", command, env)),
+    )
+
+    cast("Task", preview.smoke).body(context)
+
+    assert events == [
+        ("branch", environment),
+        ("run", "uv run pytest -m preview tests/preview -q", environment),
+    ]
+
+
+def test_standalone_smoke_leaves_an_unreachable_environment_to_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[object] = []
+    context = Context()
+    values = {"COMPOSE_PROJECT_NAME": "preview-test"}
+    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
+
+    monkeypatch.setattr(preview, "load_preview_env", lambda: values)
+    monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
+    monkeypatch.setattr(
+        preview,
+        "ensure_smoke_branch",
+        lambda _env: (_ for _ in ()).throw(ServerNotReachableError(environment["INFRAHUB_ADDRESS"])),
+    )
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(
+        context,
+        "run",
+        lambda command, *, env: events.append(("run", command, env)),
+    )
+
+    cast("Task", preview.smoke).body(context)
+
+    assert events == [("run", "uv run pytest -m preview tests/preview -q", environment)]
+
+
+def test_netbox_tutorial_uses_the_preview_1_tag_for_code_and_configuration() -> None:
+    tutorial = (REPO_ROOT / "docs/docs/tutorials/netbox-demo-to-infrahub.mdx").read_text(encoding="utf-8")
+
+    assert "infrahub-sync.git@v3-preview.1" in tutorial
+    assert "infrahub-sync/refs/tags/v3-preview.1/examples/netbox_to_infrahub/config.yml" in tutorial

--- a/tests/preview/test_preview_configuration.py
+++ b/tests/preview/test_preview_configuration.py
@@ -13,6 +13,7 @@ from tasks.preview import (
     COMPOSE_FILES,
     DEV_DIR,
     ENV_FILE,
+    EXPECT_MAIN_EMPTY_ENV,
     REPO_ROOT,
     SMOKE_BRANCH,
     ensure_smoke_branch,
@@ -82,7 +83,11 @@ def test_standalone_smoke_ensures_its_branch(monkeypatch: pytest.MonkeyPatch) ->
     events: list[object] = []
     context = Context()
     values = {"COMPOSE_PROJECT_NAME": "preview-test"}
-    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
+    environment = {
+        "INFRAHUB_ADDRESS": "http://localhost:8080",
+        "INFRAHUB_API_TOKEN": "local-token",
+        EXPECT_MAIN_EMPTY_ENV: "1",
+    }
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
     monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
@@ -96,9 +101,36 @@ def test_standalone_smoke_ensures_its_branch(monkeypatch: pytest.MonkeyPatch) ->
 
     cast("Task", preview.smoke).body(context)
 
+    assert EXPECT_MAIN_EMPTY_ENV not in environment
     assert events == [
         ("branch", environment),
         ("run", "uv run pytest -m preview tests/preview -q", environment),
+    ]
+
+
+def test_startup_smoke_requests_the_pristine_main_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[object] = []
+    context = Context()
+    values = {"COMPOSE_PROJECT_NAME": "preview-test"}
+    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
+
+    monkeypatch.setattr(preview, "load_preview_env", lambda: values)
+    monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
+    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda _env: None)
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(
+        context,
+        "run",
+        lambda command, *, env: events.append((command, env.copy())),
+    )
+
+    preview._run_smoke(context, expect_main_empty=True)
+
+    assert events == [
+        (
+            "uv run pytest -m preview tests/preview -q",
+            {**environment, EXPECT_MAIN_EMPTY_ENV: "1"},
+        )
     ]
 
 

--- a/tests/preview/test_python_api_cycle.py
+++ b/tests/preview/test_python_api_cycle.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from infrahub_sync.api.v1 import ApplyRequest, PlanRequest, VerifyRequest, apply, plan, verify
+from tasks.preview import SMOKE_BRANCH
 
 pytestmark = pytest.mark.preview
 
@@ -20,7 +21,7 @@ def test_python_api_plan_verify_apply(cli_environment: dict[str, Any], tmp_path:
         PlanRequest(
             sync_name="custom-example",
             config_directory=cli_environment["examples_dir"],
-            branch="main",
+            branch=SMOKE_BRANCH,
             product_cache_location=product_cache,
         )
     )
@@ -45,8 +46,20 @@ def test_python_api_plan_verify_apply(cli_environment: dict[str, Any], tmp_path:
             config_directory=cli_environment["examples_dir"],
             run_id=result.run_id,
             expected_checksum=reviewed_checksum,
-            branch="main",
+            branch=SMOKE_BRANCH,
             product_cache_location=product_cache,
         )
     )
     assert applied.outcome in {"applied", "no-change"}
+
+    main_result = plan(
+        PlanRequest(
+            sync_name="custom-example",
+            config_directory=cli_environment["examples_dir"],
+            branch="main",
+            product_cache_location=str(tmp_path / "main-product-cache"),
+        )
+    )
+    assert main_result.counts.create == 5, "smoke writes must leave main empty for the manual walkthrough"
+    assert main_result.counts.update == 0
+    assert main_result.counts.delete == 0

--- a/tests/preview/test_python_api_cycle.py
+++ b/tests/preview/test_python_api_cycle.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from infrahub_sync.api.v1 import ApplyRequest, PlanRequest, VerifyRequest, apply, plan, verify
-from tasks.preview import SMOKE_BRANCH
+from tasks.preview import EXPECT_MAIN_EMPTY_ENV, SMOKE_BRANCH
 
 pytestmark = pytest.mark.preview
 
@@ -51,6 +52,11 @@ def test_python_api_plan_verify_apply(cli_environment: dict[str, Any], tmp_path:
         )
     )
     assert applied.outcome in {"applied", "no-change"}
+
+
+def test_startup_smoke_preserves_main_for_manual_walkthrough(cli_environment: dict[str, Any], tmp_path: Path) -> None:
+    if os.environ.get(EXPECT_MAIN_EMPTY_ENV) != "1":
+        pytest.skip("pristine-main acceptance runs only during preview.up")
 
     main_result = plan(
         PlanRequest(

--- a/tests/preview/test_python_api_cycle.py
+++ b/tests/preview/test_python_api_cycle.py
@@ -66,6 +66,9 @@ def test_startup_smoke_preserves_main_for_manual_walkthrough(cli_environment: di
             product_cache_location=str(tmp_path / "main-product-cache"),
         )
     )
-    assert main_result.counts.create == 5, "smoke writes must leave main empty for the manual walkthrough"
+    assert main_result.counts.create == 5, (
+        "main is not pristine; if you already applied the custom-example walkthrough, reset with "
+        "`uv run invoke preview.down --volumes` before rerunning `preview.up`"
+    )
     assert main_result.counts.update == 0
     assert main_result.counts.delete == 0


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disposable preview connectivity, including more reliable Prefect UI access.
  - Preview smoke tests now isolate sample data from the pristine `main` branch.
  - Added graceful handling for unavailable preview services.
  - Repeated smoke-test runs now produce consistent, no-op results after successful setup.

- **Documentation**
  - Updated preview workflow guidance, including branch behavior and reset instructions.
  - Updated the NetBox-to-Infrahub tutorial to use the pinned preview release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Makes the disposable v3 preview reproducible for experimental evaluation. The
Prefect UI connects correctly, automated smoke data no longer consumes the
manual walkthrough, and the NetBox tutorial uses one immutable release
snapshot.

## Key Changes

- Keep Prefect's browser-facing API URL aligned with the published host port,
  including `preview.local.env` overrides.
- Run CLI, Python API, and managed HTTP smoke writes on the isolated
  `preview-smoke` Infrahub branch.
- Ensure standalone `preview.smoke` creates the smoke branch when needed while
  preserving polite skips when the environment is stopped.
- Verify during startup that `main` still produces the five-create
  custom-example plan, without making that initial state a reusable smoke
  requirement.
- Pin both NetBox tutorial code and configuration to `v3-preview.1`.

## Related Context

Supports the experimental evaluation tracked in
[SYNC-69](https://opsmill.atlassian.net/browse/SYNC-69).

## Documentation Updates

- Clarified smoke isolation and the manual walkthrough in
  `development/README.md`.
- Pinned the NetBox tutorial installation and configuration URLs.
- Added a changelog fragment.

## Test Plan

- `uv run invoke format`
- `uv run invoke lint`
- `uv run pytest -q`
  - 1,599 passed, 22 skipped, 1 xfailed
- Preview configuration regressions
  - 7 passed
- Fresh `uv run invoke preview.up`
  - Preview smoke passed 7/7
  - Startup acceptance found five creates on `main`
- Documented CLI plan/review/apply/convergence walkthrough on `main`
  - Applied five creates; the next plan contained zero operations
- Standalone `uv run invoke preview.smoke` after the walkthrough
  - 6 passed; the startup-only pristine-main check skipped
- Standalone smoke with the environment stopped
  - Skipped 7/7 without a traceback
- Live Prefect UI setting
  - `http://localhost:4210/api`
- Custom Prefect port rendering
  - Published port and browser API URL both followed the override
- `uv run invoke docs.generate`
- `uv run invoke docs.docusaurus`
- `uv run invoke preview.down --volumes`
  - Containers, processes, networks, and volumes removed

[SYNC-69]: https://opsmill.atlassian.net/browse/SYNC-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
