### PR TITLE
docs: record the CI credential requirement for prefect-extras re-adoption

### DIFF
--- a/opsmill_prefect_extras/VENDORED.md
+++ b/opsmill_prefect_extras/VENDORED.md
@@ -39,3 +39,26 @@ restore the dependency in the `managed` extra, and drop the vendoring entries
 from the Ruff exclude list, `[tool.ty.src]` exclude, the isort
 `known-third-party` pin, and `.github/file-filters.yml`.
 `tests/test_vendoring_consistency.py` fails on any half-executed re-adoption.
+
+### CI authentication on re-adoption
+
+Restoring the dependency reintroduces a problem vendoring removed: `opsmill/prefect-extras`
+is a private repository, so CI can no longer install the `managed` extra with the default
+job token.
+
+Two approaches to this were written before vendoring was chosen, and both were dropped
+unmerged. They are kept because the second one is worth reusing rather than rediscovering:
+
+* Commit `cadc0ffe` on branch `feature/pr173-ci-auth-rejected` passes the credential to
+  `actions/checkout`, which makes it available to the whole clone for the rest of the job.
+* Tag `archive/pr173-ci-credential-scoping` replaces that with a git credential helper set
+  as `env` on the dependency-install step alone, so no other step can read the token. Run
+  `git show archive/pr173-ci-credential-scoping` for the exact change.
+
+Prefer the scoped form. Whichever is used, the workflows are reusable
+(`workflow_call`), so the credential must also be declared under their `secrets:` inputs —
+an undeclared secret resolves to an empty string and fails as a confusing authentication
+error rather than a missing-input error.
+
+Neither branch nor tag is live work. Do not merge them; treat them as a starting point for
+the re-adoption change.


### PR DESCRIPTION
Record what re-adopting the vendored `opsmill_prefect_extras` package will require from CI, and point at the prior work that already solved it.

Documentation only. No behaviour, dependency, or workflow change.

## Why

Vendoring the package removed a private Git pin, and with it the need for CI to authenticate a dependency install. The re-adoption condition in `VENDORED.md` says to restore that dependency — which brings the requirement straight back, since `opsmill/prefect-extras` is private.

Two approaches to it were written on 2026-08-13 and both were dropped unmerged once vendoring was chosen. They were sitting only in a local branch and a local stash entry, so they would have been lost or redone. The scoped one is worth reusing.

## What is recorded

- Branch `feature/pr173-ci-auth-rejected` — passes the credential to `actions/checkout`, making it readable by every later step in the job.
- Tag `archive/pr173-ci-credential-scoping` — replaces that with a git credential helper set as `env` on the dependency-install step alone. `git show archive/pr173-ci-credential-scoping` is the exact change.

Both are now pushed for durability. Neither is live work and the note says not to merge them.

The note also records the trap both share: these workflows are reusable via `workflow_call`, so the credential must be declared under their `secrets:` inputs. An undeclared secret resolves to an empty string and surfaces as an authentication failure rather than a missing input, which is a slow thing to diagnose.

## Validation

- `uv run pytest -q tests/test_vendoring_consistency.py` — 1 passed
- `uv run invoke docs.rumdl` — no issues in 72 files
- No source, dependency, or workflow file is touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring CI authentication when re-adopting the private dependency.
  * Documented credential-handling considerations, required secret declarations, and the archived branch and tag as reference-only material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->