### PR TITLE
fix: expose managed bearer authentication in OpenAPI

### DIFF
--- a/docs/docs/reference/managed-http-api.mdx
+++ b/docs/docs/reference/managed-http-api.mdx
@@ -127,6 +127,9 @@ The server listens on port `8000`. Its host defaults to `127.0.0.1`. Put TLS and
 network access controls at your ingress boundary. The bearer-token provider is the MVP
 application authentication boundary, not a replacement for transport security.
 
+Open `http://127.0.0.1:8000/docs`, select **Authorize**, and enter the configured token
+without the `Bearer` prefix; Swagger UI adds the complete `Authorization` header.
+
 ## Routes
 
 Every route requires `Authorization: Bearer <token>`. Every `POST` route also requires a

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 from fastapi import Depends, FastAPI, Header, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .auth import Principal, PrincipalResolver
 from .models import (
@@ -33,14 +34,16 @@ ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
 def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastAPI:
     """Create the managed application from explicit providers."""
     application = FastAPI(title="Infrahub Sync managed API", version="1.0.0")
+    bearer_auth = HTTPBearer(auto_error=False, scheme_name="BearerAuth")
 
-    def authenticate(request: Request, authorization: Annotated[str | None, Header()] = None) -> Principal:
-        parts = [] if authorization is None else authorization.split(None, 1)
-        if len(parts) != 2 or parts[0].casefold() != "bearer" or not parts[1]:
+    def authenticate(
+        request: Request,
+        credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_auth)],
+    ) -> Principal:
+        if credentials is None:
             service.record_authentication_refusal(request.url.path, "missing-or-invalid-authorization")
             raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
-        token = parts[1]
-        principal = resolver.resolve(token)
+        principal = resolver.resolve(credentials.credentials)
         if principal is None:
             service.record_authentication_refusal(request.url.path, "invalid-bearer-token")
             raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -43,7 +43,11 @@ def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastA
         if credentials is None:
             service.record_authentication_refusal(request.url.path, "missing-or-invalid-authorization")
             raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
-        principal = resolver.resolve(credentials.credentials)
+        token = credentials.credentials.lstrip(" ")
+        if not token:
+            service.record_authentication_refusal(request.url.path, "missing-or-invalid-authorization")
+            raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")
+        principal = resolver.resolve(token)
         if principal is None:
             service.record_authentication_refusal(request.url.path, "invalid-bearer-token")
             raise ManagedAPIError(401, "unauthenticated", "a valid bearer token is required")

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -94,10 +94,16 @@ def managed(
     return TestClient(create_app(service, resolver)), projection, orchestration
 
 
-def _create(client: TestClient, *, key: str = RAW_KEY, reason: str = "review inventory changes"):
+def _create(
+    client: TestClient,
+    *,
+    key: str = RAW_KEY,
+    reason: str = "review inventory changes",
+    authorization: str = f"Bearer {OWNER_TOKEN}",
+):
     return client.post(
         "/runs",
-        headers={"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": key},
+        headers={"Authorization": authorization, "Idempotency-Key": key},
         json={
             "sync_name": "inventory",
             "operation": "plan",
@@ -141,14 +147,17 @@ def test_authentication_idempotency_and_secret_boundaries(
     missing = client.post("/runs", json={})
     malformed = client.post("/runs", headers={"Authorization": "Basic not-a-bearer-token"}, json={})
     invalid = client.post("/runs", headers={"Authorization": "Bearer invalid-token-value"}, json={})
-    assert missing.status_code == 401
-    assert malformed.status_code == 401
-    assert invalid.status_code == 401
-    for response in (missing, malformed, invalid):
+    for response in (
+        missing,
+        malformed,
+        client.post("/runs", headers={"Authorization": "Bearer    "}, json={}),
+        invalid,
+    ):
+        assert response.status_code == 401
         assert response.json()["error"]["code"] == "unauthenticated"
         assert response.headers["WWW-Authenticate"] == "Bearer"
 
-    first = _create(client, reason=f"requested because {OWNER_TOKEN}")
+    first = _create(client, reason=f"requested because {OWNER_TOKEN}", authorization=f"Bearer    {OWNER_TOKEN}")
     replay = _create(client, reason=f"requested because {OWNER_TOKEN}")
     conflict = _create(client, reason="different reason")
 

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -139,10 +139,14 @@ def test_authentication_idempotency_and_secret_boundaries(
     client, projection, orchestration = managed
 
     missing = client.post("/runs", json={})
+    malformed = client.post("/runs", headers={"Authorization": "Basic not-a-bearer-token"}, json={})
     invalid = client.post("/runs", headers={"Authorization": "Bearer invalid-token-value"}, json={})
     assert missing.status_code == 401
+    assert malformed.status_code == 401
     assert invalid.status_code == 401
-    assert missing.json()["error"]["code"] == "unauthenticated"
+    for response in (missing, malformed, invalid):
+        assert response.json()["error"]["code"] == "unauthenticated"
+        assert response.headers["WWW-Authenticate"] == "Bearer"
 
     first = _create(client, reason=f"requested because {OWNER_TOKEN}")
     replay = _create(client, reason=f"requested because {OWNER_TOKEN}")
@@ -738,7 +742,10 @@ def test_confirmation_schema_errors_and_openapi_contract(
     assert all(set(response.json()) == {"error"} for response in (unconfirmed, missing_key, invalid, invalid_operation))
     assert not orchestration.submissions
 
-    paths = client.get("/openapi.json").json()["paths"]
+    openapi = client.get("/openapi.json").json()
+    assert openapi["components"]["securitySchemes"] == {"BearerAuth": {"scheme": "bearer", "type": "http"}}
+
+    paths = openapi["paths"]
     assert set(paths) == {
         "/runs",
         "/runs/{run_id}",
@@ -754,3 +761,4 @@ def test_confirmation_schema_errors_and_openapi_contract(
         for operation in route.values():
             assert "401" in operation["responses"]
             assert "422" in operation["responses"]
+            assert operation["security"] == [{"BearerAuth": []}]


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for authenticating with the managed HTTP API through Swagger UI.
  - Clarified that tokens should be entered without the `Bearer` prefix.

- **Bug Fixes**
  - Improved handling of missing, malformed, and whitespace-only authentication credentials.
  - Preserved consistent 401 responses and authentication headers for rejected requests.

- **Tests**
  - Expanded authentication coverage and verified Bearer authentication requirements across API operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Use FastAPI's HTTPBearer dependency instead of hand rolling bearer tokens.

## Key Changes

- Advertise `BearerAuth` using FastAPI's `HTTPBearer` security dependency.
- Preserve custom 401 responses, authentication auditing, and RFC-valid repeated spaces.
- Test the OpenAPI security contract and missing, malformed, empty, and invalid credentials.

## Documentation Updates

- Explain how to authorize requests through the interactive `/docs` interface.

## Test Plan

- `uv run pytest -q tests/managed/test_http_api.py` — 24 passed
- `uv run invoke format` — passed
- `uv run invoke lint` — passed
- `uv run pytest -q` — 1,605 passed, 16 skipped, 1 xfailed
- CLI help and example-list sanity checks — passed
