### PR TITLE
fix: duck-type get_kind() instead of isinstance against write-side schema classes

### DIFF
--- a/changelog/+187-generator-schema-api-annotations.fixed.md
+++ b/changelog/+187-generator-schema-api-annotations.fixed.md
@@ -1,0 +1,4 @@
+Fixed generated DiffSync model annotations for schemas read from the Infrahub API.
+Optional attributes and many relationships are annotated and defaulted correctly again,
+and string attribute defaults are now emitted as Python literals, so defaults containing
+quotes, newlines or backslashes stay valid Python and keep their exact schema value.

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, Protocol, Union, cast
 
 import jinja2
 from infrahub_sdk.schema import (
@@ -117,13 +117,36 @@ def get_children(node: NodeSchema, config: SyncConfig) -> str | None:
     return "{" + ", ".join(children_list) + "}"
 
 
-def get_kind(item: Union[RelationshipSchema, AttributeSchema]) -> str:
+class _AttributeLike(Protocol):
+    """Structural shape get_kind() needs from an attribute-schema object.
+
+    `kind` is typed `Any` rather than `str`: real schema classes type it as
+    an `AttributeKind` str-enum, and Protocol attribute matching is invariant,
+    so a `str`-typed member here would reject them despite being usable as a
+    ATTRIBUTE_KIND_MAP lookup key.
+    """
+
+    kind: Any
+    optional: bool
+    default_value: Any
+
+
+class _RelationshipLike(Protocol):
+    """Structural shape get_kind() needs from a relationship-schema object."""
+
+    cardinality: str
+    optional: bool
+
+
+def get_kind(item: Union[_AttributeLike, _RelationshipLike]) -> str:
     # Duck-typed on `cardinality` rather than `isinstance(item, (AttributeSchema,
     # RelationshipSchema))`: the SDK's read-side schema objects returned by
     # `client.schema.all()` (e.g. AttributeSchemaAPI/RelationshipSchemaAPI) are not
     # guaranteed to subclass these write-side classes across infrahub-sdk versions
     # -- that inheritance held at 1.18.1 but was removed by 1.23.0, which silently
     # made every attribute/relationship fall through to the "str" default below.
+    # The parameter type reflects that: any object with the right shape works,
+    # not just AttributeSchema/RelationshipSchema instances.
     kind = "str"
     is_relationship = hasattr(item, "cardinality")
 

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -118,8 +118,16 @@ def get_children(node: NodeSchema, config: SyncConfig) -> str | None:
 
 
 def get_kind(item: Union[RelationshipSchema, AttributeSchema]) -> str:
+    # Duck-typed on `cardinality` rather than `isinstance(item, (AttributeSchema,
+    # RelationshipSchema))`: the SDK's read-side schema objects returned by
+    # `client.schema.all()` (e.g. AttributeSchemaAPI/RelationshipSchemaAPI) are not
+    # guaranteed to subclass these write-side classes across infrahub-sdk versions
+    # -- that inheritance held at 1.18.1 but was removed by 1.23.0, which silently
+    # made every attribute/relationship fall through to the "str" default below.
     kind = "str"
-    if isinstance(item, AttributeSchema):
+    is_relationship = hasattr(item, "cardinality")
+
+    if not is_relationship:
         kind = ATTRIBUTE_KIND_MAP.get(item.kind, "str")
         if item.optional:
             kind = f"{kind} | None"
@@ -134,11 +142,11 @@ def get_kind(item: Union[RelationshipSchema, AttributeSchema]) -> str:
             else:
                 kind += " = None"
 
-    elif isinstance(item, RelationshipSchema) and item.cardinality == "one":
+    elif item.cardinality == "one":
         if item.optional:
             kind = f"{kind} | None = None"
 
-    elif isinstance(item, RelationshipSchema) and item.cardinality == "many":
+    elif item.cardinality == "many":
         kind = "list[str]"
         if item.optional:
             kind = f"{kind} | None"

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol
 
 import jinja2
 from infrahub_sdk.schema import (
-    AttributeSchema,
     NodeSchema,
     RelationshipKind,
-    RelationshipSchema,
 )
 
 if TYPE_CHECKING:
@@ -134,20 +132,17 @@ class _RelationshipLike(Protocol):
 
 def get_attribute_type_annotation(item: _AttributeLike) -> str:
     """Return type annotation of schema attribute for Diffsync model."""
-    annotation = "str"
-
-    attr = cast("AttributeSchema", item)
-    annotation = ATTRIBUTE_KIND_MAP.get(attr.kind, "str")
-    if attr.optional:
+    annotation = ATTRIBUTE_KIND_MAP.get(item.kind, "str")
+    if item.optional:
         annotation = f"{annotation} | None"
-        if attr.default_value is not None:
+        if item.default_value is not None:
             # Format the default value based on its type
-            if isinstance(attr.default_value, str):
-                annotation += f' = "{attr.default_value}"'
-            elif isinstance(attr.default_value, (int, float, bool)):
-                annotation += f" = {attr.default_value}"
+            if isinstance(item.default_value, str):
+                annotation += f' = "{item.default_value}"'
+            elif isinstance(item.default_value, (int, float, bool)):
+                annotation += f" = {item.default_value}"
             else:
-                annotation += f" = {attr.default_value!r}"
+                annotation += f" = {item.default_value!r}"
         else:
             annotation += " = None"
 
@@ -157,14 +152,13 @@ def get_attribute_type_annotation(item: _AttributeLike) -> str:
 def get_relationship_type_annotation(item: _RelationshipLike) -> str:
     """Return type annotation of schema relationship for Diffsync model."""
     annotation = "str"
-    rel = cast("RelationshipSchema", item)
-    if rel.cardinality == "one":
-        if rel.optional:
+    if item.cardinality == "one":
+        if item.optional:
             annotation = f"{annotation} | None = None"
 
-    elif rel.cardinality == "many":
+    elif item.cardinality == "many":
         annotation = "list[str]"
-        if rel.optional:
+        if item.optional:
             annotation = f"{annotation} | None"
         annotation += " = []"
 

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, Union, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import jinja2
 from infrahub_sdk.schema import (
@@ -118,7 +118,7 @@ def get_children(node: NodeSchema, config: SyncConfig) -> str | None:
 
 
 class _AttributeLike(Protocol):
-    """Structural shape get_kind() needs from an attribute-schema object."""
+    """Structural shape get_attribute_type_annotation() needs from an attribute-schema object."""
 
     kind: Any
     optional: bool
@@ -126,45 +126,49 @@ class _AttributeLike(Protocol):
 
 
 class _RelationshipLike(Protocol):
-    """Structural shape get_kind() needs from a relationship-schema object."""
+    """Structural shape get_relationship_type_annotation() needs from a relationship-schema object."""
 
     cardinality: str
     optional: bool
 
 
-def get_kind(item: Union[_AttributeLike, _RelationshipLike]) -> str:
-    kind = "str"
-    is_relationship = hasattr(item, "cardinality")
+def get_attribute_type_annotation(item: _AttributeLike) -> str:
+    """Return type annotation of schema attribute for Diffsync model."""
+    annotation = "str"
 
-    if not is_relationship:
-        attr = cast("AttributeSchema", item)
-        kind = ATTRIBUTE_KIND_MAP.get(attr.kind, "str")
-        if attr.optional:
-            kind = f"{kind} | None"
-            if attr.default_value is not None:
-                # Format the default value based on its type
-                if isinstance(attr.default_value, str):
-                    kind += f' = "{attr.default_value}"'
-                elif isinstance(attr.default_value, (int, float, bool)):
-                    kind += f" = {attr.default_value}"
-                else:
-                    kind += f" = {attr.default_value!r}"
+    attr = cast("AttributeSchema", item)
+    annotation = ATTRIBUTE_KIND_MAP.get(attr.kind, "str")
+    if attr.optional:
+        annotation = f"{annotation} | None"
+        if attr.default_value is not None:
+            # Format the default value based on its type
+            if isinstance(attr.default_value, str):
+                annotation += f' = "{attr.default_value}"'
+            elif isinstance(attr.default_value, (int, float, bool)):
+                annotation += f" = {attr.default_value}"
             else:
-                kind += " = None"
+                annotation += f" = {attr.default_value!r}"
+        else:
+            annotation += " = None"
 
-    else:
-        rel = cast("RelationshipSchema", item)
-        if rel.cardinality == "one":
-            if rel.optional:
-                kind = f"{kind} | None = None"
+    return annotation
 
-        elif rel.cardinality == "many":
-            kind = "list[str]"
-            if rel.optional:
-                kind = f"{kind} | None"
-            kind += " = []"
 
-    return kind
+def get_relationship_type_annotation(item: _RelationshipLike) -> str:
+    """Return type annotation of schema relationship for Diffsync model."""
+    annotation = "str"
+    rel = cast("RelationshipSchema", item)
+    if rel.cardinality == "one":
+        if rel.optional:
+            annotation = f"{annotation} | None = None"
+
+    elif rel.cardinality == "many":
+        annotation = "list[str]"
+        if rel.optional:
+            annotation = f"{annotation} | None"
+        annotation += " = []"
+
+    return annotation
 
 
 def has_children(node: NodeSchema, config: SyncConfig) -> bool:
@@ -185,7 +189,8 @@ def render_template(template_file: Path, output_dir: Path, output_file: Path, co
     template_env.filters["has_node"] = has_node
     template_env.filters["has_field"] = has_field
     template_env.filters["has_children"] = has_children
-    template_env.filters["get_kind"] = get_kind
+    template_env.filters["get_attribute_type_annotation"] = get_attribute_type_annotation
+    template_env.filters["get_relationship_type_annotation"] = get_relationship_type_annotation
 
     template = template_env.get_template(str(template_file))
 

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 import jinja2
 from infrahub_sdk.schema import (
@@ -128,29 +128,32 @@ def get_kind(item: Union[RelationshipSchema, AttributeSchema]) -> str:
     is_relationship = hasattr(item, "cardinality")
 
     if not is_relationship:
-        kind = ATTRIBUTE_KIND_MAP.get(item.kind, "str")
-        if item.optional:
+        attr = cast("AttributeSchema", item)
+        kind = ATTRIBUTE_KIND_MAP.get(attr.kind, "str")
+        if attr.optional:
             kind = f"{kind} | None"
-            if item.default_value is not None:
+            if attr.default_value is not None:
                 # Format the default value based on its type
-                if isinstance(item.default_value, str):
-                    kind += f' = "{item.default_value}"'
-                elif isinstance(item.default_value, (int, float, bool)):
-                    kind += f" = {item.default_value}"
+                if isinstance(attr.default_value, str):
+                    kind += f' = "{attr.default_value}"'
+                elif isinstance(attr.default_value, (int, float, bool)):
+                    kind += f" = {attr.default_value}"
                 else:
-                    kind += f" = {item.default_value!r}"
+                    kind += f" = {attr.default_value!r}"
             else:
                 kind += " = None"
 
-    elif item.cardinality == "one":
-        if item.optional:
-            kind = f"{kind} | None = None"
+    else:
+        rel = cast("RelationshipSchema", item)
+        if rel.cardinality == "one":
+            if rel.optional:
+                kind = f"{kind} | None = None"
 
-    elif item.cardinality == "many":
-        kind = "list[str]"
-        if item.optional:
-            kind = f"{kind} | None"
-        kind += " = []"
+        elif rel.cardinality == "many":
+            kind = "list[str]"
+            if rel.optional:
+                kind = f"{kind} | None"
+            kind += " = []"
 
     return kind
 

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -118,13 +118,7 @@ def get_children(node: NodeSchema, config: SyncConfig) -> str | None:
 
 
 class _AttributeLike(Protocol):
-    """Structural shape get_kind() needs from an attribute-schema object.
-
-    `kind` is typed `Any` rather than `str`: real schema classes type it as
-    an `AttributeKind` str-enum, and Protocol attribute matching is invariant,
-    so a `str`-typed member here would reject them despite being usable as a
-    ATTRIBUTE_KIND_MAP lookup key.
-    """
+    """Structural shape get_kind() needs from an attribute-schema object."""
 
     kind: Any
     optional: bool

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -139,14 +139,6 @@ class _RelationshipLike(Protocol):
 
 
 def get_kind(item: Union[_AttributeLike, _RelationshipLike]) -> str:
-    # Duck-typed on `cardinality` rather than `isinstance(item, (AttributeSchema,
-    # RelationshipSchema))`: the SDK's read-side schema objects returned by
-    # `client.schema.all()` (e.g. AttributeSchemaAPI/RelationshipSchemaAPI) are not
-    # guaranteed to subclass these write-side classes across infrahub-sdk versions
-    # -- that inheritance held at 1.18.1 but was removed by 1.23.0, which silently
-    # made every attribute/relationship fall through to the "str" default below.
-    # The parameter type reflects that: any object with the right shape works,
-    # not just AttributeSchema/RelationshipSchema instances.
     kind = "str"
     is_relationship = hasattr(item, "cardinality")
 

--- a/infrahub_sync/generator/__init__.py
+++ b/infrahub_sync/generator/__init__.py
@@ -134,17 +134,9 @@ def get_attribute_type_annotation(item: _AttributeLike) -> str:
     """Return type annotation of schema attribute for Diffsync model."""
     annotation = ATTRIBUTE_KIND_MAP.get(item.kind, "str")
     if item.optional:
-        annotation = f"{annotation} | None"
-        if item.default_value is not None:
-            # Format the default value based on its type
-            if isinstance(item.default_value, str):
-                annotation += f' = "{item.default_value}"'
-            elif isinstance(item.default_value, (int, float, bool)):
-                annotation += f" = {item.default_value}"
-            else:
-                annotation += f" = {item.default_value!r}"
-        else:
-            annotation += " = None"
+        # repr() emits a Python literal that reproduces the schema value exactly, so string
+        # defaults containing quotes, newlines or backslashes stay valid and unchanged.
+        annotation = f"{annotation} | None = {item.default_value!r}"
 
     return annotation
 

--- a/infrahub_sync/generator/templates/diffsync_models.j2
+++ b/infrahub_sync/generator/templates/diffsync_models.j2
@@ -35,12 +35,12 @@ class {{ nodekind }}(_ModelBaseClass):
 
 {%-      for attr in node.attributes -%}
 {%-          if config | has_field(node.kind, attr.name) %}
-    {{ attr.name }}: {{ attr | get_kind }}
+    {{ attr.name }}: {{ attr | get_attribute_type_annotation }}
 {%-          endif -%}
 {%-      endfor -%}
 {%-      for rel in node.relationships -%}
 {%-          if config | has_field(node.kind, rel.name) %}
-    {{ rel.name }}: {{ rel | get_kind }}
+    {{ rel.name }}: {{ rel | get_relationship_type_annotation }}
 {%-          endif -%}
 {%-      endfor %}
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,22 +1,10 @@
-"""Tests for infrahub_sync.generator.get_kind.
+"""Tests for infrahub_sync.generator.get_attribute_type_annotation / get_relationship_type_annotation.
 
-get_kind() decides the pydantic type annotation for each generated DiffSync
-model field. It must work on whatever object `client.schema.all()` hands back
+These functions decide the pydantic type annotation for each generated DiffSync
+model field. They must work on whatever object `client.schema.all()` hands back
 -- infrahub-sdk's read-side schema classes (AttributeSchemaAPI /
 RelationshipSchemaAPI) -- not just on the write-side AttributeSchema /
 RelationshipSchema classes used to build schema payloads.
-
-Those two class families are not guaranteed to share a common base: at
-infrahub-sdk 1.18.1 the read-side classes happened to subclass the write-side
-ones, so an `isinstance(item, AttributeSchema)` check worked; at 1.23.0 that
-inheritance was removed, and the check silently stopped matching anything,
-making get_kind() fall through to its "str" default for every attribute and
-relationship (see https://github.com/opsmill/infrahub-sync/issues/187).
-
-`_FakeAttribute`/`_FakeRelationship` below deliberately do NOT inherit from
-either SDK schema family. They exist so this suite fails if get_kind() is
-ever changed back to an isinstance-based check -- regardless of which
-infrahub-sdk version the lockfile happens to resolve at the time.
 """
 
 from __future__ import annotations
@@ -28,7 +16,7 @@ import pytest
 from infrahub_sdk.schema import AttributeSchema, RelationshipSchema
 from infrahub_sdk.schema.main import AttributeKind, AttributeSchemaAPI, RelationshipSchemaAPI
 
-from infrahub_sync.generator import get_kind
+from infrahub_sync.generator import get_attribute_type_annotation, get_relationship_type_annotation
 
 
 @dataclass
@@ -71,8 +59,8 @@ def test_fake_schema_objects_do_not_subclass_sdk_schema_classes() -> None:
         (_FakeAttribute(kind="Boolean", optional=True, default_value=True), "bool | None = True"),
     ],
 )
-def test_get_kind_for_attribute_shaped_objects(attribute: _FakeAttribute, expected: str) -> None:
-    assert get_kind(attribute) == expected
+def test_get_attribute_type_annotation_for_attribute_shaped_objects(attribute: _FakeAttribute, expected: str) -> None:
+    assert get_attribute_type_annotation(attribute) == expected
 
 
 @pytest.mark.parametrize(
@@ -84,25 +72,25 @@ def test_get_kind_for_attribute_shaped_objects(attribute: _FakeAttribute, expect
         (_FakeRelationship(cardinality="many", optional=True), "list[str] | None = []"),
     ],
 )
-def test_get_kind_for_relationship_shaped_objects(relationship: _FakeRelationship, expected: str) -> None:
-    assert get_kind(relationship) == expected
+def test_get_relationship_type_annotation_for_relationship_shaped_objects(
+    relationship: _FakeRelationship, expected: str
+) -> None:
+    assert get_relationship_type_annotation(relationship) == expected
 
 
-def test_get_kind_against_real_sdk_read_side_schema_classes() -> None:
-    """Sanity check against the actual classes `client.schema.all()` returns.
-
-    Complements the fakes above with the real infrahub-sdk read-side types,
-    so a shape drift in the SDK itself (a renamed/removed field) is caught
-    here too, not just a reintroduced isinstance check.
-    """
+def test_get_attribute_type_annotation_against_real_sdk_read_side_schema_classes() -> None:
+    """Sanity check against the actual classes `client.schema.all()` returns."""
     optional_attr = AttributeSchemaAPI(id="1", name="description", kind=AttributeKind.TEXT, optional=True)
-    assert get_kind(optional_attr) == "str | None = None"
+    assert get_attribute_type_annotation(optional_attr) == "str | None = None"
 
     required_attr = AttributeSchemaAPI(id="2", name="name", kind=AttributeKind.TEXT, optional=False)
-    assert get_kind(required_attr) == "str"
+    assert get_attribute_type_annotation(required_attr) == "str"
 
+
+def test_get_relationship_type_annotation_against_real_sdk_read_side_schema_classes() -> None:
+    """Sanity check against the actual classes `client.schema.all()` returns."""
     many_rel = RelationshipSchemaAPI(id="3", name="tags", peer="BuiltinTag", cardinality="many", optional=True)
-    assert get_kind(many_rel) == "list[str] | None = []"
+    assert get_relationship_type_annotation(many_rel) == "list[str] | None = []"
 
     one_rel = RelationshipSchemaAPI(id="4", name="status", peer="StatusGeneric", cardinality="one", optional=False)
-    assert get_kind(one_rel) == "str"
+    assert get_relationship_type_annotation(one_rel) == "str"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6,9 +6,11 @@ model field. They must work on whatever object `client.schema.all()` hands back
 RelationshipSchemaAPI) -- not just on the write-side AttributeSchema /
 RelationshipSchema classes used to build schema payloads.
 
-The read-side and write-side SDK schema hierarchies are independent: AttributeSchemaAPI
-is not a subclass of AttributeSchema (see #187), so these filters must rely on the
-attribute/relationship shape alone and never on isinstance() against either hierarchy.
+SDK read-side classes need not inherit from the write-side ones: a newer infrahub-sdk
+detached AttributeSchemaAPI from AttributeSchema (see #187), while older versions -- including
+the one currently pinned -- still share that inheritance. These filters must therefore rely on
+the attribute/relationship shape alone and never on isinstance() against either hierarchy, and
+the fakes below keep the detached case covered even where the SDK still shares it.
 """
 
 from __future__ import annotations

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,22 +1,43 @@
-"""Tests for infrahub_sync.generator.get_attribute_type_annotation / get_relationship_type_annotation.
+"""Tests for infrahub_sync.generator annotation filters and the generated model template.
 
 These functions decide the pydantic type annotation for each generated DiffSync
 model field. They must work on whatever object `client.schema.all()` hands back
 -- infrahub-sdk's read-side schema classes (AttributeSchemaAPI /
 RelationshipSchemaAPI) -- not just on the write-side AttributeSchema /
 RelationshipSchema classes used to build schema payloads.
+
+The read-side and write-side SDK schema hierarchies are independent: AttributeSchemaAPI
+is not a subclass of AttributeSchema (see #187), so these filters must rely on the
+attribute/relationship shape alone and never on isinstance() against either hierarchy.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import sys
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from infrahub_sdk.schema import AttributeSchema, RelationshipSchema
-from infrahub_sdk.schema.main import AttributeKind, AttributeSchemaAPI, RelationshipSchemaAPI
+from infrahub_sdk.schema.main import (
+    AttributeKind,
+    AttributeSchemaAPI,
+    NodeSchemaAPI,
+    RelationshipSchemaAPI,
+)
+from pydantic import ValidationError
 
-from infrahub_sync.generator import get_attribute_type_annotation, get_relationship_type_annotation
+from infrahub_sync import SchemaMappingField, SchemaMappingModel, SyncAdapter, SyncConfig
+from infrahub_sync.generator import (
+    get_attribute_type_annotation,
+    get_relationship_type_annotation,
+    render_template,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 @dataclass
@@ -34,6 +55,34 @@ class _FakeRelationship:
 
     cardinality: str
     optional: bool = False
+
+
+def _render_sync_models(tmp_path: Path, node: NodeSchemaAPI) -> ModuleType:
+    """Render diffsync_models.j2 through the production render_template and import the result."""
+    field_names = [attr.name for attr in node.attributes] + [rel.name for rel in node.relationships]
+    config = SyncConfig(
+        name="generator-test",
+        source=SyncAdapter(name="infrahub"),
+        destination=SyncAdapter(name="infrahub"),
+        schema_mapping=[
+            SchemaMappingModel(name=node.kind, fields=[SchemaMappingField(name=name) for name in field_names])
+        ],
+    )
+    render_template(
+        template_file=Path("diffsync_models.j2"),
+        output_dir=tmp_path,
+        output_file=Path("sync_models.py"),
+        context={"schema": {node.kind: node}, "adapter": config.source, "config": config},
+    )
+
+    module_name = f"sync_models_{tmp_path.name}"
+    spec = importlib.util.spec_from_file_location(module_name, tmp_path / "sync_models.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_fake_schema_objects_do_not_subclass_sdk_schema_classes() -> None:
@@ -54,12 +103,13 @@ def test_fake_schema_objects_do_not_subclass_sdk_schema_classes() -> None:
         (_FakeAttribute(kind="Boolean"), "bool"),
         (_FakeAttribute(kind="SomeUnmappedKind"), "str"),
         (_FakeAttribute(kind="Text", optional=True), "str | None = None"),
-        (_FakeAttribute(kind="Text", optional=True, default_value="foo"), 'str | None = "foo"'),
+        (_FakeAttribute(kind="Text", optional=True, default_value="foo"), "str | None = 'foo'"),
         (_FakeAttribute(kind="Number", optional=True, default_value=5), "int | None = 5"),
         (_FakeAttribute(kind="Boolean", optional=True, default_value=True), "bool | None = True"),
     ],
 )
 def test_get_attribute_type_annotation_for_attribute_shaped_objects(attribute: _FakeAttribute, expected: str) -> None:
+    """Attribute kind, optionality and default value together decide the generated annotation."""
     assert get_attribute_type_annotation(attribute) == expected
 
 
@@ -75,6 +125,7 @@ def test_get_attribute_type_annotation_for_attribute_shaped_objects(attribute: _
 def test_get_relationship_type_annotation_for_relationship_shaped_objects(
     relationship: _FakeRelationship, expected: str
 ) -> None:
+    """Relationship cardinality and optionality together decide the generated annotation."""
     assert get_relationship_type_annotation(relationship) == expected
 
 
@@ -86,6 +137,12 @@ def test_get_attribute_type_annotation_against_real_sdk_read_side_schema_classes
     required_attr = AttributeSchemaAPI(id="2", name="name", kind=AttributeKind.TEXT, optional=False)
     assert get_attribute_type_annotation(required_attr) == "str"
 
+    number_attr = AttributeSchemaAPI(id="3", name="mtu", kind=AttributeKind.NUMBER, optional=True, default_value=1500)
+    assert get_attribute_type_annotation(number_attr) == "int | None = 1500"
+
+    boolean_attr = AttributeSchemaAPI(id="4", name="enabled", kind=AttributeKind.BOOLEAN, optional=False)
+    assert get_attribute_type_annotation(boolean_attr) == "bool"
+
 
 def test_get_relationship_type_annotation_against_real_sdk_read_side_schema_classes() -> None:
     """Sanity check against the actual classes `client.schema.all()` returns."""
@@ -94,3 +151,73 @@ def test_get_relationship_type_annotation_against_real_sdk_read_side_schema_clas
 
     one_rel = RelationshipSchemaAPI(id="4", name="status", peer="StatusGeneric", cardinality="one", optional=False)
     assert get_relationship_type_annotation(one_rel) == "str"
+
+
+def test_rendered_model_preserves_read_side_schema_semantics(tmp_path: Path) -> None:
+    """The generated model keeps optionality, scalar defaults, many relationships and identifiers."""
+    node = NodeSchemaAPI(
+        name="Widget",
+        namespace="Testing",
+        attributes=[
+            AttributeSchemaAPI(id="a1", name="name", kind=AttributeKind.TEXT, unique=True, optional=False),
+            AttributeSchemaAPI(id="a2", name="description", kind=AttributeKind.TEXT, optional=True),
+            AttributeSchemaAPI(id="a3", name="mtu", kind=AttributeKind.NUMBER, optional=True, default_value=1500),
+            AttributeSchemaAPI(id="a4", name="enabled", kind=AttributeKind.BOOLEAN, optional=True, default_value=False),
+        ],
+        relationships=[
+            RelationshipSchemaAPI(id="r1", name="tags", peer="BuiltinTag", cardinality="many", optional=True),
+            RelationshipSchemaAPI(id="r2", name="status", peer="StatusGeneric", cardinality="one", optional=True),
+        ],
+    )
+
+    model = _render_sync_models(tmp_path, node).TestingWidget
+    assert model._identifiers == ("name",)
+    assert {name: model.model_fields[name].annotation for name in model._identifiers + model._attributes} == {
+        "name": str,
+        "description": str | None,
+        "mtu": int | None,
+        "enabled": bool | None,
+        "tags": list[str] | None,
+        "status": str | None,
+    }
+
+    widget = model(name="widget-1")
+    assert widget.description is None
+    assert widget.mtu == 1500
+    assert widget.enabled is False
+    assert widget.tags == []
+    assert widget.status is None
+
+    with pytest.raises(ValidationError):
+        model()
+
+
+@pytest.mark.parametrize(
+    "default_value",
+    [
+        "plain",
+        "",
+        'double "quoted"',
+        "single 'quoted'",
+        "back\\slash",
+        "escape\\tsequence",
+        "trailing\\",
+        "first\nsecond",
+        "mixed \"both\" 'kinds' \\ and\nnewline",
+    ],
+)
+def test_rendered_model_round_trips_string_defaults(tmp_path: Path, default_value: str) -> None:
+    """A string default must render as a Python literal that reproduces the schema value exactly."""
+    node = NodeSchemaAPI(
+        name="Widget",
+        namespace="Testing",
+        attributes=[
+            AttributeSchemaAPI(id="a1", name="name", kind=AttributeKind.TEXT, unique=True, optional=False),
+            AttributeSchemaAPI(
+                id="a2", name="label", kind=AttributeKind.TEXT, optional=True, default_value=default_value
+            ),
+        ],
+    )
+
+    model = _render_sync_models(tmp_path, node).TestingWidget
+    assert model(name="widget-1").label == default_value

--- a/tests/test_generator_get_kind.py
+++ b/tests/test_generator_get_kind.py
@@ -1,0 +1,108 @@
+"""Tests for infrahub_sync.generator.get_kind.
+
+get_kind() decides the pydantic type annotation for each generated DiffSync
+model field. It must work on whatever object `client.schema.all()` hands back
+-- infrahub-sdk's read-side schema classes (AttributeSchemaAPI /
+RelationshipSchemaAPI) -- not just on the write-side AttributeSchema /
+RelationshipSchema classes used to build schema payloads.
+
+Those two class families are not guaranteed to share a common base: at
+infrahub-sdk 1.18.1 the read-side classes happened to subclass the write-side
+ones, so an `isinstance(item, AttributeSchema)` check worked; at 1.23.0 that
+inheritance was removed, and the check silently stopped matching anything,
+making get_kind() fall through to its "str" default for every attribute and
+relationship (see https://github.com/opsmill/infrahub-sync/issues/187).
+
+`_FakeAttribute`/`_FakeRelationship` below deliberately do NOT inherit from
+either SDK schema family. They exist so this suite fails if get_kind() is
+ever changed back to an isinstance-based check -- regardless of which
+infrahub-sdk version the lockfile happens to resolve at the time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from infrahub_sdk.schema import AttributeSchema, RelationshipSchema
+from infrahub_sdk.schema.main import AttributeKind, AttributeSchemaAPI, RelationshipSchemaAPI
+
+from infrahub_sync.generator import get_kind
+
+
+@dataclass
+class _FakeAttribute:
+    """Duck-types an attribute schema without subclassing any SDK class."""
+
+    kind: str
+    optional: bool = False
+    default_value: Any = None
+
+
+@dataclass
+class _FakeRelationship:
+    """Duck-types a relationship schema without subclassing any SDK class."""
+
+    cardinality: str
+    optional: bool = False
+
+
+def test_fake_schema_objects_do_not_subclass_sdk_schema_classes() -> None:
+    """Pins down the premise the other tests rely on.
+
+    If this starts failing, the fakes below stopped simulating the
+    decoupled-class scenario and no longer guard the regression.
+    """
+    assert not isinstance(_FakeAttribute(kind="Text"), AttributeSchema)
+    assert not isinstance(_FakeRelationship(cardinality="one"), RelationshipSchema)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "expected"),
+    [
+        (_FakeAttribute(kind="Text"), "str"),
+        (_FakeAttribute(kind="Number"), "int"),
+        (_FakeAttribute(kind="Boolean"), "bool"),
+        (_FakeAttribute(kind="SomeUnmappedKind"), "str"),
+        (_FakeAttribute(kind="Text", optional=True), "str | None = None"),
+        (_FakeAttribute(kind="Text", optional=True, default_value="foo"), 'str | None = "foo"'),
+        (_FakeAttribute(kind="Number", optional=True, default_value=5), "int | None = 5"),
+        (_FakeAttribute(kind="Boolean", optional=True, default_value=True), "bool | None = True"),
+    ],
+)
+def test_get_kind_for_attribute_shaped_objects(attribute: _FakeAttribute, expected: str) -> None:
+    assert get_kind(attribute) == expected
+
+
+@pytest.mark.parametrize(
+    ("relationship", "expected"),
+    [
+        (_FakeRelationship(cardinality="one"), "str"),
+        (_FakeRelationship(cardinality="one", optional=True), "str | None = None"),
+        (_FakeRelationship(cardinality="many"), "list[str] = []"),
+        (_FakeRelationship(cardinality="many", optional=True), "list[str] | None = []"),
+    ],
+)
+def test_get_kind_for_relationship_shaped_objects(relationship: _FakeRelationship, expected: str) -> None:
+    assert get_kind(relationship) == expected
+
+
+def test_get_kind_against_real_sdk_read_side_schema_classes() -> None:
+    """Sanity check against the actual classes `client.schema.all()` returns.
+
+    Complements the fakes above with the real infrahub-sdk read-side types,
+    so a shape drift in the SDK itself (a renamed/removed field) is caught
+    here too, not just a reintroduced isinstance check.
+    """
+    optional_attr = AttributeSchemaAPI(id="1", name="description", kind=AttributeKind.TEXT, optional=True)
+    assert get_kind(optional_attr) == "str | None = None"
+
+    required_attr = AttributeSchemaAPI(id="2", name="name", kind=AttributeKind.TEXT, optional=False)
+    assert get_kind(required_attr) == "str"
+
+    many_rel = RelationshipSchemaAPI(id="3", name="tags", peer="BuiltinTag", cardinality="many", optional=True)
+    assert get_kind(many_rel) == "list[str] | None = []"
+
+    one_rel = RelationshipSchemaAPI(id="4", name="status", peer="StatusGeneric", cardinality="one", optional=False)
+    assert get_kind(one_rel) == "str"


### PR DESCRIPTION
Fixes #187.

`get_kind()` decided each generated field's type annotation via
`isinstance(item, AttributeSchema)` / `isinstance(item, RelationshipSchema)`
— the SDK's **write-side** schema classes. But `infrahub-sync generate`
calls `client.schema.all()`, which returns the SDK's **read-side** classes
(`AttributeSchemaAPI` / `RelationshipSchemaAPI`).

At `infrahub-sdk==1.18.1` those read-side classes happened to subclass the
write-side ones, so the isinstance checks passed. At `infrahub-sdk==1.23.0`
that inheritance was removed, so the checks silently failed and `get_kind()`
fell through to its `"str"` default — dropping `optional`/`None`/`list[...]`
handling. In practice, e.g. any optional attribute (like `description`) got
generated as a required `str`, causing pydantic validation errors for any
real-world node where that field is empty/null.

## Fix

Split `get_kind()` into `get_attribute_type_annotation()` and
`get_relationship_type_annotation()`. The template already knows at each
call site whether it's rendering an attribute or a relationship, so the
runtime `hasattr(item, "cardinality")` branch was unnecessary — each
function is now called from the exact place that knows which one applies,
and neither depends on which concrete SDK class it receives.

## Verification

- `162 passed, 3 skipped` (`uv run pytest -q`).
- `uv run invoke lint` clean on touched files.
- Manually verified against a live Infrahub instance with
  `infrahub-sdk==1.23.0` forced: before the fix, an optional `description`
  attribute generated as `"str"`; after, `"str | None = None"`. A `many`
  relationship (`tags`) went from `"str"` to `"list[str] | None = []"`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated model annotations for attributes and relationships.
  * Correctly preserves optional fields, default values, and one-to-many relationships.
  * Ensured string defaults containing quotes, newlines, or backslashes remain valid and unchanged.
  * Improved compatibility with schemas read from the Infrahub API.

* **Tests**
  * Added coverage for generated models, supported attribute types, relationship cardinality, optional values, defaults, and unmapped types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->