### PR TITLE
fix(managed): harden Prefect execution safety

### DIFF
--- a/changelog/+sync-50-direct-flow-log-redaction.fixed.md
+++ b/changelog/+sync-50-direct-flow-log-redaction.fixed.md
@@ -1,0 +1,1 @@
+Fixed direct Prefect flow logs so credentials from the worker environment and resolved Sync settings are redacted before reaching Prefect.

--- a/dev/knowledge/orchestration-prefect.md
+++ b/dev/knowledge/orchestration-prefect.md
@@ -16,7 +16,7 @@ spawns the CLI.
 `infrahub_sync/managed/` is a separate, optional operational profile. Its managed flow
 consumes the API-created product run ID and delegates deployment catalogue validation,
 deployment convergence, and native submission idempotency to OpsMill Prefect Extras pinned
-at commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The managed HTTP service owns the
+at commit `97465e75137f6121d0377cd637383cfb3530d734`. The managed HTTP service owns the
 public contract; Prefect remains authoritative for live execution, logs, retries, workers,
 and cancellation.
 

--- a/docs/docs/reference/managed-http-api.mdx
+++ b/docs/docs/reference/managed-http-api.mdx
@@ -28,7 +28,7 @@ Once a release with the managed profile is published, `pip install
 
 The profile directly installs FastAPI, HTTPX, Uvicorn, and Prefect 3.8.1. The OpsMill
 Prefect Extras integration ships with the package itself as a vendored copy of upstream
-commit `84688eb8d8db7e17770413640a66481ccdc3e725`. The base installation does not import
+commit `97465e75137f6121d0377cd637383cfb3530d734`. The base installation does not import
 any of these modules. Ordinary CLI and Python API imports remain Prefect-free.
 
 You also need:

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -20,6 +20,7 @@ import os
 import re
 from collections.abc import Mapping
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -160,6 +161,12 @@ _URL_USERINFO = re.compile(r"://(?P<userinfo>[^/\s@]+)@")
 # that the config's own shape is the cause. No real adapter settings tree comes
 # close to this depth; hitting it means the walk stops descending, never raises.
 MAX_SETTINGS_DEPTH = 64
+
+# Private composition channel used only by the packaged direct Prefect flow.
+# Keeping this out of ``run_remote_request``'s parameters preserves that
+# function's remote-shaped call contract while allowing the bridge's mutable
+# collection to learn configuration-derived values after resolution.
+_REMOTE_SECRET_VALUES: ContextVar[list[str] | None] = ContextVar("remote_secret_values", default=None)
 
 # Runner-environment variables each adapter reads its credentials from, keyed by
 # the adapter's normalized name. Named here, at the remote boundary, so the
@@ -416,6 +423,16 @@ def collect_secret_values(
         for settings in settings_blocks:
             _collect_from_settings(settings or {}, values, secret_context=False, environ=env, seen=set())
     return tuple(sorted(values, key=lambda value: (-len(value), value)))
+
+
+@contextmanager
+def _bind_remote_secret_values(values: list[str]) -> Iterator[None]:
+    """Bind a flow-owned mutable secret collection for one remote request."""
+    token = _REMOTE_SECRET_VALUES.set(values)
+    try:
+        yield
+    finally:
+        _REMOTE_SECRET_VALUES.reset(token)
 
 
 def redact(message: str, secrets: Sequence[str]) -> str:
@@ -1270,9 +1287,14 @@ def run_remote_request(
             raise _FactoryValueError(str(exc)) from exc
 
     secrets = collect_secret_values()
+    shared_secrets = _REMOTE_SECRET_VALUES.get()
+    if shared_secrets is not None:
+        shared_secrets[:] = secrets
     try:
         sync_instance = resolve_sync_instance(sync_name, directory=config_directory)
         secrets = collect_secret_values(sync_instance)
+        if shared_secrets is not None:
+            shared_secrets[:] = secrets
         return cast(
             "RunResult",
             execute_run(

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -25,7 +25,13 @@ from infrahub_sync.execution import (
     resolve_sync_instance,
     sanitize_exception_chain,
 )
-from infrahub_sync.orchestration.flow import BRIDGED_LEVEL, SOURCE_LOGGER_NAME, RunLogger, RunLoggerBridge
+from infrahub_sync.orchestration.flow import (
+    _REMOTE_LOGGER_OWNERSHIP_LOCK,
+    BRIDGED_LEVEL,
+    SOURCE_LOGGER_NAME,
+    RunLogger,
+    RunLoggerBridge,
+)
 from infrahub_sync.plan.models import ApplyRecord
 from infrahub_sync.plan.review import SavedPlan
 from infrahub_sync.product_store import ProductProjection, local_product_projection
@@ -59,19 +65,20 @@ def _remote_log_bridge(
     if not prefect_context:
         yield
         return
-    source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
-    bridge = RunLoggerBridge(run_logger, secrets=secrets)
-    previous_level = source_logger.level
-    previous_propagate = source_logger.propagate
-    source_logger.addHandler(bridge)
-    source_logger.setLevel(BRIDGED_LEVEL)
-    source_logger.propagate = False
-    try:
-        yield
-    finally:
-        source_logger.removeHandler(bridge)
-        source_logger.setLevel(previous_level)
-        source_logger.propagate = previous_propagate
+    with _REMOTE_LOGGER_OWNERSHIP_LOCK:
+        source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
+        bridge = RunLoggerBridge(run_logger, secrets=secrets)
+        previous_level = source_logger.level
+        previous_propagate = source_logger.propagate
+        source_logger.addHandler(bridge)
+        source_logger.setLevel(BRIDGED_LEVEL)
+        source_logger.propagate = False
+        try:
+            yield
+        finally:
+            source_logger.removeHandler(bridge)
+            source_logger.setLevel(previous_level)
+            source_logger.propagate = previous_propagate
 
 
 def _runtime() -> tuple[str, ProductProjection]:

--- a/infrahub_sync/orchestration/flow.py
+++ b/infrahub_sync/orchestration/flow.py
@@ -27,6 +27,7 @@ import dataclasses
 import logging
 import os
 from collections.abc import Sequence
+from threading import Lock
 from typing import Any, Literal, Protocol
 
 from prefect import flow
@@ -55,6 +56,7 @@ CONFIG_DIR_ENV = "INFRAHUB_SYNC_CONFIG_DIRECTORY"
 # effective for the duration of one run.
 SOURCE_LOGGER_NAME = "infrahub_sync"
 BRIDGED_LEVEL = logging.INFO
+_REMOTE_LOGGER_OWNERSHIP_LOCK = Lock()
 
 # Contractual format of the one summary line a remote caller may parse. Carries
 # five RunResult fields (run_id, status, changed, summary, artifact_path);
@@ -128,54 +130,55 @@ def infrahub_sync_run(
     """
     run_logger = get_run_logger()
     secrets = list(collect_secret_values())
-    source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
-    bridge = RunLoggerBridge(run_logger, secrets=secrets)
-    # The flow owns the source logger's LEVEL as well as the handler: attaching a
-    # handler never defeats `Logger.isEnabledFor`, and the `infrahub_sync`
-    # hierarchy is level-NOTSET by default (the CLI makes INFO effective through
-    # `_setup_logging`, which this flow never calls). Without owning the level,
-    # forwarding would silently depend on ambient root/Prefect configuration.
-    previous_level = source_logger.level
-    previous_propagate = source_logger.propagate
-    source_logger.addHandler(bridge)
-    source_logger.setLevel(BRIDGED_LEVEL)
-    source_logger.propagate = False
-    try:
-        with _bind_remote_secret_values(secrets):
-            config_directory = os.environ.get(CONFIG_DIR_ENV)
-            if not config_directory:
-                # Validated at serve start; checked again here so a flow run started
-                # some other way fails with the actionable reason.
-                msg = f"{CONFIG_DIR_ENV} is not set in the serving process environment"
-                raise RunExecutionError(msg)
+    with _REMOTE_LOGGER_OWNERSHIP_LOCK:
+        source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
+        bridge = RunLoggerBridge(run_logger, secrets=secrets)
+        # The flow owns the source logger's LEVEL as well as the handler: attaching a
+        # handler never defeats `Logger.isEnabledFor`, and the `infrahub_sync`
+        # hierarchy is level-NOTSET by default (the CLI makes INFO effective through
+        # `_setup_logging`, which this flow never calls). Without owning the level,
+        # forwarding would silently depend on ambient root/Prefect configuration.
+        previous_level = source_logger.level
+        previous_propagate = source_logger.propagate
+        source_logger.addHandler(bridge)
+        source_logger.setLevel(BRIDGED_LEVEL)
+        source_logger.propagate = False
+        try:
+            with _bind_remote_secret_values(secrets):
+                config_directory = os.environ.get(CONFIG_DIR_ENV)
+                if not config_directory:
+                    # Validated at serve start; checked again here so a flow run started
+                    # some other way fails with the actionable reason.
+                    msg = f"{CONFIG_DIR_ENV} is not set in the serving process environment"
+                    raise RunExecutionError(msg)
 
-            result = run_remote_request(
-                sync_name,
-                operation,
-                confirm_writes,
-                branch,
-                config_directory=config_directory,
-            )
-            run_logger.info(
-                SUMMARY_LINE_FORMAT,
-                result.run_id,
-                result.status,
-                result.changed,
-                result.summary["create"],
-                result.summary["update"],
-                result.summary["delete"],
-                result.artifact_path,
-            )
-            # NOT `dataclasses.asdict(result)`: asdict() deep-copies field values, and
-            # `RunResult.summary` is a `types.MappingProxyType`, which is not
-            # deep-copyable — it raises `TypeError: cannot pickle 'mappingproxy'
-            # object`, so every successful run would fail at return time. Do not
-            # "simplify" this back to asdict().
-            out = {field.name: getattr(result, field.name) for field in dataclasses.fields(result)}
-            out["summary"] = dict(result.summary)
-            return out
-    finally:
-        source_logger.removeHandler(bridge)
-        source_logger.setLevel(previous_level)
-        source_logger.propagate = previous_propagate
-        secrets.clear()
+                result = run_remote_request(
+                    sync_name,
+                    operation,
+                    confirm_writes,
+                    branch,
+                    config_directory=config_directory,
+                )
+                run_logger.info(
+                    SUMMARY_LINE_FORMAT,
+                    result.run_id,
+                    result.status,
+                    result.changed,
+                    result.summary["create"],
+                    result.summary["update"],
+                    result.summary["delete"],
+                    result.artifact_path,
+                )
+                # NOT `dataclasses.asdict(result)`: asdict() deep-copies field values, and
+                # `RunResult.summary` is a `types.MappingProxyType`, which is not
+                # deep-copyable — it raises `TypeError: cannot pickle 'mappingproxy'
+                # object`, so every successful run would fail at return time. Do not
+                # "simplify" this back to asdict().
+                out = {field.name: getattr(result, field.name) for field in dataclasses.fields(result)}
+                out["summary"] = dict(result.summary)
+                return out
+        finally:
+            source_logger.removeHandler(bridge)
+            source_logger.setLevel(previous_level)
+            source_logger.propagate = previous_propagate
+            secrets.clear()

--- a/infrahub_sync/orchestration/flow.py
+++ b/infrahub_sync/orchestration/flow.py
@@ -32,7 +32,13 @@ from typing import Any, Literal, Protocol
 from prefect import flow
 from prefect.logging import get_run_logger
 
-from infrahub_sync.execution import RunExecutionError, redact, run_remote_request
+from infrahub_sync.execution import (
+    RunExecutionError,
+    _bind_remote_secret_values,
+    collect_secret_values,
+    redact,
+    run_remote_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,49 +127,55 @@ def infrahub_sync_run(
             serving environment, or any adapter/engine failure (sanitized).
     """
     run_logger = get_run_logger()
+    secrets = list(collect_secret_values())
     source_logger = logging.getLogger(SOURCE_LOGGER_NAME)
-    bridge = RunLoggerBridge(run_logger)
+    bridge = RunLoggerBridge(run_logger, secrets=secrets)
     # The flow owns the source logger's LEVEL as well as the handler: attaching a
     # handler never defeats `Logger.isEnabledFor`, and the `infrahub_sync`
     # hierarchy is level-NOTSET by default (the CLI makes INFO effective through
     # `_setup_logging`, which this flow never calls). Without owning the level,
     # forwarding would silently depend on ambient root/Prefect configuration.
     previous_level = source_logger.level
+    previous_propagate = source_logger.propagate
     source_logger.addHandler(bridge)
     source_logger.setLevel(BRIDGED_LEVEL)
+    source_logger.propagate = False
     try:
-        config_directory = os.environ.get(CONFIG_DIR_ENV)
-        if not config_directory:
-            # Validated at serve start; checked again here so a flow run started
-            # some other way fails with the actionable reason.
-            msg = f"{CONFIG_DIR_ENV} is not set in the serving process environment"
-            raise RunExecutionError(msg)
+        with _bind_remote_secret_values(secrets):
+            config_directory = os.environ.get(CONFIG_DIR_ENV)
+            if not config_directory:
+                # Validated at serve start; checked again here so a flow run started
+                # some other way fails with the actionable reason.
+                msg = f"{CONFIG_DIR_ENV} is not set in the serving process environment"
+                raise RunExecutionError(msg)
 
-        result = run_remote_request(
-            sync_name,
-            operation,
-            confirm_writes,
-            branch,
-            config_directory=config_directory,
-        )
-        run_logger.info(
-            SUMMARY_LINE_FORMAT,
-            result.run_id,
-            result.status,
-            result.changed,
-            result.summary["create"],
-            result.summary["update"],
-            result.summary["delete"],
-            result.artifact_path,
-        )
-        # NOT `dataclasses.asdict(result)`: asdict() deep-copies field values, and
-        # `RunResult.summary` is a `types.MappingProxyType`, which is not
-        # deep-copyable — it raises `TypeError: cannot pickle 'mappingproxy'
-        # object`, so every successful run would fail at return time. Do not
-        # "simplify" this back to asdict().
-        out = {field.name: getattr(result, field.name) for field in dataclasses.fields(result)}
-        out["summary"] = dict(result.summary)
-        return out
+            result = run_remote_request(
+                sync_name,
+                operation,
+                confirm_writes,
+                branch,
+                config_directory=config_directory,
+            )
+            run_logger.info(
+                SUMMARY_LINE_FORMAT,
+                result.run_id,
+                result.status,
+                result.changed,
+                result.summary["create"],
+                result.summary["update"],
+                result.summary["delete"],
+                result.artifact_path,
+            )
+            # NOT `dataclasses.asdict(result)`: asdict() deep-copies field values, and
+            # `RunResult.summary` is a `types.MappingProxyType`, which is not
+            # deep-copyable — it raises `TypeError: cannot pickle 'mappingproxy'
+            # object`, so every successful run would fail at return time. Do not
+            # "simplify" this back to asdict().
+            out = {field.name: getattr(result, field.name) for field in dataclasses.fields(result)}
+            out["summary"] = dict(result.summary)
+            return out
     finally:
         source_logger.removeHandler(bridge)
         source_logger.setLevel(previous_level)
+        source_logger.propagate = previous_propagate
+        secrets.clear()

--- a/opsmill_prefect_extras/VENDORED.md
+++ b/opsmill_prefect_extras/VENDORED.md
@@ -1,7 +1,7 @@
 # Vendored: opsmill-prefect-extras
 
 This directory is a **byte-identical** copy of the private upstream package
-`opsmill/prefect-extras` at commit `84688eb8d8db7e17770413640a66481ccdc3e725`
+`opsmill/prefect-extras` at commit `97465e75137f6121d0377cd637383cfb3530d734`
 (branch `feature/db-104-executors`; upstream PRs #13–#17 remain open). Its
 upstream unit tests are copied, also byte-identical, under
 `tests/vendored_prefect_extras/`. Only this file and the test directory's

--- a/opsmill_prefect_extras/deployments.py
+++ b/opsmill_prefect_extras/deployments.py
@@ -36,7 +36,7 @@ _COMPARABLE_FIELDS: tuple[str, ...] = (
     "work_pool_name",
     "job_variables",
 )
-"""Fields this feature owns and therefore reconciles."""
+"""Fields this feature can own and reconcile from a desired payload."""
 
 _SENTINEL_FLOW_ID: UUID = UUID("00000000-0000-0000-0000-000000000000")
 """A local schema-validation stand-in; it is never sent to Prefect."""
@@ -222,9 +222,9 @@ async def apply_deployments(
             client=client,
         )
 
-    manager = get_client() if client_factory is None else client_factory()
     entered = False
     try:
+        manager = get_client() if client_factory is None else client_factory()
         async with manager as active_client:
             entered = True
             return await _apply_with_client(
@@ -234,9 +234,10 @@ async def apply_deployments(
                 client=cast(DeploymentClient, active_client),
             )
     except Exception as exc:
-        if not entered:
-            raise DeploymentApplyConnectionError(exc) from None
-        raise
+        if entered:
+            raise
+        connection_error = DeploymentApplyConnectionError(exc)
+    raise connection_error from None
 
 
 async def _apply_with_client(
@@ -323,10 +324,11 @@ def _assert_definition_key_grammar(definition: WorkflowDefinition) -> None:
 
 def _matches(existing: DeploymentRecord, desired: Mapping[str, Any]) -> bool:
     """Compare the persisted deployment with the fields this feature owns."""
+    comparable_fields = _comparable_fields(desired)
     existing_payload = existing.model_dump(mode="json", exclude_none=True)
     comparable_existing = {
         field: existing_payload[field]
-        for field in _COMPARABLE_FIELDS
+        for field in comparable_fields
         if field in existing_payload
     }
     if "schedules" in comparable_existing:
@@ -337,7 +339,7 @@ def _matches(existing: DeploymentRecord, desired: Mapping[str, Any]) -> bool:
     desired_payload = _normalised_payload(desired)
     fields_match = all(
         normalized_existing.get(field) == desired_payload.get(field)
-        for field in _COMPARABLE_FIELDS
+        for field in comparable_fields
     )
     return fields_match and _response_concurrency_limit(existing_payload) == (
         desired_payload.get("concurrency_limit")
@@ -386,14 +388,30 @@ def _normalised_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], model.model_dump(mode="json", exclude_none=True))
 
 
+def _comparable_fields(desired: Mapping[str, Any]) -> tuple[str, ...]:
+    """Select owned fields, treating empty job variables as unmanaged."""
+    job_variables = desired.get("job_variables")
+    if isinstance(job_variables, Mapping) and job_variables:
+        return _COMPARABLE_FIELDS
+    return tuple(field for field in _COMPARABLE_FIELDS if field != "job_variables")
+
+
 def _update(payload: Mapping[str, Any]) -> DeploymentUpdate:
     """Build Prefect's named update schema from the fields this feature owns."""
     normalized = _normalised_payload(payload)
     update_fields = {
         field: normalized[field]
-        for field in _COMPARABLE_FIELDS
+        for field in _comparable_fields(payload)
         if field != "name" and field in normalized
     }
+    clear_values: Mapping[str, object] = {
+        "tags": [],
+        "schedules": [],
+        "concurrency_options": None,
+        "entrypoint": None,
+    }
+    for field, value in clear_values.items():
+        update_fields.setdefault(field, value)
     # Setting this field explicitly also lets an update clear a prior limit.
     update_fields["concurrency_limit"] = normalized.get("concurrency_limit")
     return DeploymentUpdate(**update_fields)

--- a/opsmill_prefect_extras/executors.py
+++ b/opsmill_prefect_extras/executors.py
@@ -91,6 +91,8 @@ ExecutionStatus = Literal[
     "pending",
     "running",
     "cancelling",
+    "paused",
+    "suspended",
     "completed",
     "failed",
     "crashed",
@@ -469,6 +471,10 @@ def _status_for_state(state: State[Any] | None) -> ExecutionStatus:
         return "cancelled"
     if state.is_cancelling():
         return "cancelling"
+    if state.is_paused():
+        if getattr(state.state_details, "pause_reschedule", False):
+            return "suspended"
+        return "paused"
     if state.is_final():
         return "failed"
     if state.is_running():
@@ -604,6 +610,8 @@ class RemoteWorkflowExecutor:
                 parameters=validated,
                 idempotency_key=idempotency_key,
             )
-        except ObjectNotFound as exc:
-            raise WorkflowNotFoundError(definition) from exc
-        return _RemoteFlowRunHandle(self._client, flow_run.id, self._poll_interval)
+        except ObjectNotFound:
+            pass
+        else:
+            return _RemoteFlowRunHandle(self._client, flow_run.id, self._poll_interval)
+        raise WorkflowNotFoundError(definition)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dependencies = [
     "infrahub-sdk[all]>=1.17,<2",
     "structlog>=25.1,<26.0",
+    "typing-extensions>=4.0",
     # The `[redis]` extra is deliberately dropped: it caps `redis<5.0`, which is
     # unsatisfiable next to the optional `prefect` extra below
     # (prefect>=3.6 -> pydocket -> redis>=5). diffsync's cap is stale rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ prefect = [
 # Prefect integration is pinned to the reviewed DB-102/103/104 stack exactly.
 # The previous `opsmill-prefect-extras` private Git pin is vendored instead: the
 # package ships from this repository at `opsmill_prefect_extras/`, byte-identical to
-# upstream commit 84688eb8d8db7e17770413640a66481ccdc3e725. See
+# upstream commit 97465e75137f6121d0377cd637383cfb3530d734. See
 # `opsmill_prefect_extras/VENDORED.md` for the freeze and re-adoption rules.
 managed = [
     "fastapi>=0.115,<1; python_version >= '3.11'",

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -12,7 +12,6 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from typing_extensions import Self
 
 pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
@@ -97,7 +96,7 @@ class _LoggerOwnershipProbe:
         self.events.append(f"{current_thread().name}:released")
         self._delegate.release()
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> _LoggerOwnershipProbe:  # noqa: PYI034
         self.acquire()
         return self
 
@@ -315,8 +314,9 @@ def test_direct_and_managed_log_bridges_serialize_ownership_and_restore_state(  
     finally:
         release_direct.set()
         release_managed.set()
-        direct_thread.join(timeout=5)
-        managed_thread.join(timeout=5)
+        for thread in (direct_thread, managed_thread):
+            if thread.ident is not None:
+                thread.join(timeout=5)
         source_logger.handlers = original_handlers
         source_logger.setLevel(original_level)
         source_logger.propagate = original_propagate

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -5,12 +5,14 @@ import logging
 from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Event, Thread, current_thread
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol
 from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from typing_extensions import Self
 
 pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
@@ -25,6 +27,7 @@ from infrahub_sync.managed import flow as managed_flow
 from infrahub_sync.managed.deploy import CATALOGUE
 from infrahub_sync.managed.flow import managed_sync_run
 from infrahub_sync.managed.orchestration import MANAGED_DEFINITION, Observation, PrefectOrchestration
+from infrahub_sync.orchestration import flow as direct_flow
 from infrahub_sync.orchestration.flow import infrahub_sync_run
 from infrahub_sync.plan.errors import OperationApplyFailedError
 from infrahub_sync.plan.models import ApplyRecord, PlanManifest
@@ -58,11 +61,48 @@ class _RecordingRunLogger:
     def __init__(self) -> None:
         self.rendered: list[str] = []
 
-    def log(self, _level: int, message: str, *args: object) -> None:
-        self.rendered.append(message % args)
+    def log(self, level: int, msg: str, *args: object) -> None:
+        del level
+        self.rendered.append(msg % args)
 
-    def info(self, message: str, *args: object) -> None:
-        self.rendered.append(message % args)
+    def info(self, msg: str, *args: object) -> None:
+        self.rendered.append(msg % args)
+
+
+class _LockDelegate(Protocol):
+    def acquire(self) -> bool: ...
+
+    def release(self) -> None: ...
+
+
+class _LoggerOwnershipProbe:
+    """Record lock acquisition order while delegating synchronization unchanged."""
+
+    def __init__(self, delegate: _LockDelegate) -> None:
+        self._delegate = delegate
+        self.events: list[str] = []
+        self.managed_acquire_attempted = Event()
+
+    def acquire(self) -> None:
+        """Signal from inside the contender's acquisition attempt, then delegate."""
+        thread_name = current_thread().name
+        self.events.append(f"{thread_name}:acquire-attempted")
+        if thread_name == "test-managed-flow":
+            self.managed_acquire_attempted.set()
+        self._delegate.acquire()
+        self.events.append(f"{thread_name}:acquired")
+
+    def release(self) -> None:
+        """Record release before making ownership available to a contender."""
+        self.events.append(f"{current_thread().name}:released")
+        self._delegate.release()
+
+    def __enter__(self) -> Self:
+        self.acquire()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.release()
 
 
 def _create_product_run(
@@ -159,6 +199,127 @@ def test_missing_context_uses_local_logger_without_constructing_a_bridge(monkeyp
 
     assert isinstance(run_logger, logging.Logger)
     assert prefect_context is False
+
+
+def test_direct_and_managed_log_bridges_serialize_ownership_and_restore_state(  # noqa: PLR0914, PLR0915
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Concurrent flow bridges must not share records or clobber logger state."""
+    direct_canary = "direct-flow-secret-canary"
+    managed_canary = "managed-flow-secret-canary"
+    direct_logger = _RecordingRunLogger()
+    managed_logger = _RecordingRunLogger()
+    source_logger = logging.getLogger(managed_flow.SOURCE_LOGGER_NAME)
+    child_logger = logging.getLogger(f"{managed_flow.SOURCE_LOGGER_NAME}.concurrency-test")
+    sentinel_handler = logging.NullHandler()
+    original_handlers = list(source_logger.handlers)
+    original_level = source_logger.level
+    original_propagate = source_logger.propagate
+    direct_entered = Event()
+    release_direct = Event()
+    managed_entered = Event()
+    release_managed = Event()
+    direct_failures: list[BaseException] = []
+    managed_failures: list[BaseException] = []
+
+    def fail_direct_request(*_args: object, **_kwargs: object) -> NoReturn:
+        direct_entered.set()
+        assert release_direct.wait(timeout=5)
+        failure_message = "direct flow failed"
+        raise RuntimeError(failure_message)
+
+    def run_direct() -> None:
+        try:
+            infrahub_sync_run.fn("inventory")
+        except BaseException as exc:  # noqa: BLE001 - retain thread failure for the main test.
+            direct_failures.append(exc)
+
+    def run_managed_bridge() -> None:
+        try:
+            with managed_flow._remote_log_bridge(
+                managed_logger,
+                prefect_context=True,
+                secrets=(managed_canary,),
+            ):
+                managed_entered.set()
+                child_logger.warning("managed record used %s", managed_canary)
+                assert release_managed.wait(timeout=5)
+        except BaseException as exc:  # noqa: BLE001 - retain thread failure for the main test.
+            managed_failures.append(exc)
+
+    monkeypatch.setattr("infrahub_sync.orchestration.flow.get_run_logger", lambda: direct_logger)
+    monkeypatch.setattr("infrahub_sync.orchestration.flow.collect_secret_values", lambda: (direct_canary,))
+    monkeypatch.setattr("infrahub_sync.orchestration.flow.run_remote_request", fail_direct_request)
+    monkeypatch.setenv(managed_flow.CONFIG_DIR_ENV, str(tmp_path))
+    original_ownership_lock = direct_flow._REMOTE_LOGGER_OWNERSHIP_LOCK
+    assert managed_flow._REMOTE_LOGGER_OWNERSHIP_LOCK is original_ownership_lock
+    ownership_probe = _LoggerOwnershipProbe(original_ownership_lock)
+    monkeypatch.setattr(direct_flow, "_REMOTE_LOGGER_OWNERSHIP_LOCK", ownership_probe)
+    monkeypatch.setattr(managed_flow, "_REMOTE_LOGGER_OWNERSHIP_LOCK", ownership_probe)
+    source_logger.handlers = [sentinel_handler]
+    source_logger.setLevel(logging.ERROR)
+    source_logger.propagate = True
+
+    direct_thread = Thread(target=run_direct, name="test-direct-flow")
+    managed_thread = Thread(target=run_managed_bridge, name="test-managed-flow")
+    try:
+        direct_thread.start()
+        assert direct_entered.wait(timeout=5)
+        managed_thread.start()
+        assert ownership_probe.managed_acquire_attempted.wait(timeout=5)
+        child_logger.warning("direct record used %s", direct_canary)
+
+        release_direct.set()
+        direct_thread.join(timeout=5)
+        assert not direct_thread.is_alive()
+        assert managed_entered.wait(timeout=5)
+        release_managed.set()
+        managed_thread.join(timeout=5)
+        assert not managed_thread.is_alive()
+
+        rendered = "\n".join((*direct_logger.rendered, *managed_logger.rendered))
+        expected_acquisition_order = [
+            "test-direct-flow:acquire-attempted",
+            "test-direct-flow:acquired",
+            "test-managed-flow:acquire-attempted",
+            "test-direct-flow:released",
+            "test-managed-flow:acquired",
+            "test-managed-flow:released",
+        ]
+        violations = [
+            label
+            for label, violated in (
+                ("bridge ownership was not serialized", ownership_probe.events != expected_acquisition_order),
+                (
+                    "direct bridge received the managed record",
+                    any("managed record" in line for line in direct_logger.rendered),
+                ),
+                (
+                    "managed bridge received the direct record",
+                    any("direct record" in line for line in managed_logger.rendered),
+                ),
+                ("direct canary reached a run logger", direct_canary in rendered),
+                ("managed canary reached a run logger", managed_canary in rendered),
+                ("source handlers were not restored", source_logger.handlers != [sentinel_handler]),
+                ("source level was not restored", source_logger.level != logging.ERROR),
+                ("source propagation was not restored", source_logger.propagate is not True),
+            )
+            if violated
+        ]
+        assert violations == []
+        assert len(direct_failures) == 1
+        assert isinstance(direct_failures[0], RuntimeError)
+        assert str(direct_failures[0]) == "direct flow failed"
+        assert managed_failures == []
+    finally:
+        release_direct.set()
+        release_managed.set()
+        direct_thread.join(timeout=5)
+        managed_thread.join(timeout=5)
+        source_logger.handlers = original_handlers
+        source_logger.setLevel(original_level)
+        source_logger.propagate = original_propagate
 
 
 def test_managed_flow_redacts_worker_logs_exception_chain_and_failed_state(

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
+from typing_extensions import Self
 
 pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
@@ -96,7 +97,7 @@ class _LoggerOwnershipProbe:
         self.events.append(f"{current_thread().name}:released")
         self._delegate.release()
 
-    def __enter__(self) -> _LoggerOwnershipProbe:  # noqa: PYI034
+    def __enter__(self) -> Self:
         self.acquire()
         return self
 

--- a/tests/orchestration/test_flow.py
+++ b/tests/orchestration/test_flow.py
@@ -54,7 +54,7 @@ from infrahub_sync.orchestration.flow import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from prefect.client.schemas.objects import FlowRun
     from prefect.states import State
@@ -694,17 +694,27 @@ class _InjectedEngine:
     so the bridged-record scan has real records to scan.
     """
 
-    def __init__(self, *, run_dir: Path, rows: list[dict[str, Any]], fault: BaseException | None) -> None:
+    def __init__(
+        self,
+        *,
+        run_dir: Path,
+        rows: list[dict[str, Any]],
+        fault: BaseException | None,
+        source_log_message: str | None = None,
+    ) -> None:
         self.run_dir = run_dir
         self.run_id = run_dir.name
         self.top_level = ["InfraDevice"]
         self.force_full_extract = False
         self.rows = rows
         self.fault = fault
+        self.source_log_message = source_log_message
 
     def load_both_sides(self) -> None:
         """Log a lifecycle line, then raise the injected fault if there is one."""
         logging.getLogger(CHILD_LOGGER_NAME).info("Load: Importing data from MockDB")
+        if self.source_log_message is not None:
+            logging.getLogger(CHILD_LOGGER_NAME).warning(self.source_log_message)
         if self.fault is not None:
             raise self.fault
 
@@ -731,18 +741,25 @@ class _InjectedFactory:
         cache_root: Path,
         rows: list[dict[str, Any]] | None = None,
         fault_factory: Any = None,  # noqa: ANN401 - Callable[[], BaseException] | None
+        source_log_message: str | None = None,
     ) -> None:
         self.calls: list[dict[str, object]] = []
         self.cache_root = cache_root
         self.rows = rows if rows is not None else []
         self.fault_factory = fault_factory
+        self.source_log_message = source_log_message
 
     def __call__(self, **kwargs: object) -> Any:  # noqa: ANN401 - a fake engine, not a real Potenda
         self.calls.append(kwargs)
         run_dir = self.cache_root / CANARY_RUN_ID
         run_dir.mkdir(parents=True, exist_ok=True)
         fault = self.fault_factory() if self.fault_factory is not None else None
-        return _InjectedEngine(run_dir=run_dir, rows=list(self.rows), fault=fault)
+        return _InjectedEngine(
+            run_dir=run_dir,
+            rows=list(self.rows),
+            fault=fault,
+            source_log_message=self.source_log_message,
+        )
 
 
 def _bind_seam(monkeypatch: pytest.MonkeyPatch, factory: _InjectedFactory) -> None:
@@ -786,6 +803,65 @@ def _assert_canary_free(surfaces: dict[str, str]) -> None:
 # --------------------------------------------------------------------------- #
 # T022 — canary redaction scan (DBA-008, SC-005)
 # --------------------------------------------------------------------------- #
+
+
+@pytest.mark.usefixtures("prefect_harness", "canary_environment")
+@pytest.mark.parametrize(
+    "fault_factory",
+    [
+        pytest.param(None, id="success"),
+        pytest.param(lambda: RuntimeError("injected failure"), id="failure"),
+    ],
+)
+def test_direct_flow_redacts_source_logs_and_owns_propagation(
+    monkeypatch: pytest.MonkeyPatch,
+    source_logger: logging.Logger,
+    tmp_path: Path,
+    fault_factory: Callable[[], BaseException] | None,
+) -> None:
+    """The direct flow is the sole, sanitized owner of source-log forwarding."""
+
+    class AmbientHandler(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.messages: list[str] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            if record.name.startswith(SOURCE_LOGGER_NAME):
+                self.messages.append(record.getMessage())
+
+    source_log_message = (
+        f"credentials env={ENV_TOKEN_CANARY}/{ENV_PATTERN_CANARY} settings={SOURCE_TOKEN_CANARY}/{DEST_PASSWORD_CANARY}"
+    )
+    factory = _InjectedFactory(
+        cache_root=tmp_path / "cache" / CANARY_SYNC_NAME,
+        rows=[_plan_row("dev01")],
+        fault_factory=fault_factory,
+        source_log_message=source_log_message,
+    )
+    run_logger = _StubRunLogger()
+    monkeypatch.setattr("infrahub_sync.orchestration.flow.get_run_logger", lambda: run_logger)
+    _bind_seam(monkeypatch, factory)
+
+    ambient = AmbientHandler()
+    root_logger = logging.getLogger()
+    original_handlers = list(source_logger.handlers)
+    source_logger.setLevel(logging.CRITICAL)
+    monkeypatch.setattr(source_logger, "propagate", True)
+    root_logger.addHandler(ambient)
+    try:
+        state = infrahub_sync_run(CANARY_SYNC_NAME, "plan", return_state=True)  # ty: ignore[no-matching-overload] - TODO: ty cannot select prefect's ParamSpec return_state overload
+    finally:
+        root_logger.removeHandler(ambient)
+
+    assert state.is_failed() if fault_factory is not None else state.is_completed()
+    forwarded = "\n".join(run_logger.rendered)
+    assert f"{CHILD_LOGGER_NAME} | credentials env={REDACTED}/{REDACTED} settings={REDACTED}/{REDACTED}" in forwarded
+    _assert_canary_free({"forwarded log records": forwarded})
+    assert ambient.messages == []
+    assert source_logger.handlers == original_handlers
+    assert source_logger.level == logging.CRITICAL
+    assert source_logger.propagate is True
 
 
 @pytest.mark.usefixtures("prefect_harness", "canary_environment")

--- a/tests/vendored_prefect_extras/test_deployments.py
+++ b/tests/vendored_prefect_extras/test_deployments.py
@@ -102,7 +102,7 @@ class FakePrefectClient:
             if existing.id == deployment_id:
                 existing.payload = {
                     **existing.payload,
-                    **deployment.model_dump(mode="json", exclude_none=True),
+                    **deployment.model_dump(mode="json", exclude_unset=True),
                 }
                 return
         raise AssertionError("unknown fake deployment")
@@ -244,6 +244,52 @@ def test_second_apply_is_unchanged_and_drift_is_updated() -> None:
     assert [call[0] for call in client.calls].count("update_deployment") == 1
 
 
+@pytest.mark.parametrize(
+    ("definition_kwargs", "cleared_fields"),
+    [
+        pytest.param(
+            {"cron": "0 2 * * *"},
+            {"schedules": []},
+            id="schedule",
+        ),
+        pytest.param(
+            {"concurrency_limit": 2, "collision_strategy": "CANCEL_NEW"},
+            {"concurrency_limit": None, "concurrency_options": None},
+            id="concurrency-settings",
+        ),
+        pytest.param(
+            {"entrypoint": "tests.workflows.flows:my_sync_flow"},
+            {"entrypoint": None},
+            id="entrypoint",
+        ),
+    ],
+)
+def test_removing_supported_owned_optional_settings_converges(
+    definition_kwargs: Mapping[str, Any],
+    cleared_fields: Mapping[str, object],
+) -> None:
+    client = FakePrefectClient()
+    configured = _definition("inventory-refresh", "scheduled", **definition_kwargs)
+    without_optional_settings = _definition("inventory-refresh", "scheduled")
+
+    created = _apply(
+        (configured,),
+        work_pool_name="pool",
+        client=client,
+    )
+    removed = _apply((without_optional_settings,), work_pool_name="pool", client=client)
+    unchanged = _apply(
+        (without_optional_settings,), work_pool_name="pool", client=client
+    )
+
+    assert [result.status for result in created.results] == ["created"]
+    assert [result.status for result in removed.results] == ["updated"]
+    assert [result.status for result in unchanged.results] == ["unchanged"]
+    payload = client.deployments[configured.key].payload
+    assert all(payload[field] == value for field, value in cleared_fields.items())
+    assert [call[0] for call in client.calls].count("update_deployment") == 1
+
+
 def test_create_race_converges_after_a_defensive_conflict() -> None:
     class RacingClient(FakePrefectClient):
         async def create_deployment(self, flow_id: UUID, **payload: Any) -> UUID:
@@ -315,6 +361,53 @@ def test_real_prefect_server_second_scheduled_apply_is_unchanged() -> None:
 
     assert [result.status for result in first.results] == ["created"]
     assert [result.status for result in second.results] == ["unchanged"]
+
+
+def test_real_prefect_server_omitted_job_variables_remain_unmanaged() -> None:
+    definition = _definition("integration-flow", "job-variables")
+    job_variables = {
+        "image": "registry.example/application:previous",
+        "env": {"MODE": "managed"},
+    }
+
+    async def scenario() -> tuple[
+        DeploymentApplyReport,
+        DeploymentApplyReport,
+        DeploymentApplyReport,
+        Mapping[str, Any],
+    ]:
+        async with get_client() as client:
+            await client.create_work_pool(
+                WorkPoolCreate(name="integration-pool", type="process")
+            )
+            created = await apply_deployments(
+                (definition,),
+                work_pool_name="integration-pool",
+                job_variables=job_variables,
+                client=cast(DeploymentClient, client),
+            )
+            first_omitted = await apply_deployments(
+                (definition,),
+                work_pool_name="integration-pool",
+                client=cast(DeploymentClient, client),
+            )
+            second_omitted = await apply_deployments(
+                (definition,),
+                work_pool_name="integration-pool",
+                client=cast(DeploymentClient, client),
+            )
+            persisted = await client.read_deployment_by_name(definition.key)
+            return created, first_omitted, second_omitted, persisted.job_variables
+
+    with prefect_test_harness():
+        created, first_omitted, second_omitted, persisted_job_variables = asyncio.run(
+            scenario()
+        )
+
+    assert [result.status for result in created.results] == ["created"]
+    assert [result.status for result in first_omitted.results] == ["unchanged"]
+    assert [result.status for result in second_omitted.results] == ["unchanged"]
+    assert persisted_job_variables == job_variables
 
 
 @pytest.mark.skipif(
@@ -406,14 +499,39 @@ def test_preflight_schema_and_definition_refusals_do_not_call_the_client() -> No
     ]
 
 
-def test_connection_failure_before_processing_is_typed_and_attempts_nothing() -> None:
+@pytest.mark.parametrize(
+    ("failure_point", "expected_calls"),
+    [
+        pytest.param("factory", ["factory"], id="factory-call"),
+        pytest.param("context-entry", ["factory", "enter"], id="context-entry"),
+    ],
+)
+def test_client_opening_failure_is_typed_without_retaining_provider_exception(
+    failure_point: str,
+    expected_calls: list[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     calls: list[str] = []
+    canary = "connection-sentinel-value"
 
-    @asynccontextmanager
-    async def unavailable() -> AsyncIterator[FakePrefectClient]:
-        calls.append("open")
-        raise RuntimeError("connection-sentinel-value")
-        yield FakePrefectClient()
+    class UnavailableContext:
+        async def __aenter__(self) -> FakePrefectClient:
+            calls.append("enter")
+            raise RuntimeError(canary)
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: object,
+        ) -> None:
+            raise AssertionError("context entry failure must not call __aexit__")
+
+    def unavailable() -> UnavailableContext:
+        calls.append("factory")
+        if failure_point == "factory":
+            raise RuntimeError(canary)
+        return UnavailableContext()
 
     with pytest.raises(DeploymentApplyConnectionError) as excinfo:
         _apply(
@@ -423,8 +541,10 @@ def test_connection_failure_before_processing_is_typed_and_attempts_nothing() ->
         )
 
     assert excinfo.value.cause_type == "RuntimeError"
-    assert "connection-sentinel-value" not in str(excinfo.value)
-    assert calls == ["open"]
+    assert canary not in f"{excinfo.value}\n{excinfo.value!r}\n{caplog.text}"
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
+    assert calls == expected_calls
 
 
 def test_client_context_receives_an_iteration_failure() -> None:

--- a/tests/vendored_prefect_extras/test_executors.py
+++ b/tests/vendored_prefect_extras/test_executors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import sys
 import threading
 from dataclasses import dataclass
@@ -17,7 +18,18 @@ from prefect import flow, get_run_logger
 from prefect.client.schemas.objects import FlowRun, State
 from prefect.exceptions import MissingContextError, ObjectNotFound, ParameterTypeError
 from prefect.flows import Flow
-from prefect.states import Cancelled, Completed, Crashed, Failed, Running
+from prefect.states import (
+    Cancelled,
+    Cancelling,
+    Completed,
+    Crashed,
+    Failed,
+    Paused,
+    Pending,
+    Running,
+    Scheduled,
+    Suspended,
+)
 
 import opsmill_prefect_extras.executors as executors_module
 from opsmill_prefect_extras.executors import (
@@ -683,8 +695,15 @@ def test_remote_terminal_faults_raise_narrow_errors_with_server_id(
     asyncio.run(scenario())
 
 
-def test_remote_missing_deployment_is_typed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Remote runs name the missing deployment instead of exposing client details."""
+@pytest.mark.parametrize("failure_point", ["lookup", "deletion-race"])
+def test_remote_not_found_translation_discards_provider_details(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure_point: str,
+) -> None:
+    """Both not-found paths expose only the safe deployment target."""
+
+    provider_canary = "provider-secret-token=https://private.invalid"
 
     @flow(name="absent-flow")
     def absent_flow() -> None:
@@ -692,32 +711,13 @@ def test_remote_missing_deployment_is_typed(monkeypatch: pytest.MonkeyPatch) -> 
 
     definition = _definition(monkeypatch, absent_flow)
 
-    class MissingDeploymentClient(_Client):
-        """A seam that reports the deployment as absent."""
+    class NotFoundClient(_Client):
+        """Raise a canary-bearing provider error at either submission step."""
 
         async def read_deployment_by_name(self, name: str) -> _Deployment:
-            raise ObjectNotFound(Exception("not found"))
-
-    async def scenario() -> None:
-        with pytest.raises(WorkflowNotFoundError, match="absent-flow/run"):
-            await RemoteWorkflowExecutor(MissingDeploymentClient()).run(definition, {})
-
-    asyncio.run(scenario())
-
-
-def test_remote_deployment_deleted_between_lookup_and_submit_is_typed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A deployment deletion race is reported as the same missing target error."""
-
-    @flow(name="deleted-flow")
-    def deleted_flow() -> None:
-        return None
-
-    definition = _definition(monkeypatch, deleted_flow)
-
-    class DeletionRaceClient(_Client):
-        """Find a deployment, then emulate its removal before submission."""
+            if failure_point == "lookup":
+                raise ObjectNotFound(Exception(provider_canary), provider_canary)
+            return await super().read_deployment_by_name(name)
 
         async def create_flow_run_from_deployment(
             self,
@@ -726,11 +726,24 @@ def test_remote_deployment_deleted_between_lookup_and_submit_is_typed(
             parameters: dict[str, Any],
             idempotency_key: str | None = None,
         ) -> _FlowRun:
-            raise ObjectNotFound(Exception("deleted"))
+            raise ObjectNotFound(Exception(provider_canary), provider_canary)
 
     async def scenario() -> None:
-        with pytest.raises(WorkflowNotFoundError, match="deleted-flow/run"):
-            await RemoteWorkflowExecutor(DeletionRaceClient()).submit(definition, {})
+        with pytest.raises(WorkflowNotFoundError) as raised:
+            await RemoteWorkflowExecutor(NotFoundClient()).submit(definition, {})
+
+        error = raised.value
+        logging.getLogger(__name__).error(
+            "translated remote submission failure",
+            exc_info=(type(error), error, error.__traceback__),
+        )
+        assert error.target == "absent-flow/run"
+        assert "absent-flow/run" in str(error)
+        assert provider_canary not in str(error)
+        assert provider_canary not in repr(error)
+        assert error.__cause__ is None
+        assert error.__context__ is None
+        assert provider_canary not in caplog.text
 
     asyncio.run(scenario())
 
@@ -775,6 +788,44 @@ def test_remote_cancel_requests_cancelling_then_observes_server_acknowledgement(
         assert await handle.wait() == "cancelled"
         assert await handle.cancel() == "cancelled"
         assert client.cancellation_requests == 1
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_status"),
+    [
+        pytest.param(None, "failed", id="absent"),
+        pytest.param(Scheduled(), "pending", id="scheduled"),
+        pytest.param(Pending(), "pending", id="pending"),
+        pytest.param(Running(), "running", id="running"),
+        pytest.param(Cancelling(), "cancelling", id="cancelling"),
+        pytest.param(Paused(), "paused", id="paused"),
+        pytest.param(Suspended(), "suspended", id="suspended"),
+        pytest.param(Completed(), "completed", id="completed"),
+        pytest.param(Failed(), "failed", id="failed"),
+        pytest.param(Crashed(), "crashed", id="crashed"),
+        pytest.param(Cancelled(), "cancelled", id="cancelled"),
+    ],
+)
+def test_remote_status_maps_every_public_prefect_state(
+    monkeypatch: pytest.MonkeyPatch,
+    state: State[Any] | None,
+    expected_status: str,
+) -> None:
+    """Remote status distinguishes every supported portable state."""
+
+    @flow(name="status-mapping-flow")
+    def status_mapping_flow() -> None:
+        return None
+
+    definition = _definition(monkeypatch, status_mapping_flow)
+    client = _Client()
+    client.flow_run.state = state
+
+    async def scenario() -> None:
+        handle = await RemoteWorkflowExecutor(client).submit(definition, {})
+        assert await handle.status() == expected_status
 
     asyncio.run(scenario())
 

--- a/uv.lock
+++ b/uv.lock
@@ -1076,6 +1076,7 @@ dependencies = [
     { name = "ruff" },
     { name = "structlog" },
     { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1146,6 +1147,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "types-toml", marker = "extra == 'dev'" },
     { name = "types-ujson", marker = "extra == 'dev'" },
+    { name = "typing-extensions", specifier = ">=4.0" },
     { name = "uvicorn", marker = "python_full_version >= '3.11' and extra == 'managed'", specifier = ">=0.34,<1" },
     { name = "yamllint", marker = "extra == 'dev'", specifier = ">=1.37.1" },
 ]


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credentials and resolved settings are now redacted from direct flow logs and error details.
  * Concurrent workflow runs no longer interfere with logging or redaction state.
  * Deployment updates correctly clear removed schedules, concurrency settings, tags, and entrypoints.
  * Missing workflows now produce consistent, sanitized errors.
* **New Features**
  * Added distinct execution statuses for paused and suspended workflows.
  * Improved workflow state reporting across supported remote execution states.
* **Documentation**
  * Updated managed orchestration references and changelog information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Harden Prefect-backed execution boundaries and refresh the vendored Prefect Extras source.

- Re-vendor the accepted deployment and executor safety changes from [opsmill/prefect-extras#16](https://github.com/opsmill/prefect-extras/pull/16) and [opsmill/prefect-extras#17](https://github.com/opsmill/prefect-extras/pull/17).
- Redact direct Prefect-flow logs with secret values collected from both the worker environment and the resolved Sync configuration.
- Prevent unsanitized duplicate records from propagating to ambient parent handlers.
- Restore the source logger's handlers, level, and propagation state after both successful and failed runs.

## Why

The direct Prefect flow installed its run-log bridge without the secret collection used by the managed flow and allowed the original source record to propagate. A credential-bearing adapter or engine message could therefore reach Prefect logs without redaction.

The vendored package also lagged the independently reviewed upstream safety fixes for deployment convergence, provider-detail removal, and paused/suspended state mapping.

## Compatibility and scope

- The public direct-flow parameters remain exactly `sync_name`, `operation`, `confirm_writes`, and `branch`.
- The vendored package and mapped upstream tests are byte-identical to upstream commit `97465e75137f6121d0377cd637383cfb3530d734`; no local adaptation was made.
- CLI and local execution behavior are unchanged.
- This does not merge or release the upstream Prefect Extras changes.

## Validation

- `uv run invoke format`
- `uv run invoke lint`
- `uv run pytest -q tests/orchestration/test_flow.py` — 35 passed
- `uv run pytest -q tests/vendored_prefect_extras` — 194 passed, 1 skipped
- `uv run pytest -q` — 1617 passed, 22 skipped, 1 xfailed
