### PR TITLE
Add the configuration application service

### DIFF
--- a/docs/docs/reference/durable-product-records.mdx
+++ b/docs/docs/reference/durable-product-records.mdx
@@ -20,14 +20,59 @@ reviewing a saved plan through `diff --from-plan`. The path must be absolute aft
 expansion, an unresolvable `~user` is rejected as invalid configuration, and every stage
 continuing a plan must use the same location.
 
-This is minimum product-projection configuration. It does not register or version a
-configuration package, select a new provider type, or add a release-management API.
+This is minimum product-projection configuration. It does not select a new provider type or
+add a release-management API.
 
 For configured direct `sync`, the immutable review artifact is published after the saved
 plan commits and before the first destination write, in both serial and tiered execution.
 If publication fails, synchronization stops before contacting the destination write
 surface and retains typed failure evidence on a terminal failed ProductRun. A reserved
 artifact remains unavailable until an exact publication retry completes it.
+
+## Configuration registry
+
+The product store holds an append-only registry of declared configuration packages. A
+package is a strict, JSON-native envelope containing declared content only: adapter names,
+settings, and *references* to credentials. It never contains a credential value.
+
+Registration validates before it persists, so an invalid package is refused and no version
+is written. `validate` re-reads a version that is already registered and checks it against
+the adapter declarations installed *now* — which is why a package accepted at registration
+can report findings later, after an adapter's declared setting surface changes.
+
+A package carrying several independent defects yields one finding per defect, not just the
+first. Each finding carries a stable machine-readable `code`, an `error` severity, a JSON
+Pointer `location` into the declared package, and a message.
+
+### Finding codes
+
+The `code` is the stable part of a finding. The message wording and the printed layout may
+change; the code will not. Fifteen codes are emitted. One location can report more than one
+of them — a credential declaration naming an uninstalled provider *and* an invalid identifier
+reports both at `/credentials/<name>` — but only ever from one check: when two checks reach
+the same pointer, the first to judge it is the one that reports.
+
+| Code | What it means | Where it points |
+| ---- | ------------- | --------------- |
+| `adapter-role-mismatch` | The adapter named for this role cannot serve it — most often a source-only adapter declared as the destination. | `/configuration/source` or `/configuration/destination` |
+| `adapter-validator-finding` | The adapter's own configuration check failed, or handed back something unusable. Nothing the adapter said is carried into the message, so read the adapter's own findings for detail. | `/configuration/<role>` |
+| `credential-path-not-declared` | A `$credential` reference sits somewhere that does not accept one. Usually a misspelled setting name, or a reference placed in `schema_mapping` or `order`. | the referencing node |
+| `endpoint-not-absolute` | A `url` or `base_url` setting is not an absolute `http` or `https` URL. | the setting |
+| `endpoint-not-relative` | An `api_endpoint` or `endpoint` setting carries a scheme or a host. It names a path beneath the absolute URL, not a second address. | the setting |
+| `finding-limit-reached` | The package carries more than 256 defects and the rest were not reported. It is reported first, not last, and it is counted as a finding: when it fires the reported set holds 257 items, not 256. | the whole package |
+| `inline-credential-value` | A credential-bearing setting holds a literal value instead of a `{"$credential": "<name>"}` reference. A package never contains a credential value. | the setting |
+| `malformed-credential-reference` | A credential declaration's environment identifier is not a valid variable name, or a `$credential` node carries keys beyond the reference itself. | the declaration or the node |
+| `missing-adapter` | No adapter is installed under the declared name — check the spelling and the case. That role's settings are not judged at all, because there is no declared surface to judge them against, so expect exactly one finding for the role. | `/configuration/<role>` |
+| `missing-store-capabilities` | The declared store `type` is unknown and carries settings. An unknown store type with no settings declares nothing unsafe and is accepted. | `/configuration/store` |
+| `setting-contains-credential-material` | An endpoint setting carries user information, a query string, or a fragment. Credentials belong in a reference, not in a URL. | the setting |
+| `setting-not-a-string` | An endpoint setting is declared as something other than a string. | the setting |
+| `undeclared-setting` | The adapter or store does not declare that setting name. One finding per name, each at its own pointer. | the setting |
+| `unknown-credential-provider` | A credential declaration names a provider that is not installed. `env` is the installed provider. | `/credentials/<name>` |
+| `unknown-credential-reference` | A `$credential` names a reference the package's own `credentials` block does not declare. | the referencing setting |
+
+An adapter's own configuration check keeps its own codes, which are outside this set —
+`unsafe-rest-request-endpoint` is the one shipped today. Two families are not emitted yet:
+destination schema mismatch, and unsupported destination write behavior.
 
 ## Provider profiles
 

--- a/docs/docs/reference/durable-product-records.mdx
+++ b/docs/docs/reference/durable-product-records.mdx
@@ -41,16 +41,21 @@ the adapter declarations installed *now* — which is why a package accepted at 
 can report findings later, after an adapter's declared setting surface changes.
 
 A package carrying several independent defects yields one finding per defect, not just the
-first. Each finding carries a stable machine-readable `code`, an `error` severity, a JSON
-Pointer `location` into the declared package, and a message.
+first. Each finding carries a stable machine-readable `code`, a severity of `error` or
+`warning`, a JSON Pointer `location` into the declared package, and a message. An `error`
+prevents execution; a `warning` records declared intent or a qualification gap and does
+not.
 
 ### Finding codes
 
 The `code` is the stable part of a finding. The message wording and the printed layout may
-change; the code will not. Fifteen codes are emitted. One location can report more than one
-of them — a credential declaration naming an uninstalled provider *and* an invalid identifier
-reports both at `/credentials/<name>` — but only ever from one check: when two checks reach
-the same pointer, the first to judge it is the one that reports.
+change; the code will not. Three enumerations are emitted: the declared-content core's
+fifteen error codes below, the four destination-schema codes (emitted only when `validate`
+is given an explicit destination-schema opt-in), and the three warning-channel codes. One
+location can report more than one of them — a credential declaration naming an uninstalled
+provider *and* an invalid identifier reports both at `/credentials/<name>` — but only ever
+from one check: when two checks reach the same pointer, the first to judge it is the one
+that reports.
 
 | Code | What it means | Where it points |
 | ---- | ------------- | --------------- |
@@ -71,8 +76,32 @@ the same pointer, the first to judge it is the one that reports.
 | `unknown-credential-reference` | A `$credential` names a reference the package's own `credentials` block does not declare. | the referencing setting |
 
 An adapter's own configuration check keeps its own codes, which are outside this set —
-`unsafe-rest-request-endpoint` is the one shipped today. Two families are not emitted yet:
-destination schema mismatch, and unsupported destination write behavior.
+`unsafe-rest-request-endpoint` is the one shipped today.
+
+#### Destination schema validation codes
+
+These four codes are emitted **only on the explicit opt-in**: `validate` given a
+destination-schema options object. The default `validate` path judges declared content
+only, performs no schema read and no network I/O, and never emits them. All four carry an
+`error` severity.
+
+| Code | What it means | Where it points |
+| ---- | ------------- | --------------- |
+| `destination-schema-mismatch` | A declared schema mapping disagrees with the destination's schema snapshot: an undeclared kind, a field that is neither an attribute nor a relationship, a relationship reference on an attribute, or a static value whose shape disagrees with the relationship's cardinality. | the mapping entry, field, reference, or static value |
+| `destination-schema-read-failed` | The destination schema could not be read: a timeout, refused credentials, an unreachable server, a rejected or unusable response, an unresolvable declared token, or unusable declared client settings. The message names the failure class. | `/configuration/destination` |
+| `destination-schema-validation-unsupported` | Schema validation was explicitly requested against a destination adapter that does not declare it. A missing capability needed to determine safety is an error, not a warning. | `/configuration/destination` |
+| `unsupported-destination-write` | The configuration requests destination write operations the destination adapter does not declare support for. | `/configuration/destination` |
+
+#### Warning-channel codes
+
+The warning channel is closed: warnings are limited to intentional omissions and
+explicitly unqualified optional features, and nothing else.
+
+| Code | Severity | What it means | Where it points |
+| ---- | -------- | ------------- | --------------- |
+| `intentional-omission` | `warning` | An `omissions` entry declares that destination content is intentionally not synchronized. The declared reason, when present, is carried verbatim. | `/omissions/<index>` |
+| `omission-contradicts-mapping` | `error` | An omission names content a schema mapping also maps. A contradictory declaration is a package defect, not a preference; the error replaces the warning at that location. | `/omissions/<index>` |
+| `optional-feature-unqualified` | `warning` | The optional `incremental` feature is declared against a source adapter whose capability declaration does not qualify it, so extraction silently runs full. | `/configuration/incremental` |
 
 ## Provider profiles
 

--- a/infrahub_sync/__init__.py
+++ b/infrahub_sync/__init__.py
@@ -170,6 +170,30 @@ def resolve_effective_diffsync_flags(
     return flags
 
 
+def requested_destination_write_operations(
+    configured_flags: Iterable[str | DiffSyncFlags] | None,
+) -> frozenset[str]:
+    """Derive the destination write operations one configuration requests.
+
+    The operations-level sibling of :func:`resolve_effective_diffsync_flags`: the
+    effective flags come from that one shared rule, so ``SKIP_UNMATCHED_DST`` is
+    invariant and ``"delete"`` is never requested under the supported live-sync
+    profile. ``"update"`` is always requested for matched objects, and
+    ``"create"`` only while ``SKIP_UNMATCHED_SRC`` is not in effect. Consumers
+    (the destination write-operations capability check) import this symbol
+    rather than testing ``DiffSyncFlags`` bits themselves.
+
+    Raises ``KeyError`` for a flag name that ``DiffSyncFlags`` does not define.
+    """
+    effective = resolve_effective_diffsync_flags(configured_flags)
+    requested = {"update"}
+    if not effective & DiffSyncFlags.SKIP_UNMATCHED_SRC:
+        requested.add("create")
+    if not effective & DiffSyncFlags.SKIP_UNMATCHED_DST:
+        requested.add("delete")
+    return frozenset(requested)
+
+
 def is_ip_within_filter(ip: str, ip_compare: Union[str, list[str]]) -> bool:
     """Check if an IP address is within a given subnet."""
     return netutils_is_ip_within(ip=ip, ip_compare=ip_compare)

--- a/infrahub_sync/__init__.py
+++ b/infrahub_sync/__init__.py
@@ -149,6 +149,27 @@ class SyncInstance(SyncConfig):
     directory: str
 
 
+def resolve_effective_diffsync_flags(
+    configured_flags: Iterable[str | DiffSyncFlags] | None,
+) -> DiffSyncFlags:
+    """Resolve the effective DiffSync flags for the supported live-sync profile.
+
+    The SYNC-78 rule: ``SKIP_UNMATCHED_DST`` is invariant — a destination-only
+    object is never turned into a delete action, no matter which unrelated flags
+    are configured. Configured flags are OR-combined on top of that invariant,
+    so no flags resolve to ``SKIP_UNMATCHED_DST`` alone and a set that already
+    contains it is unchanged. This is the one place that interprets flag
+    aggregation; consumers (the sync engine, the destination write-operations
+    capability check) call it rather than re-deriving the rule.
+
+    Raises ``KeyError`` for a flag name that ``DiffSyncFlags`` does not define.
+    """
+    flags = DiffSyncFlags.SKIP_UNMATCHED_DST
+    for flag in configured_flags or []:
+        flags |= flag if isinstance(flag, DiffSyncFlags) else DiffSyncFlags[flag]
+    return flags
+
+
 def is_ip_within_filter(ip: str, ip_compare: Union[str, list[str]]) -> bool:
     """Check if an IP address is within a given subnet."""
     return netutils_is_ip_within(ip=ip, ip_compare=ip_compare)

--- a/infrahub_sync/api/v1/_models.py
+++ b/infrahub_sync/api/v1/_models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import (
@@ -17,6 +16,8 @@ from pydantic import (
 )
 
 from infrahub_sync.execution import collect_secret_values, redact
+from infrahub_sync.product_store.configs import is_closed_vocabulary_field
+from infrahub_sync.product_store.standalone import resolve_product_cache_location
 
 API_VERSION: Literal["1"] = "1"
 Operation = Literal["plan", "sync", "verify", "apply"]
@@ -70,14 +71,13 @@ class _Request(BaseModel):
     @field_validator("product_cache_location")
     @classmethod
     def _require_absolute_product_cache(cls, value: str | None) -> str | None:
-        try:
-            expanded = None if value is None else Path(value).expanduser()
-        except RuntimeError:
-            msg = "product_cache_location has an unresolvable user home"
-            raise ValueError(msg) from None
-        if expanded is not None and not expanded.is_absolute():
-            msg = "product_cache_location must be absolute after user expansion"
-            raise ValueError(msg)
+        """Apply the one shared product-cache-location rule (envelope OES-21).
+
+        ``None`` stays legal here and means the legacy cache-only behavior. Only the
+        absoluteness half of the rule is shared with the registry, which has no fallback.
+        """
+        if value is not None:
+            resolve_product_cache_location(value)
         return value
 
 
@@ -144,16 +144,43 @@ class LifecycleEvent(BaseModel):
     outcome: str = Field(min_length=1)
 
 
-class RunResult(BaseModel):
+class _RedactedResult(BaseModel):
+    """Forward-tolerant result that removes current credential values at both boundaries.
+
+    Redaction happens once on the way in, so no public attribute is ever built from an
+    unredacted value, and once on the way out, so a serializer sees values collected after
+    the model was built.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+    api_version: Literal["1"] = API_VERSION
+
+    @model_validator(mode="before")
+    @classmethod
+    def _redact_current_values(cls, data: Any) -> Any:
+        """Remove current process credentials before public attributes are built."""
+        return cls._redacted(data, collect_secret_values())
+
+    @model_serializer(mode="wrap")
+    def _serialize_redacted(self, handler: SerializerFunctionWrapHandler) -> Any:
+        """Redact credential values from every serialized result field."""
+        return type(self)._redacted(handler(self), collect_secret_values())
+
+    @classmethod
+    def _redacted(cls, data: Any, secrets: Sequence[str]) -> Any:
+        """Redact one result's data. Both boundaries go through here, so a result that owns
+        fields redaction must treat differently overrides this once and gets both."""
+        return _redact_data(data, secrets)
+
+
+class RunResult(_RedactedResult):
     """Stable success result shared by every local product operation.
 
     ``phase`` and ``outcome`` are forward-tolerant strings. The operation
     vocabulary is closed to the four product operations supported by API v1.
     """
 
-    model_config = ConfigDict(extra="allow", frozen=True)
-
-    api_version: Literal["1"] = API_VERSION
     run_id: str = Field(min_length=1)
     operation: Operation
     phase: str = Field(min_length=1)
@@ -162,21 +189,10 @@ class RunResult(BaseModel):
     domain_summary: dict[str, int]
     artifacts: tuple[ArtifactReference, ...]
 
-    @model_validator(mode="before")
-    @classmethod
-    def _redact_current_values(cls, data: Any) -> Any:
-        """Remove current process credentials before public attributes are built."""
-        return _redact_data(data, collect_secret_values())
-
     def _with_secret_values(self, values: Sequence[str]) -> RunResult:
         """Return a result whose public fields contain no boundary credentials."""
         secrets = _merged_secrets(values)
         return type(self).model_validate(_redact_data(self.model_dump(), secrets))
-
-    @model_serializer(mode="wrap")
-    def _serialize_redacted(self, handler: SerializerFunctionWrapHandler) -> Any:
-        """Redact credential values from every serialized result field."""
-        return _redact_data(handler(self), collect_secret_values())
 
 
 class RunError(Exception):
@@ -201,8 +217,15 @@ class RunError(Exception):
         super().__init__(self.message)
 
     def model_dump(self) -> dict[str, str | None]:
-        """Serialize the structured public error with current redaction values."""
-        data = {
+        """Serialize the structured public error with current redaction values.
+
+        Field by field, because a whole-object pass cannot tell a closed vocabulary apart from
+        caller data: ``operation`` is the four-operation literal and ``outcome`` is always
+        "failed", so an environment holding a collected value equal to either turned the dump
+        into "***" while the attribute beside it still read the real token. Which names are
+        exempt is the service's one rule, read from there rather than listed again here.
+        """
+        data: dict[str, str | None] = {
             "api_version": self.api_version,
             "run_id": self.run_id,
             "operation": self.operation,
@@ -210,7 +233,11 @@ class RunError(Exception):
             "outcome": self.outcome,
             "message": self.message,
         }
-        return _redact_data(data, collect_secret_values())
+        secrets = collect_secret_values()
+        return {
+            field: value if value is None or is_closed_vocabulary_field(field) else redact(value, secrets)
+            for field, value in data.items()
+        }
 
 
 class RunValidationError(RunError):

--- a/infrahub_sync/cli.py
+++ b/infrahub_sync/cli.py
@@ -28,6 +28,7 @@ from infrahub_sync.plan.errors import (
     UnknownPlanKindError,
     UnsafeRunIdentifierError,
 )
+from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store.standalone import StandaloneProductRecordError, execute_standalone
 from infrahub_sync.utils import (
     PlanApplier,
@@ -93,8 +94,15 @@ def main(
 
 
 def print_error_and_abort(message: str, sync_instance: SyncInstance | None = None) -> NoReturn:
-    """Log one operator-facing refusal after redacting resolved credentials."""
-    logger.error("%s", redact(message, collect_secret_values(sync_instance)))
+    """Log one operator-facing refusal after redacting resolved credentials.
+
+    Through the service's free-text rule, which is escape-aware. A refusal is text the core
+    built, and a ``configs`` refusal carries ``str(CredentialConfigurationError)`` — a declared
+    key already escaped by the same function a pointer is escaped by. A plain match therefore
+    logged, on the line above the rendered findings, the credential those findings had just
+    redacted.
+    """
+    logger.error("%s", configs_service.redact_message(message, collect_secret_values(sync_instance)))
     raise typer.Abort
 
 

--- a/infrahub_sync/configuration/__init__.py
+++ b/infrahub_sync/configuration/__init__.py
@@ -15,7 +15,6 @@ from .credentials import (
     EnvironmentCredentialProvider,
     provider_for,
     resolve_reference,
-    validate_package_credentials,
 )
 from .models import (
     ConfigurationPackage,
@@ -27,6 +26,7 @@ from .models import (
     parse_configuration_package,
     sort_findings,
 )
+from .validation import collect_findings, validate_package_credentials
 
 __all__ = [
     "BUILTIN_ADAPTER_CAPABILITIES",
@@ -44,6 +44,7 @@ __all__ = [
     "UnknownAdapterCapabilitiesError",
     "ValidationFinding",
     "WriteOperation",
+    "collect_findings",
     "get_adapter_capabilities",
     "parse_configuration_package",
     "provider_for",

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -275,20 +275,23 @@ def _normalized_schema_snapshot(schema: object) -> Mapping[str, Any]:
     if not isinstance(schema, Mapping):
         msg = f"destination returned an unusable schema response: {type(schema).__name__}"
         raise DestinationSchemaReadError(msg, reason="rejected")
+    snapshot: dict[str, Any] = {}
     try:
-        return {
-            kind: {
+        for kind, node in schema.items():
+            if not isinstance(kind, str):
+                msg = f"destination returned an unusable schema member: {type(kind).__name__}"
+                raise DestinationSchemaReadError(msg, reason="rejected")
+            snapshot[kind] = {
                 "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
                 "relationships": {
                     relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
                     for relationship in getattr(node, "relationships", ()) or ()
                 },
             }
-            for kind, node in schema.items()
-        }
     except (AttributeError, TypeError) as exc:
         msg = f"destination returned an unusable schema member: {type(exc).__name__}"
         raise DestinationSchemaReadError(msg, reason="rejected") from None
+    return snapshot
 
 
 BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlsplit
 
 from .models import ConfigurationPackage, ValidationFinding
@@ -14,6 +14,12 @@ from .models import ConfigurationPackage, ValidationFinding
 AdapterRole = Literal["source", "destination"]
 WriteOperation = Literal["create", "update", "delete"]
 ConfigurationValidator = Callable[[ConfigurationPackage, AdapterRole], Sequence[ValidationFinding]]
+# The destination-schema accessor contract: (package, branch) -> one JSON-native schema
+# snapshot, mapping each kind name to its attributes (name -> attribute kind) and
+# relationships (name -> {"peer", "cardinality"}). Raises DestinationSchemaReadError and
+# nothing else for a read that fails; performs I/O only when called, never at import.
+DestinationSchemaAccessor = Callable[[ConfigurationPackage, str], Mapping[str, Any]]
+_SCHEMA_READ_REASON = re.compile(r"^[a-z]{1,32}$")
 _ADAPTER_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
 _ADAPTER_ROLES: frozenset[AdapterRole] = frozenset({"source", "destination"})
 _WRITE_OPERATIONS: frozenset[WriteOperation] = frozenset({"create", "update", "delete"})
@@ -21,6 +27,23 @@ _SETTING_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
 # A declared path component must survive pointer rendering unchanged, so the pointer built
 # from the declaration and the pointer built while walking a package cannot disagree.
 _MAX_SETTING_PATH_COMPONENT_LENGTH = 64
+
+
+class DestinationSchemaReadError(Exception):
+    """An accessor could not read the destination schema, classified by ``reason``.
+
+    ``reason`` is a short lowercase word naming the failure class ("timeout",
+    "unauthorized", "unreachable", ...) and is validated here so the finding a
+    failed read becomes can carry it verbatim. The message follows the module's
+    own rule for refusal text: exception type names, never third-party content.
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        if _SCHEMA_READ_REASON.fullmatch(reason) is None:
+            msg = f"schema read failure reason {reason!r} is not a short lowercase word"
+            raise ValueError(msg)
+        super().__init__(message)
+        self.reason = reason
 
 
 def is_renderable_setting_path(path: str) -> bool:
@@ -43,6 +66,7 @@ class AdapterConfigurationCapabilities:
     credential_setting_paths: tuple[str, ...] = ()
     supported_destination_write_operations: frozenset[WriteOperation] = frozenset()
     destination_schema_validation: bool = False
+    destination_schema_accessor: DestinationSchemaAccessor | None = None
     validator: ConfigurationValidator | None = None
     contract_version: Literal[1] = 1
 
@@ -75,6 +99,14 @@ class AdapterConfigurationCapabilities:
             raise ValueError(msg)
         if "destination" not in roles and write_operations:
             msg = f"source-only adapter {self.adapter_name!r} cannot declare destination writes"
+            raise ValueError(msg)
+        if self.destination_schema_validation != (self.destination_schema_accessor is not None):
+            # The declaration and the accessor are one fact: declaring schema validation
+            # without a working accessor — or the reverse — is a registration-time error.
+            msg = (
+                f"adapter {self.adapter_name!r} must declare destination schema validation "
+                "together with its schema accessor"
+            )
             raise ValueError(msg)
         if len(credential_setting_paths) != len(set(credential_setting_paths)):
             msg = f"adapter {self.adapter_name!r} contains duplicate credential paths"
@@ -146,6 +178,77 @@ def _validate_relative_rest_mapping_endpoints(
     return tuple(findings)
 
 
+def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+    """Read one destination schema snapshot from a live Infrahub server.
+
+    The bundled accessor behind ``infrahub``'s schema-validation declaration. Only the
+    explicit validation opt-in calls it, so resolving the *declared* token credential
+    reference here is the sanctioned read (contract section 4); the branch arrives already
+    resolved from the declared setting and nothing ambient is consulted for it. Every
+    failure is classified into :class:`DestinationSchemaReadError` — the accessor contract
+    the schema checks handle — carrying exception type names, never third-party content.
+    """
+    # Imported here, not at module load: this module stays connection-free to import, and
+    # the default validate path never touches a network client (envelope AR7).
+    import httpx
+    from infrahub_sdk import Config, InfrahubClientSync
+    from infrahub_sdk.exceptions import (
+        AuthenticationError,
+        ServerNotReachableError,
+        ServerNotResponsiveError,
+    )
+
+    from .credentials import CredentialConfigurationError, resolve_reference
+
+    settings = package.configuration.destination.settings or {}
+    url = settings.get("url")
+    if not isinstance(url, str) or not url:
+        msg = "destination setting 'url' is required to read the destination schema"
+        raise DestinationSchemaReadError(msg, reason="unconfigured")
+    sdk_config: dict[str, Any] = {"timeout": 60, "default_branch": branch}
+    token = settings.get("token")
+    if isinstance(token, Mapping):
+        reference_name = token.get("$credential")
+        if isinstance(reference_name, str):
+            try:
+                sdk_config["api_token"] = resolve_reference(package, reference_name)
+            except CredentialConfigurationError as exc:
+                msg = f"destination token credential could not be resolved: {type(exc).__name__}"
+                raise DestinationSchemaReadError(msg, reason="credentials") from None
+    verify_ssl = settings.get("verify_ssl")
+    if verify_ssl is not None:
+        sdk_config["tls_insecure"] = not verify_ssl
+    try:
+        client = InfrahubClientSync(address=url, config=Config(**sdk_config))
+        schema = client.schema.all(branch=branch)
+    except (httpx.TimeoutException, ServerNotResponsiveError) as exc:
+        msg = f"destination schema read timed out: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="timeout") from None
+    except AuthenticationError as exc:
+        msg = f"destination refused the schema read credentials: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="unauthorized") from None
+    except httpx.HTTPStatusError as exc:
+        unauthorized = exc.response.status_code in {401, 403}
+        reason = "unauthorized" if unauthorized else "unreachable"
+        msg = f"destination refused the schema read: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason=reason) from None
+    except (httpx.TransportError, ServerNotReachableError) as exc:
+        msg = f"destination server could not be reached: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="unreachable") from None
+    return {
+        kind: {
+            "attributes": {
+                attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()
+            },
+            "relationships": {
+                relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
+                for relationship in getattr(node, "relationships", ()) or ()
+            },
+        }
+        for kind, node in schema.items()
+    }
+
+
 BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(
     {
         "aci": AdapterConfigurationCapabilities(
@@ -168,6 +271,7 @@ BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(
             credential_setting_paths=("token",),
             supported_destination_write_operations=_CREATE_UPDATE,
             destination_schema_validation=True,
+            destination_schema_accessor=_read_infrahub_destination_schema,
         ),
         "ipfabricsync": AdapterConfigurationCapabilities(
             adapter_name="ipfabricsync",

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -263,35 +263,69 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
 
 
 def _normalized_schema_snapshot(schema: object) -> Mapping[str, Any]:
-    """Normalize one client schema response inside the typed failure boundary.
+    """Normalize one client schema response inside one total typed boundary.
 
-    A response the client call accepted but that is not a usable schema — ``None`` or any
-    other non-mapping root, or a member whose nodes do not carry the attribute and
-    relationship shape the SDK contract promises — is still a read the destination
-    rejected. Classifying it here keeps the accessor contract total: a malformed response
-    becomes the typed ``destination-schema-read-failed`` finding rather than escaping as an
-    untyped ``AttributeError`` the service boundary can only report as internal.
+    A response the client call accepted but that is not a usable schema is still a read
+    the destination rejected. The entire normalization — the root check, iterating the
+    members, reading their attribute and relationship shapes, and validating the built
+    snapshot — runs under one rule: any ordinary ``Exception`` it raises (``items()``
+    raising, a raising attribute property, raising iteration — whatever a third-party
+    response can do) becomes the typed :class:`DestinationSchemaReadError` carrying the
+    exception type name only, never third-party exception text, so nothing escapes as an
+    untyped error the service boundary can only report as internal. ``BaseException``
+    still propagates, and an inner ``DestinationSchemaReadError`` passes through untouched.
     """
+    try:
+        return _build_schema_snapshot(schema)
+    except DestinationSchemaReadError:
+        raise
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # The totality rule: re-raised typed, type name only.
+        msg = f"destination returned an unusable schema response: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="rejected") from None
+
+
+def _build_schema_snapshot(schema: object) -> dict[str, Any]:
+    """Build the snapshot from a third-party response, inside the boundary above."""
     if not isinstance(schema, Mapping):
         msg = f"destination returned an unusable schema response: {type(schema).__name__}"
         raise DestinationSchemaReadError(msg, reason="rejected")
     snapshot: dict[str, Any] = {}
-    try:
-        for kind, node in schema.items():
-            if not isinstance(kind, str):
-                msg = f"destination returned an unusable schema member: {type(kind).__name__}"
-                raise DestinationSchemaReadError(msg, reason="rejected")
-            snapshot[kind] = {
-                "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
-                "relationships": {
-                    relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
-                    for relationship in getattr(node, "relationships", ()) or ()
-                },
-            }
-    except (AttributeError, TypeError) as exc:
-        msg = f"destination returned an unusable schema member: {type(exc).__name__}"
-        raise DestinationSchemaReadError(msg, reason="rejected") from None
+    for kind, node in schema.items():
+        if not isinstance(kind, str):
+            msg = f"destination returned an unusable schema member: {type(kind).__name__}"
+            raise DestinationSchemaReadError(msg, reason="rejected")
+        snapshot[kind] = {
+            "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
+            "relationships": {
+                relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
+                for relationship in getattr(node, "relationships", ()) or ()
+            },
+        }
+    _require_usable_snapshot(snapshot)
     return snapshot
+
+
+def _require_usable_snapshot(snapshot: Mapping[str, Any]) -> None:
+    """Refuse a built snapshot that is not the string shape the schema checks consume.
+
+    The last step inside the normalization boundary: the members were read without
+    raising and every kind is already a string, but the snapshot is usable only when
+    every attribute name and kind, relationship name, peer, and cardinality is a string
+    too — the shape the SDK contract promises and ``compute_schema_subhash`` and the
+    content checks rely on.
+    """
+    for entry in snapshot.values():
+        attributes: dict[str, Any] = entry["attributes"]
+        relationships: dict[str, Any] = entry["relationships"]
+        usable = all(isinstance(name, str) and isinstance(value, str) for name, value in attributes.items()) and all(
+            isinstance(name, str)
+            and isinstance(relationship["peer"], str)
+            and isinstance(relationship["cardinality"], str)
+            for name, relationship in relationships.items()
+        )
+        if not usable:
+            msg = "destination returned an unusable schema member shape"
+            raise DestinationSchemaReadError(msg, reason="rejected")
 
 
 BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -53,6 +53,11 @@ class AdapterConfigurationCapabilities:
     supported_destination_write_operations: frozenset[WriteOperation] = frozenset()
     destination_schema_validation: bool = False
     destination_schema_accessor: DestinationSchemaAccessor | None = None
+    # Whether this adapter implements incremental extraction (the cursor_tier_for /
+    # list_changed_since overrides). A package declaring `incremental:` against a source
+    # that does not is warned about the unqualified optional feature; the conformance
+    # tests hold this flag to the runtime overrides so it cannot drift.
+    incremental_extraction: bool = False
     validator: ConfigurationValidator | None = None
     contract_version: Literal[1] = 1
 
@@ -288,6 +293,7 @@ BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(
             supported_destination_write_operations=_CREATE_UPDATE,
             destination_schema_validation=True,
             destination_schema_accessor=_read_infrahub_destination_schema,
+            incremental_extraction=True,
         ),
         "ipfabricsync": AdapterConfigurationCapabilities(
             adapter_name="ipfabricsync",
@@ -300,12 +306,14 @@ BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(
             roles=_SOURCE_ONLY,
             allowed_settings=frozenset({"token", "url", "verify_ssl"}),
             credential_setting_paths=("token",),
+            incremental_extraction=True,
         ),
         "netbox": AdapterConfigurationCapabilities(
             adapter_name="netbox",
             roles=_SOURCE_ONLY,
             allowed_settings=frozenset({"token", "url", "verify_ssl"}),
             credential_setting_paths=("token",),
+            incremental_extraction=True,
         ),
         "peeringmanager": AdapterConfigurationCapabilities(
             adapter_name="peeringmanager",

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -164,30 +164,17 @@ def _validate_relative_rest_mapping_endpoints(
     return tuple(findings)
 
 
-def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
-    """Read one destination schema snapshot from a live Infrahub server.
+def _resolved_client_settings(package: ConfigurationPackage, branch: str) -> tuple[str, dict[str, Any]]:
+    """Resolve the declared destination settings one schema read needs.
 
-    The bundled accessor behind ``infrahub``'s schema-validation declaration. Only the
-    explicit validation opt-in calls it, so resolving the *declared* token credential
-    reference here is the sanctioned read (contract section 4); the branch arrives already
-    resolved from the declared setting and nothing ambient is consulted for it. Every
-    failure is classified into :class:`DestinationSchemaReadError` — the accessor contract
-    the schema checks handle — carrying exception type names, never third-party content.
+    Returns the declared url and the SDK configuration built from the declared settings,
+    refusing — as :class:`DestinationSchemaReadError` — a missing url and a declared token
+    credential that does not resolve.
     """
-    # Imported here, not at module load: this module stays connection-free to import, and
-    # the default validate path never touches a network client (envelope AR7).
-    # pylint: disable=import-outside-toplevel
-    import httpx
-    from infrahub_sdk import Config, InfrahubClientSync
-    from infrahub_sdk.exceptions import (
-        AuthenticationError,
-        ServerNotReachableError,
-        ServerNotResponsiveError,
-    )
-
+    # Imported here, not at module load, for the same reason as the client imports below.
+    # pylint: disable-next=import-outside-toplevel
     from .credentials import CredentialConfigurationError, resolve_reference
 
-    # pylint: enable=import-outside-toplevel
     settings = package.configuration.destination.settings or {}
     url = settings.get("url")
     if not isinstance(url, str) or not url:
@@ -206,6 +193,38 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     verify_ssl = settings.get("verify_ssl")
     if verify_ssl is not None:
         sdk_config["tls_insecure"] = not verify_ssl
+    return url, sdk_config
+
+
+def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+    """Read one destination schema snapshot from a live Infrahub server.
+
+    The bundled accessor behind ``infrahub``'s schema-validation declaration. Only the
+    explicit validation opt-in calls it, so resolving the *declared* token credential
+    reference here is the sanctioned read (contract section 4); the branch arrives already
+    resolved from the declared setting and nothing ambient is consulted for it. Every
+    SDK-raised error (``infrahub_sdk.exceptions.Error`` and its subclasses), every HTTP
+    transport or status failure, an unresolvable declared credential, and a declared
+    client configuration the SDK refuses (``ValueError``, including pydantic's validation
+    error) is classified into :class:`DestinationSchemaReadError` — the accessor contract
+    the schema checks handle — carrying exception type names, never third-party content.
+    """
+    # Imported here, not at module load: this module stays connection-free to import, and
+    # the default validate path never touches a network client (envelope AR7).
+    # pylint: disable=import-outside-toplevel
+    import httpx
+    from infrahub_sdk import Config, InfrahubClientSync
+    from infrahub_sdk.exceptions import (
+        AuthenticationError,
+        ServerNotReachableError,
+        ServerNotResponsiveError,
+    )
+    from infrahub_sdk.exceptions import (
+        Error as InfrahubSdkError,
+    )
+
+    # pylint: enable=import-outside-toplevel
+    url, sdk_config = _resolved_client_settings(package, branch)
     try:
         client = InfrahubClientSync(address=url, config=Config(**sdk_config))
         schema = client.schema.all(branch=branch)
@@ -223,6 +242,17 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     except (httpx.TransportError, ServerNotReachableError) as exc:
         msg = f"destination server could not be reached: {type(exc).__name__}"
         raise DestinationSchemaReadError(msg, reason="unreachable") from None
+    except InfrahubSdkError as exc:
+        # The SDK's own base error: everything it raises that the arms above did not
+        # classify (a missing branch, a GraphQL refusal, undecodable content) is still a
+        # read the destination rejected, never an untyped escape (review F1).
+        msg = f"destination rejected the schema read: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="rejected") from None
+    except ValueError as exc:
+        # Config(**sdk_config) refusing the declared settings: pydantic's ValidationError
+        # subclasses ValueError, so both land here as one unusable-configuration class.
+        msg = f"destination client could not be configured from the declared settings: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="unconfigured") from None
     return {
         kind: {
             "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -209,9 +209,10 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     reference here is the sanctioned read (contract section 4); the branch arrives already
     resolved from the declared setting and nothing ambient is consulted for it. Every
     SDK-raised error (``infrahub_sdk.exceptions.Error`` and its subclasses), every HTTP
-    transport or status failure, an unresolvable declared credential, and a declared
+    transport or status failure, an unresolvable declared credential, a declared
     client configuration the SDK refuses (``ValueError``, including pydantic's validation
-    error) is classified into :class:`DestinationSchemaReadError` — the accessor contract
+    error), and a response the call accepted but that cannot be normalized into a schema
+    snapshot is classified into :class:`DestinationSchemaReadError` — the accessor contract
     the schema checks handle — carrying exception type names, never third-party content.
     """
     # Imported here, not at module load: this module stays connection-free to import, and
@@ -258,16 +259,36 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
         # subclasses ValueError, so both land here as one unusable-configuration class.
         msg = f"destination client could not be configured from the declared settings: {type(exc).__name__}"
         raise DestinationSchemaReadError(msg, reason="unconfigured") from None
-    return {
-        kind: {
-            "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
-            "relationships": {
-                relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
-                for relationship in getattr(node, "relationships", ()) or ()
-            },
+    return _normalized_schema_snapshot(schema)
+
+
+def _normalized_schema_snapshot(schema: object) -> Mapping[str, Any]:
+    """Normalize one client schema response inside the typed failure boundary.
+
+    A response the client call accepted but that is not a usable schema — ``None`` or any
+    other non-mapping root, or a member whose nodes do not carry the attribute and
+    relationship shape the SDK contract promises — is still a read the destination
+    rejected. Classifying it here keeps the accessor contract total: a malformed response
+    becomes the typed ``destination-schema-read-failed`` finding rather than escaping as an
+    untyped ``AttributeError`` the service boundary can only report as internal.
+    """
+    if not isinstance(schema, Mapping):
+        msg = f"destination returned an unusable schema response: {type(schema).__name__}"
+        raise DestinationSchemaReadError(msg, reason="rejected")
+    try:
+        return {
+            kind: {
+                "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
+                "relationships": {
+                    relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
+                    for relationship in getattr(node, "relationships", ()) or ()
+                },
+            }
+            for kind, node in schema.items()
         }
-        for kind, node in schema.items()
-    }
+    except (AttributeError, TypeError) as exc:
+        msg = f"destination returned an unusable schema member: {type(exc).__name__}"
+        raise DestinationSchemaReadError(msg, reason="rejected") from None
 
 
 BUILTIN_ADAPTER_CAPABILITIES = MappingProxyType(

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -213,7 +213,9 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     client configuration the SDK refuses (``ValueError``, including pydantic's validation
     error), and a response the call accepted but that cannot be normalized into a schema
     snapshot is classified into :class:`DestinationSchemaReadError` — the accessor contract
-    the schema checks handle — carrying exception type names, never third-party content.
+    the schema checks handle. The SDK-call arms carry exception type names, never
+    third-party content; a normalization failure carries one fixed message
+    (:func:`_normalized_schema_snapshot`).
     """
     # Imported here, not at module load: this module stays connection-free to import, and
     # the default validate path never touches a network client (envelope AR7).
@@ -262,6 +264,12 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     return _normalized_schema_snapshot(schema)
 
 
+# The one message every normalization failure carries. Fixed, so a hostile response puts
+# nothing into it: not an exception type name — a metaclass executes on that read — and
+# never third-party exception text.
+_UNUSABLE_SCHEMA_RESPONSE = "destination returned an unusable schema response"
+
+
 def _normalized_schema_snapshot(schema: object) -> Mapping[str, Any]:
     """Normalize one client schema response inside one total typed boundary.
 
@@ -270,30 +278,27 @@ def _normalized_schema_snapshot(schema: object) -> Mapping[str, Any]:
     members, reading their attribute and relationship shapes, and validating the built
     snapshot — runs under one rule: any ordinary ``Exception`` it raises (``items()``
     raising, a raising attribute property, raising iteration — whatever a third-party
-    response can do) becomes the typed :class:`DestinationSchemaReadError` carrying the
-    exception type name only, never third-party exception text, so nothing escapes as an
-    untyped error the service boundary can only report as internal. ``BaseException``
-    still propagates, and an inner ``DestinationSchemaReadError`` passes through untouched.
+    response can do) becomes one *new* :class:`DestinationSchemaReadError` carrying the
+    fixed message and ``reason="rejected"``. The rejection reads nothing from the
+    exception — not its type, whose ``__name__`` a hostile metaclass executes on — and a
+    ``DestinationSchemaReadError`` raised during normalization is rewrapped rather than
+    passed through, so untrusted response code cannot forge its own reason.
+    ``BaseException`` still propagates.
     """
     try:
         return _build_schema_snapshot(schema)
-    except DestinationSchemaReadError:
-        raise
-    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # The totality rule: re-raised typed, type name only.
-        msg = f"destination returned an unusable schema response: {type(exc).__name__}"
-        raise DestinationSchemaReadError(msg, reason="rejected") from None
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # The totality rule: re-raised typed, nothing read.
+        raise DestinationSchemaReadError(_UNUSABLE_SCHEMA_RESPONSE, reason="rejected") from None
 
 
 def _build_schema_snapshot(schema: object) -> dict[str, Any]:
     """Build the snapshot from a third-party response, inside the boundary above."""
     if not isinstance(schema, Mapping):
-        msg = f"destination returned an unusable schema response: {type(schema).__name__}"
-        raise DestinationSchemaReadError(msg, reason="rejected")
+        raise DestinationSchemaReadError(_UNUSABLE_SCHEMA_RESPONSE, reason="rejected")
     snapshot: dict[str, Any] = {}
     for kind, node in schema.items():
         if not isinstance(kind, str):
-            msg = f"destination returned an unusable schema member: {type(kind).__name__}"
-            raise DestinationSchemaReadError(msg, reason="rejected")
+            raise DestinationSchemaReadError(_UNUSABLE_SCHEMA_RESPONSE, reason="rejected")
         snapshot[kind] = {
             "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
             "relationships": {

--- a/infrahub_sync/configuration/capabilities.py
+++ b/infrahub_sync/configuration/capabilities.py
@@ -9,7 +9,7 @@ from types import MappingProxyType
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
-from .models import ConfigurationPackage, ValidationFinding
+from .models import _SETTING_NAME, ConfigurationPackage, ValidationFinding, is_renderable_setting_path
 
 AdapterRole = Literal["source", "destination"]
 WriteOperation = Literal["create", "update", "delete"]
@@ -23,10 +23,6 @@ _SCHEMA_READ_REASON = re.compile(r"^[a-z]{1,32}$")
 _ADAPTER_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
 _ADAPTER_ROLES: frozenset[AdapterRole] = frozenset({"source", "destination"})
 _WRITE_OPERATIONS: frozenset[WriteOperation] = frozenset({"create", "update", "delete"})
-_SETTING_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
-# A declared path component must survive pointer rendering unchanged, so the pointer built
-# from the declaration and the pointer built while walking a package cannot disagree.
-_MAX_SETTING_PATH_COMPONENT_LENGTH = 64
 
 
 class DestinationSchemaReadError(Exception):
@@ -44,16 +40,6 @@ class DestinationSchemaReadError(Exception):
             raise ValueError(msg)
         super().__init__(message)
         self.reason = reason
-
-
-def is_renderable_setting_path(path: str) -> bool:
-    """Return whether every dotted component is an exact, bounded setting name."""
-    if not path or path.startswith(".") or path.endswith("."):
-        return False
-    return all(
-        _SETTING_NAME.fullmatch(component) is not None and len(component) <= _MAX_SETTING_PATH_COMPONENT_LENGTH
-        for component in path.split(".")
-    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -190,6 +176,7 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
     """
     # Imported here, not at module load: this module stays connection-free to import, and
     # the default validate path never touches a network client (envelope AR7).
+    # pylint: disable=import-outside-toplevel
     import httpx
     from infrahub_sdk import Config, InfrahubClientSync
     from infrahub_sdk.exceptions import (
@@ -200,6 +187,7 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
 
     from .credentials import CredentialConfigurationError, resolve_reference
 
+    # pylint: enable=import-outside-toplevel
     settings = package.configuration.destination.settings or {}
     url = settings.get("url")
     if not isinstance(url, str) or not url:
@@ -237,9 +225,7 @@ def _read_infrahub_destination_schema(package: ConfigurationPackage, branch: str
         raise DestinationSchemaReadError(msg, reason="unreachable") from None
     return {
         kind: {
-            "attributes": {
-                attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()
-            },
+            "attributes": {attribute.name: attribute.kind for attribute in getattr(node, "attributes", ()) or ()},
             "relationships": {
                 relationship.name: {"peer": relationship.peer, "cardinality": relationship.cardinality}
                 for relationship in getattr(node, "relationships", ()) or ()

--- a/infrahub_sync/configuration/credentials.py
+++ b/infrahub_sync/configuration/credentials.py
@@ -15,8 +15,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
-from .capabilities import is_renderable_setting_path
-from .models import safe_pointer_component
+from .models import is_renderable_setting_path, safe_pointer_component
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping

--- a/infrahub_sync/configuration/credentials.py
+++ b/infrahub_sync/configuration/credentials.py
@@ -1,30 +1,27 @@
-"""Credential-reference validation and runtime provider contracts."""
+"""Credential-reference primitives and runtime provider contracts.
+
+The checks that read these primitives live in :mod:`infrahub_sync.configuration.validation`,
+which accumulates findings instead of raising at the first defect, and which owns
+``validate_package_credentials`` with them. What stays here is what a credential reference *is*:
+how one is declared, how one is rendered into a diagnostic, and how one is resolved at run time.
+The dependency runs one way — validation reads these primitives and nothing here reads it back.
+"""
 
 from __future__ import annotations
 
 import json
 import os
 import re
-from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Protocol, cast
-from urllib.parse import urlsplit
+from typing import TYPE_CHECKING, Protocol
 
-from pydantic import ValidationError
+from .capabilities import is_renderable_setting_path
+from .models import safe_pointer_component
 
-from .capabilities import (
-    AdapterConfigurationCapabilities,
-    AdapterRole,
-    get_adapter_capabilities,
-    is_renderable_setting_path,
-)
-from .models import (
-    ConfigurationPackage,
-    CredentialReference,
-    CredentialReferenceNode,
-    safe_pointer_component,
-    sort_findings,
-)
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from .models import ConfigurationPackage, CredentialReference
 
 _ENV_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -54,12 +51,6 @@ _STORE_CAPABILITIES: dict[str, _StoreCapabilities] = {
         credential_setting_paths=("url", "username", "password"),
     ),
 }
-# Absolute settings name where to connect; relative ones name a path beneath it. Applying one
-# rule to both would refuse every legitimate relative endpoint.
-_ABSOLUTE_URL_SETTING_NAMES = frozenset({"base_url", "url"})
-_RELATIVE_PATH_SETTING_NAMES = frozenset({"api_endpoint", "endpoint"})
-_URL_SETTING_NAMES = _ABSOLUTE_URL_SETTING_NAMES | _RELATIVE_PATH_SETTING_NAMES
-_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 # Diagnostics are rendered from declared keys, so they inherit the declaration's size unless
 # bounded here the way models.py bounds its own parse diagnostics.
 _MAX_DIAGNOSTIC_COMPONENT_LENGTH = 64
@@ -69,7 +60,9 @@ _MAX_DIAGNOSTIC_NAME_ENTRIES = 16
 # content: a literal "~2" in a declared key renders as "~02". This is what makes a truncated
 # pointer unforgeable — declared components are capped at 64, so an over-length package key
 # always carries the marker and can never truncate onto a legitimately declared pointer.
-# Changing the marker to something escaping can produce reopens that.
+# Changing the marker to something escaping can produce reopens that. This holds for the "~2"
+# form, which only ever appears in a message; validation.py notes where the pointer form of the
+# same marker stops being unforgeable.
 _TRUNCATION_MARKER = "~2"
 
 
@@ -132,231 +125,6 @@ def provider_for(reference: CredentialReference, *, environment: Mapping[str, st
         return EnvironmentCredentialProvider(environment)
     msg = f"credential provider {reference.provider!r} is not installed"
     raise CredentialConfigurationError(msg)
-
-
-def _validate_reference_declarations(package: ConfigurationPackage) -> None:
-    """Validate provider names and identifiers without resolving credential values."""
-    for name, reference in package.credentials.items():
-        if reference.provider != "env":
-            msg = f"credential reference {name!r} uses provider {reference.provider!r}, which is not installed"
-            raise CredentialConfigurationError(msg)
-        if _ENV_IDENTIFIER.fullmatch(reference.identifier) is None:
-            msg = f"credential reference {name!r} has an invalid environment identifier"
-            raise CredentialConfigurationError(msg)
-
-
-def _setting_at_path(settings: Mapping[str, object], path: str) -> tuple[bool, object | None]:
-    current: object = settings
-    for component in path.split("."):
-        if not isinstance(current, Mapping) or component not in current:
-            return False, None
-        current = cast("Mapping[str, object]", current)[component]
-    return True, current
-
-
-def _reference_name(value: object, *, location: str) -> str:
-    if not isinstance(value, Mapping) or "$credential" not in value:
-        msg = f"{location} contains an inline credential value"
-        raise CredentialConfigurationError(msg)
-    try:
-        node = CredentialReferenceNode.model_validate(value)
-    except ValidationError:
-        msg = f"{location} contains a malformed credential reference"
-        raise CredentialConfigurationError(msg) from None
-    return node.reference_name
-
-
-def _settings_pointer(prefix: str, path: str) -> str:
-    """Build one settings pointer the same way the declared-content walk builds it.
-
-    The only place a declared setting path becomes a pointer. The allowed-location set and
-    the walk must produce byte-identical strings, or a reference is accepted by one check
-    and refused by the next; a second formatter is how that divergence gets reintroduced.
-    """
-    return prefix + "".join(f"/{_bounded_component(component)}" for component in path.split("."))
-
-
-def _allowed_reference_locations(
-    package: ConfigurationPackage,
-    source_capabilities: AdapterConfigurationCapabilities,
-    destination_capabilities: AdapterConfigurationCapabilities,
-) -> frozenset[str]:
-    """Return every pointer at which a declared credential reference is resolved at run time."""
-    allowed = {
-        _settings_pointer(f"/configuration/{role}/settings", path)
-        for role, capabilities in (("source", source_capabilities), ("destination", destination_capabilities))
-        for path in capabilities.credential_setting_paths
-    }
-    store = package.configuration.store
-    store_capabilities = None if store is None else _STORE_CAPABILITIES.get(store.type)
-    if store_capabilities is not None:
-        allowed.update(
-            _settings_pointer("/configuration/store/settings", path)
-            for path in store_capabilities.credential_setting_paths
-        )
-    return frozenset(allowed)
-
-
-def _validate_all_reference_nodes(
-    value: object,
-    package: ConfigurationPackage,
-    *,
-    location: str,
-    allowed_locations: frozenset[str],
-) -> None:
-    """Validate every use of the reserved ``$credential`` key without echoing values."""
-    if isinstance(value, Mapping):
-        if "$credential" in value:
-            bounded = _bounded_location(location)
-            if location not in allowed_locations:
-                # Nothing resolves a reference here, so the adapter would receive the node itself.
-                msg = f"{bounded} is not a credential-bearing setting"
-                raise CredentialConfigurationError(msg)
-            reference_name = _reference_name(value, location=bounded)
-            if reference_name not in package.credentials:
-                msg = f"{bounded} names unknown credential reference {reference_name!r}"
-                raise CredentialConfigurationError(msg)
-            return
-        for key, item in value.items():
-            escaped = _bounded_component(key)
-            _validate_all_reference_nodes(
-                item,
-                package,
-                location=f"{location}/{escaped}",
-                allowed_locations=allowed_locations,
-            )
-    elif isinstance(value, list):
-        for index, item in enumerate(value):
-            _validate_all_reference_nodes(
-                item,
-                package,
-                location=f"{location}/{index}",
-                allowed_locations=allowed_locations,
-            )
-
-
-def _validate_url_setting(value: object, *, setting_name: str, location: str) -> None:
-    """Prove one declared endpoint setting carries no credential material and no scheme surprise."""
-    if not isinstance(value, str):
-        msg = f"{location} must be declared as a string"
-        raise CredentialConfigurationError(msg)
-    try:
-        parsed = urlsplit(value)
-    except ValueError:
-        parsed = None
-    if parsed is None or parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
-        msg = f"{location} cannot contain user information, query parameters, or fragments"
-        raise CredentialConfigurationError(msg)
-    if setting_name in _ABSOLUTE_URL_SETTING_NAMES:
-        if parsed.scheme not in _ALLOWED_URL_SCHEMES or not parsed.netloc:
-            msg = f"{location} must be an absolute http or https URL"
-            raise CredentialConfigurationError(msg)
-    elif parsed.scheme or parsed.netloc:
-        msg = f"{location} must be a relative request path without a scheme or authority"
-        raise CredentialConfigurationError(msg)
-
-
-def _validate_adapter_credentials(
-    package: ConfigurationPackage,
-    capabilities: AdapterConfigurationCapabilities,
-    *,
-    role: AdapterRole,
-    settings: Mapping[str, object],
-) -> None:
-    if role not in capabilities.roles:
-        msg = f"adapter {capabilities.adapter_name!r} does not support the {role} role"
-        raise CredentialConfigurationError(msg)
-    unsupported_settings = set(settings) - capabilities.allowed_settings
-    if unsupported_settings:
-        msg = (
-            f"adapter {capabilities.adapter_name!r} contains unsupported declared settings for the {role} role: "
-            f"{_render_setting_name_list(unsupported_settings)}"
-        )
-        raise CredentialConfigurationError(msg)
-    for setting_name in sorted(capabilities.allowed_settings & _URL_SETTING_NAMES):
-        value = settings.get(setting_name)
-        if value is None:
-            continue
-        _validate_url_setting(
-            value,
-            setting_name=setting_name,
-            location=_settings_pointer(f"/configuration/{role}/settings", setting_name),
-        )
-    if capabilities.validator is not None:
-        findings = sort_findings(capabilities.validator(package, role))
-        if findings:
-            msg = "; ".join(f"{_bounded_location(finding.location)}: {finding.message}" for finding in findings)
-            raise CredentialConfigurationError(msg)
-    for path in capabilities.credential_setting_paths:
-        present, value = _setting_at_path(settings, path)
-        if not present or value is None:
-            continue
-        location = _settings_pointer(f"/configuration/{role}/settings", path)
-        reference_name = _reference_name(value, location=location)
-        if reference_name not in package.credentials:
-            msg = f"{location} names unknown credential reference {reference_name!r}"
-            raise CredentialConfigurationError(msg)
-
-
-def _validate_store_credentials(package: ConfigurationPackage) -> None:
-    """Refuse inline values at credential-bearing store settings."""
-    store = package.configuration.store
-    if store is None:
-        return
-    settings = store.settings or {}
-    capabilities = _STORE_CAPABILITIES.get(store.type)
-    if capabilities is None:
-        if settings:
-            msg = f"store type {store.type!r} has no configuration capability declaration"
-            raise CredentialConfigurationError(msg)
-        return
-    credential_paths = capabilities.credential_setting_paths
-    unsupported_settings = set(settings) - capabilities.allowed_settings
-    if unsupported_settings:
-        msg = (
-            f"store type {store.type!r} contains unsupported declared settings: "
-            f"{_render_setting_name_list(unsupported_settings)}"
-        )
-        raise CredentialConfigurationError(msg)
-    for path in credential_paths:
-        present, value = _setting_at_path(settings, path)
-        if not present or value is None:
-            continue
-        location = _settings_pointer("/configuration/store/settings", path)
-        reference_name = _reference_name(value, location=location)
-        if reference_name not in package.credentials:
-            msg = f"{location} names unknown credential reference {reference_name!r}"
-            raise CredentialConfigurationError(msg)
-
-
-def validate_package_credentials(package: ConfigurationPackage) -> None:
-    """Prove bundled adapter settings contain references rather than credential values."""
-    _validate_reference_declarations(package)
-    source = package.configuration.source
-    destination = package.configuration.destination
-    _validate_store_credentials(package)
-    source_capabilities = get_adapter_capabilities(source.name)
-    _validate_adapter_credentials(
-        package,
-        source_capabilities,
-        role="source",
-        settings=source.settings or {},
-    )
-    destination_capabilities = get_adapter_capabilities(destination.name)
-    _validate_adapter_credentials(
-        package,
-        destination_capabilities,
-        role="destination",
-        settings=destination.settings or {},
-    )
-    # Last: the surface checks above give a more precise reason for a node on an unsupported
-    # setting than "not credential-bearing" would.
-    _validate_all_reference_nodes(
-        package.declared_content(),
-        package,
-        location="",
-        allowed_locations=_allowed_reference_locations(package, source_capabilities, destination_capabilities),
-    )
 
 
 def resolve_reference(

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -452,6 +452,29 @@ class ConfigurationPackageMetadata(BaseModel):
     adapter_api_version: Literal[1] = 1
 
 
+# An omission reason reaches a finding message verbatim, so the bound is what keeps the
+# reason plus the fixed message template under _MAX_FINDING_TEXT_LENGTH: an over-long
+# reason is a registration-time refusal here, never a finding-construction crash.
+_MAX_OMISSION_REASON_LENGTH = 160
+
+_OmissionFieldName = Annotated[str, StringConstraints(min_length=1)]
+
+
+class _OmissionDeclaration(BaseModel):
+    """One declared intent: this destination content is intentionally not synchronized."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: str = Field(min_length=1)
+    # Omit the list to omit the whole kind; an empty list would declare nothing.
+    fields: tuple[_OmissionFieldName, ...] | None = Field(default=None, min_length=1)
+    reason: str | None = Field(default=None, min_length=1, max_length=_MAX_OMISSION_REASON_LENGTH)
+
+    @field_serializer("fields")
+    def _serialize_fields(self, value: tuple[str, ...] | None) -> list[str] | None:
+        return None if value is None else list(value)
+
+
 class ValidationFinding(BaseModel):
     """Stable, secret-safe result produced by configuration validation."""
 
@@ -479,6 +502,10 @@ class ConfigurationPackage(BaseModel):
     credentials: Mapping[CredentialReferenceName, CredentialReference] = Field(
         default_factory=dict, validate_default=True
     )
+    # Always serialized, the empty tuple included: omissions change the validation report a
+    # version produces, so they sit inside declared identity, and serializing the empty
+    # declaration keeps absent and empty from being two different byte streams.
+    omissions: tuple[_OmissionDeclaration, ...] = ()
 
     @model_validator(mode="before")
     @classmethod
@@ -503,6 +530,10 @@ class ConfigurationPackage(BaseModel):
     @field_serializer("credentials")
     def _serialize_credentials(self, value: Mapping[str, CredentialReference]) -> dict[str, CredentialReference]:
         return dict(value)
+
+    @field_serializer("omissions")
+    def _serialize_omissions(self, value: tuple[_OmissionDeclaration, ...]) -> list[_OmissionDeclaration]:
+        return list(value)
 
     def declared_content(self) -> dict[str, Any]:
         """Return the exact JSON-native content covered by the package checksum."""

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -456,12 +456,13 @@ class ConfigurationPackageMetadata(BaseModel):
 # reason plus the fixed message template under _MAX_FINDING_TEXT_LENGTH: an over-long
 # reason is a registration-time refusal here, never a finding-construction crash.
 _MAX_OMISSION_REASON_LENGTH = 160
-# The same categories the parse-diagnostic pointer guard refuses: control (Cc), format
-# (Cf, which carries the bidi overrides), surrogate (Cs), and the line/paragraph
-# separators (Zl, Zp). Ordinary spaces are Zs and stay legal. A reason reaches an
-# operator-facing finding message verbatim, so any of these would carry a newline, an
-# ANSI escape, or a bidi override straight into a rendered line.
-_UNPRINTABLE_REASON_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Zl", "Zp"})
+# Acceptance is exactly ``str.isprintable()``. A reason reaches an operator-facing
+# finding message verbatim, so every character a rendered line cannot carry — a control
+# character or ANSI escape (Cc), a format character such as a bidi override (Cf), a
+# surrogate (Cs), a private-use or unassigned code point (Co, Cn), a line or paragraph
+# separator (Zl, Zp), a non-space separator such as U+00A0 (Zs) — is refused by the one
+# closed property Python defines, not by a category list that has to enumerate them.
+# The ordinary space stays legal: ``' '.isprintable()`` is True.
 _UNPRINTABLE_OMISSION_REASON_ERROR = "unprintable_omission_reason"
 
 _OmissionFieldName = Annotated[str, StringConstraints(min_length=1)]
@@ -481,8 +482,8 @@ class _OmissionDeclaration(BaseModel):
     @classmethod
     def _require_printable_reason(cls, value: str | None) -> str | None:
         """Refuse a reason no rendered line can carry safely, without echoing it."""
-        if value is not None and any(category(character) in _UNPRINTABLE_REASON_CATEGORIES for character in value):
-            reason = "omission reason must not contain control or non-printable characters"
+        if value is not None and not value.isprintable():
+            reason = "omission reason must contain only printable characters"
             raise PydanticCustomError(_UNPRINTABLE_OMISSION_REASON_ERROR, reason, {"reason": reason})
         return value
 

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -458,9 +458,12 @@ class ValidationFinding(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
 
     code: str = Field(pattern=r"^[a-z][a-z0-9-]*$", max_length=_MAX_FINDING_TEXT_LENGTH)
-    # Only "error" has a channel: validate_package_credentials raises. Re-add "warning" with
-    # the surface that reports it, so a capability author cannot write one into silence.
-    severity: Literal["error"]
+    # Exactly the two contract severities. "warning" is reported by the two contract
+    # section 4 families in configuration/warnings.py and nothing else — the core and the
+    # adapter containment boundary emit errors only, so a capability author still cannot
+    # write a severity into silence. A third severity has no reporting surface and is
+    # refused here.
+    severity: Literal["error", "warning"]
     location: str = Field(pattern=r"^(/(?:[^~/]|~[01])*)*$", max_length=_MAX_FINDING_TEXT_LENGTH)
     message: str = Field(min_length=1, max_length=_MAX_FINDING_TEXT_LENGTH)
 
@@ -786,5 +789,7 @@ def parse_configuration_package(value: object) -> ConfigurationPackage:
 
 def sort_findings(findings: Sequence[ValidationFinding]) -> tuple[ValidationFinding, ...]:
     """Return findings in the stable cross-interface order."""
-    severity_order = {"error": 0}
+    # Error before warning at one location: errors prevent execution, warnings do not.
+    # Deliberately still a KeyError on any third severity rather than a silent sort.
+    severity_order = {"error": 0, "warning": 1}
     return tuple(sorted(findings, key=lambda item: (item.location, severity_order[item.severity], item.code)))

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -37,6 +37,10 @@ from infrahub_sync.plan.canonical import canonical_json_bytes
 
 _REFERENCE_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_.-]{0,127}$"
 _PROVIDER_NAME_PATTERN = r"^[a-z][a-z0-9-]{0,63}$"
+_SETTING_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+# A declared path component must survive pointer rendering unchanged, so the pointer built
+# from the declaration and the pointer built while walking a package cannot disagree.
+_MAX_SETTING_PATH_COMPONENT_LENGTH = 64
 _SAFE_POINTER_RE = re.compile(r"^(/(?:[^~/]|~[01])*)*$")
 _MAX_DECLARATION_DEPTH = 64
 _MAX_VALIDATION_ERRORS = 256
@@ -104,6 +108,20 @@ _POINTER_CHARACTER_ESCAPES = {
 
 class ConfigurationPackageParseError(ValueError):
     """A declared package failed validation at a secret-safe public boundary."""
+
+
+def is_renderable_setting_path(path: str) -> bool:
+    """Return whether every dotted component is an exact, bounded setting name.
+
+    Declared here — beneath both the capability and the credential declarations that
+    check their setting paths against it — so neither module needs the other for it.
+    """
+    if not path or path.startswith(".") or path.endswith("."):
+        return False
+    return all(
+        _SETTING_NAME.fullmatch(component) is not None and len(component) <= _MAX_SETTING_PATH_COMPONENT_LENGTH
+        for component in path.split(".")
+    )
 
 
 def _raise_unsupported_declared_fields(

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -456,6 +456,13 @@ class ConfigurationPackageMetadata(BaseModel):
 # reason plus the fixed message template under _MAX_FINDING_TEXT_LENGTH: an over-long
 # reason is a registration-time refusal here, never a finding-construction crash.
 _MAX_OMISSION_REASON_LENGTH = 160
+# The same categories the parse-diagnostic pointer guard refuses: control (Cc), format
+# (Cf, which carries the bidi overrides), surrogate (Cs), and the line/paragraph
+# separators (Zl, Zp). Ordinary spaces are Zs and stay legal. A reason reaches an
+# operator-facing finding message verbatim, so any of these would carry a newline, an
+# ANSI escape, or a bidi override straight into a rendered line.
+_UNPRINTABLE_REASON_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Zl", "Zp"})
+_UNPRINTABLE_OMISSION_REASON_ERROR = "unprintable_omission_reason"
 
 _OmissionFieldName = Annotated[str, StringConstraints(min_length=1)]
 
@@ -469,6 +476,15 @@ class _OmissionDeclaration(BaseModel):
     # Omit the list to omit the whole kind; an empty list would declare nothing.
     fields: tuple[_OmissionFieldName, ...] | None = Field(default=None, min_length=1)
     reason: str | None = Field(default=None, min_length=1, max_length=_MAX_OMISSION_REASON_LENGTH)
+
+    @field_validator("reason")
+    @classmethod
+    def _require_printable_reason(cls, value: str | None) -> str | None:
+        """Refuse a reason no rendered line can carry safely, without echoing it."""
+        if value is not None and any(category(character) in _UNPRINTABLE_REASON_CATEGORIES for character in value):
+            reason = "omission reason must not contain control or non-printable characters"
+            raise PydanticCustomError(_UNPRINTABLE_OMISSION_REASON_ERROR, reason, {"reason": reason})
+        return value
 
     @field_serializer("fields")
     def _serialize_fields(self, value: tuple[str, ...] | None) -> list[str] | None:

--- a/infrahub_sync/configuration/schema_validation.py
+++ b/infrahub_sync/configuration/schema_validation.py
@@ -130,8 +130,7 @@ def _schema_content_findings(
                         code=_CODE_DESTINATION_SCHEMA_MISMATCH,
                         location=f"{field_location}/name",
                         message=(
-                            f"destination kind {mapping.name!r} declares no attribute or "
-                            f"relationship {field.name!r}"
+                            f"destination kind {mapping.name!r} declares no attribute or relationship {field.name!r}"
                         ),
                     )
                 )
@@ -190,8 +189,7 @@ def collect_destination_schema_findings(package: ConfigurationPackage) -> Destin
                 code=_CODE_UNSUPPORTED_DESTINATION_WRITE,
                 location=_DESTINATION_LOCATION,
                 message=(
-                    f"adapter {destination.name!r} does not support requested destination "
-                    f"write operations: {rendered}"
+                    f"adapter {destination.name!r} does not support requested destination write operations: {rendered}"
                 ),
             )
         )

--- a/infrahub_sync/configuration/schema_validation.py
+++ b/infrahub_sync/configuration/schema_validation.py
@@ -5,15 +5,24 @@ untouched; this module owns the schema-path checks and their finding codes. Thre
 families live here, each behind its own ``_CODE_`` constant and frozen by this module's
 own exact-set and reachability tests (envelope AR8):
 
-* the destination-schema-mismatch family — declared mappings judged against a real
-  destination schema snapshot, plus the capability gate for an explicit request against a
-  destination that does not declare schema validation (a missing capability needed to
-  determine safety is an error, contract section 4);
+* the destination-schema-mismatch family — exactly four predicates judged against the
+  destination schema snapshot: a mapping kind the snapshot does not declare, a field name
+  that is neither an attribute nor a relationship of its kind, a relationship reference on
+  a name the schema declares as an attribute, and a declared static value whose shape
+  (list versus scalar) disagrees with the relationship's declared cardinality — plus the
+  capability gate for an explicit request against a destination that does not declare
+  schema validation (a missing capability needed to determine safety is an error, contract
+  section 4). Two further checkable predicates are deliberately out of this unit's scope
+  and recorded as parent-level follow-up: a static value's type against the attribute's
+  declared kind, and a reference against the relationship's declared peer kind;
 * the unsupported-destination-write family — the operations one configuration requests,
   derived through the one shared SYNC-78 effective-operation rule, judged against the
   destination's declared write operations;
-* the schema-read-failure family (envelope AR9) — a schema read that fails on the opt-in
-  path becomes a typed error finding, never a generic service-boundary refusal.
+* the schema-read-failure family (envelope AR9) — a schema read the accessor reports as
+  failed becomes a typed error finding rather than a generic service-boundary refusal.
+  The bundled accessor classifies SDK-raised errors, HTTP transport and status failures,
+  an unresolvable declared credential, and a declared client configuration the SDK
+  refuses; an exception outside the accessor contract is not intercepted here.
 
 Checks accumulate: a failed check never suppresses an independent one, and an unevaluable
 subtree — an unknown destination adapter, an unknown kind, an unknown field — suppresses

--- a/infrahub_sync/configuration/schema_validation.py
+++ b/infrahub_sync/configuration/schema_validation.py
@@ -1,0 +1,225 @@
+"""Destination schema validation — the explicit opt-in checks outside the declared-content core.
+
+The declared-content core (``validation.py``) judges declared content only and stays
+untouched; this module owns the schema-path checks and their finding codes. Three error
+families live here, each behind its own ``_CODE_`` constant and frozen by this module's
+own exact-set and reachability tests (envelope AR8):
+
+* the destination-schema-mismatch family — declared mappings judged against a real
+  destination schema snapshot, plus the capability gate for an explicit request against a
+  destination that does not declare schema validation (a missing capability needed to
+  determine safety is an error, contract section 4);
+* the unsupported-destination-write family — the operations one configuration requests,
+  derived through the one shared SYNC-78 effective-operation rule, judged against the
+  destination's declared write operations;
+* the schema-read-failure family (envelope AR9) — a schema read that fails on the opt-in
+  path becomes a typed error finding, never a generic service-boundary refusal.
+
+Checks accumulate: a failed check never suppresses an independent one, and an unevaluable
+subtree — an unknown destination adapter, an unknown kind, an unknown field — suppresses
+only its own deeper checks, mirroring the core's OES-15 rule. Nothing here runs on the
+default ``validate`` path: only the explicit opt-in reaches this module, and the accessor
+is the only thing that may perform I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from infrahub_sync import requested_destination_write_operations
+from infrahub_sync.cache import compute_schema_subhash
+
+from .capabilities import BUILTIN_ADAPTER_CAPABILITIES, DestinationSchemaReadError
+from .models import ValidationFinding, sort_findings
+from .validation import _finding_message
+
+if TYPE_CHECKING:
+    from .models import ConfigurationPackage
+
+_CODE_DESTINATION_SCHEMA_MISMATCH = "destination-schema-mismatch"
+_CODE_DESTINATION_SCHEMA_READ_FAILED = "destination-schema-read-failed"
+_CODE_DESTINATION_SCHEMA_VALIDATION_UNSUPPORTED = "destination-schema-validation-unsupported"
+_CODE_UNSUPPORTED_DESTINATION_WRITE = "unsupported-destination-write"
+
+_DESTINATION_LOCATION = "/configuration/destination"
+_CARDINALITIES = frozenset({"one", "many"})
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationSchemaOptions:
+    """Explicit request for destination schema validation on ``validate``.
+
+    Presence is the opt-in: ``None`` on the operation keeps today's declared-content-only
+    behavior byte-identical, with zero schema reads. No options exist yet; the type is the
+    extension point later units add to.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class DestinationSchemaValidation:
+    """Every schema-path finding for one package, with the judged snapshot's identity.
+
+    ``schema_fingerprint`` is the ``compute_schema_subhash`` identity of the snapshot the
+    content checks actually judged (envelope AR6) — ``None`` whenever no snapshot was
+    read: a non-declaring destination, an unknown adapter, or a failed read.
+    """
+
+    findings: tuple[ValidationFinding, ...]
+    schema_fingerprint: str | None
+
+
+def resolve_declared_destination_branch(package: ConfigurationPackage) -> str:
+    """Resolve the destination branch from the declared setting only.
+
+    The interim SYNC-79 helper: reads ``destination.settings.branch`` and nothing else —
+    never the ambient environment — defaulting to ``"main"``, the SDK's own default
+    branch. Its consumers are the schema read and, through the snapshot that read
+    returns, the fingerprint subhash. CF-005's shared resolver replaces this at its one
+    call site.
+    """
+    settings = package.configuration.destination.settings or {}
+    branch = settings.get("branch")
+    if isinstance(branch, str) and branch:
+        return branch
+    return "main"
+
+
+def _finding(*, code: str, location: str, message: str) -> ValidationFinding:
+    """Build one error finding under the core's own message bound.
+
+    The locations this module writes are built from fixed literals and list indices —
+    never from declared keys — so only the message needs bounding.
+    """
+    return ValidationFinding(code=code, severity="error", location=location, message=_finding_message(message))
+
+
+def _schema_content_findings(
+    package: ConfigurationPackage,
+    snapshot: Mapping[str, Any],
+) -> list[ValidationFinding]:
+    """Judge every declared schema mapping against the snapshot, accumulating.
+
+    An unknown kind makes its mapping entry unevaluable, so its fields are judged nowhere
+    deeper; an unknown field ends that field's own checks the same way. Entries whose
+    snapshot shape is not a mapping are treated as undeclared, never crashed on.
+    """
+    findings: list[ValidationFinding] = []
+    for index, mapping in enumerate(package.configuration.schema_mapping):
+        entry = snapshot.get(mapping.name)
+        if not isinstance(entry, Mapping):
+            findings.append(
+                _finding(
+                    code=_CODE_DESTINATION_SCHEMA_MISMATCH,
+                    location=f"/configuration/schema_mapping/{index}/name",
+                    message=f"destination schema declares no kind {mapping.name!r}",
+                )
+            )
+            continue
+        raw_attributes = entry.get("attributes")
+        raw_relationships = entry.get("relationships")
+        attributes: Mapping[str, Any] = raw_attributes if isinstance(raw_attributes, Mapping) else {}
+        relationships: Mapping[str, Any] = raw_relationships if isinstance(raw_relationships, Mapping) else {}
+        for field_index, field in enumerate(mapping.fields or ()):
+            field_location = f"/configuration/schema_mapping/{index}/fields/{field_index}"
+            relationship = relationships.get(field.name)
+            if field.name not in attributes and relationship is None:
+                findings.append(
+                    _finding(
+                        code=_CODE_DESTINATION_SCHEMA_MISMATCH,
+                        location=f"{field_location}/name",
+                        message=(
+                            f"destination kind {mapping.name!r} declares no attribute or "
+                            f"relationship {field.name!r}"
+                        ),
+                    )
+                )
+                continue
+            if field.reference is not None and relationship is None:
+                findings.append(
+                    _finding(
+                        code=_CODE_DESTINATION_SCHEMA_MISMATCH,
+                        location=f"{field_location}/reference",
+                        message=(
+                            f"field {field.name!r} declares a relationship reference, but destination "
+                            f"kind {mapping.name!r} declares an attribute"
+                        ),
+                    )
+                )
+                continue
+            if relationship is None or field.static is None:
+                continue
+            cardinality = relationship.get("cardinality") if isinstance(relationship, Mapping) else None
+            declared_many = isinstance(field.static, (list, tuple))
+            if cardinality in _CARDINALITIES and declared_many != (cardinality == "many"):
+                shape = "list" if declared_many else "single"
+                findings.append(
+                    _finding(
+                        code=_CODE_DESTINATION_SCHEMA_MISMATCH,
+                        location=f"{field_location}/static",
+                        message=(
+                            f"field {field.name!r} declares a {shape} static value, but the "
+                            f"destination relationship has cardinality {cardinality!r}"
+                        ),
+                    )
+                )
+    return findings
+
+
+def collect_destination_schema_findings(package: ConfigurationPackage) -> DestinationSchemaValidation:
+    """Run every destination schema check for one explicit opt-in request.
+
+    Accumulating and total over declared defects: a non-declaring destination, a failed
+    schema read, and an unsupported write request each become findings, never raises. An
+    unknown destination adapter adds nothing here — the core's own finding already names
+    that defect and its subtree is unevaluable (OES-15) — and checks independent of a
+    failed read still report. Findings return in the stable ``sort_findings`` order.
+    """
+    destination = package.configuration.destination
+    capabilities = BUILTIN_ADAPTER_CAPABILITIES.get(destination.name)
+    if capabilities is None:
+        return DestinationSchemaValidation(findings=(), schema_fingerprint=None)
+    findings: list[ValidationFinding] = []
+    requested = requested_destination_write_operations(package.configuration.diffsync_flags)
+    unsupported = requested - capabilities.supported_destination_write_operations
+    if unsupported:
+        rendered = ", ".join(sorted(unsupported))
+        findings.append(
+            _finding(
+                code=_CODE_UNSUPPORTED_DESTINATION_WRITE,
+                location=_DESTINATION_LOCATION,
+                message=(
+                    f"adapter {destination.name!r} does not support requested destination "
+                    f"write operations: {rendered}"
+                ),
+            )
+        )
+    fingerprint: str | None = None
+    # The registration-time invariant on the seam makes the accessor and the declaration
+    # one fact, so presence of the accessor is the declaration.
+    accessor = capabilities.destination_schema_accessor
+    if accessor is None:
+        findings.append(
+            _finding(
+                code=_CODE_DESTINATION_SCHEMA_VALIDATION_UNSUPPORTED,
+                location=_DESTINATION_LOCATION,
+                message=f"adapter {destination.name!r} does not declare destination schema validation",
+            )
+        )
+    else:
+        branch = resolve_declared_destination_branch(package)
+        try:
+            snapshot = accessor(package, branch)
+        except DestinationSchemaReadError as exc:
+            findings.append(
+                _finding(
+                    code=_CODE_DESTINATION_SCHEMA_READ_FAILED,
+                    location=_DESTINATION_LOCATION,
+                    message=f"destination schema for branch {branch!r} could not be read: {exc.reason}",
+                )
+            )
+        else:
+            fingerprint = compute_schema_subhash(package.configuration, dict(snapshot))
+            findings.extend(_schema_content_findings(package, snapshot))
+    return DestinationSchemaValidation(findings=sort_findings(findings), schema_fingerprint=fingerprint)

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -413,9 +413,16 @@ def _revalidated_finding(item: ValidationFinding) -> ValidationFinding:
         # adapter may not put a raw control character into operator-facing text either.
         msg = "adapter finding carries an unprintable character"
         raise ValueError(msg)
+    if validated.severity != "error":
+        # The warning channel's emission rule is closed: only the two contract section 4
+        # families in the warnings module report warnings. The wrapper never raises on a
+        # warning, so an adapter allowed to return one could write a defect into the
+        # non-blocking channel; the caller contains this like any other unusable result.
+        msg = "adapter finding carries a severity the adapter has no standing to report"
+        raise ValueError(msg)
     return _finding(
         code=validated.code,
-        severity=validated.severity,
+        severity="error",
         location=_finding_location(validated.location),
         message=_finding_message(validated.message),
     )

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -38,6 +38,7 @@ from .models import (
     safe_pointer_component,
     sort_findings,
 )
+from .warnings import accumulate_intentional_omissions
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -97,6 +98,7 @@ _LOCATION_DIGEST_LENGTH = 8
 _CHECK_CREDENTIALS = "credentials"
 _CHECK_STORE = "store"
 _CHECK_WALK = "walk"
+_CHECK_OMISSIONS = "omissions"
 
 # Where an adapter-owned validator has standing to report. Its own role's subtree, plus the
 # package content that belongs to no role: a schema mapping is declared once for the package
@@ -116,6 +118,11 @@ class _AccumulatedFinding:
 def _from_check(check: str, accumulated: list[_AccumulatedFinding]) -> list[_AccumulatedFinding]:
     """Name the check one group of findings came from, which is what precedence is decided on."""
     return [replace(item, check=check) for item in accumulated]
+
+
+def _from_module(check: str, findings: Iterable[ValidationFinding]) -> list[_AccumulatedFinding]:
+    """Adopt findings a sibling emission module built, each carrying its own message."""
+    return [_AccumulatedFinding(finding=finding, legacy_message=finding.message, check=check) for finding in findings]
 
 
 def _unbounded_component(name: object) -> str:
@@ -682,6 +689,11 @@ def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...
         accumulated=walked,
     )
     accumulated.extend(_from_check(_CHECK_WALK, walked))
+    # Contract section 4's warning families run last, appended after the shipped execution
+    # order, so a package carrying any legacy defect keeps its shipped first-error message
+    # at the wrapper. Warnings before an error here are what the wrapper's first-*error*
+    # rule exists for.
+    accumulated.extend(_from_module(_CHECK_OMISSIONS, accumulate_intentional_omissions(package)))
     return tuple(accumulated)
 
 

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -38,7 +38,7 @@ from .models import (
     safe_pointer_component,
     sort_findings,
 )
-from .warnings import accumulate_intentional_omissions
+from .warnings import accumulate_intentional_omissions, accumulate_unqualified_optional_features
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -99,6 +99,7 @@ _CHECK_CREDENTIALS = "credentials"
 _CHECK_STORE = "store"
 _CHECK_WALK = "walk"
 _CHECK_OMISSIONS = "omissions"
+_CHECK_OPTIONAL_FEATURES = "features"
 
 # Where an adapter-owned validator has standing to report. Its own role's subtree, plus the
 # package content that belongs to no role: a schema mapping is declared once for the package
@@ -694,6 +695,7 @@ def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...
     # at the wrapper. Warnings before an error here are what the wrapper's first-*error*
     # rule exists for.
     accumulated.extend(_from_module(_CHECK_OMISSIONS, accumulate_intentional_omissions(package)))
+    accumulated.extend(_from_module(_CHECK_OPTIONAL_FEATURES, accumulate_unqualified_optional_features(package)))
     return tuple(accumulated)
 
 

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -747,7 +747,10 @@ def collect_findings(package: ConfigurationPackage) -> tuple[ValidationFinding, 
 def validate_package_credentials(package: ConfigurationPackage) -> None:
     """Prove bundled adapter settings contain references rather than credential values."""
     accumulated = _accumulate(package)
-    if accumulated:
-        # Element zero of the untruncated, execution-ordered accumulation: the defect the
-        # raise-first code reported, so the message is the one it produced.
-        raise CredentialConfigurationError(accumulated[0].legacy_message)
+    for item in accumulated:
+        # The first *error* of the untruncated, execution-ordered accumulation: the defect
+        # the raise-first code reported, so the message is the one it produced. Errors
+        # prevent execution and warnings do not, so a warning is never raised on — a
+        # warning-only package passes.
+        if item.finding.severity == "error":
+            raise CredentialConfigurationError(item.legacy_message)

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -1,0 +1,734 @@
+"""Accumulating validation over one declared configuration package.
+
+Every check the shipped ``validate_package_credentials`` performed lives here as a finding
+producer rather than a raise site, so a package carrying N independent defects yields N
+findings.
+
+Two orderings matter and they are deliberately different. ``_accumulate`` runs the checks in
+the order the shipped code ran them, which is what makes the wrapper's first-error message
+defined rather than incidental. ``collect_findings`` re-orders the same list into the stable
+cross-interface order and bounds it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from hashlib import blake2b
+from typing import TYPE_CHECKING, Any, Literal, cast
+from urllib.parse import urlsplit
+
+from pydantic import ValidationError
+
+from .capabilities import BUILTIN_ADAPTER_CAPABILITIES
+from .credentials import (
+    _ENV_IDENTIFIER,
+    _STORE_CAPABILITIES,
+    _TRUNCATION_MARKER,
+    CredentialConfigurationError,
+    _bounded_component,
+    _bounded_location,
+    _render_setting_name_list,
+)
+from .models import (
+    _MAX_FINDING_TEXT_LENGTH,
+    ConfigurationPackage,
+    CredentialReferenceNode,
+    ValidationFinding,
+    safe_pointer_component,
+    sort_findings,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from .capabilities import AdapterConfigurationCapabilities, AdapterRole
+
+# Absolute settings name where to connect; relative ones name a path beneath it. Applying one
+# rule to both would refuse every legitimate relative endpoint.
+_ABSOLUTE_URL_SETTING_NAMES = frozenset({"base_url", "url"})
+_RELATIVE_PATH_SETTING_NAMES = frozenset({"api_endpoint", "endpoint"})
+_URL_SETTING_NAMES = _ABSOLUTE_URL_SETTING_NAMES | _RELATIVE_PATH_SETTING_NAMES
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+# Matching models.py's own family of caps. A package with more findings than this is
+# pathological, so bounding the work is not worth making the reported set depend on the
+# order the defects were declared in.
+_MAX_REPORTED_FINDINGS = 256
+
+_CODE_ADAPTER_ROLE_MISMATCH = "adapter-role-mismatch"
+_CODE_ADAPTER_VALIDATOR_FINDING = "adapter-validator-finding"
+_CODE_CREDENTIAL_PATH_NOT_DECLARED = "credential-path-not-declared"
+_CODE_ENDPOINT_NOT_ABSOLUTE = "endpoint-not-absolute"
+_CODE_ENDPOINT_NOT_RELATIVE = "endpoint-not-relative"
+_CODE_FINDING_LIMIT_REACHED = "finding-limit-reached"
+_CODE_INLINE_CREDENTIAL_VALUE = "inline-credential-value"
+_CODE_MALFORMED_CREDENTIAL_REFERENCE = "malformed-credential-reference"
+_CODE_MISSING_ADAPTER = "missing-adapter"
+_CODE_MISSING_STORE_CAPABILITIES = "missing-store-capabilities"
+_CODE_SETTING_CONTAINS_CREDENTIAL_MATERIAL = "setting-contains-credential-material"
+_CODE_SETTING_NOT_A_STRING = "setting-not-a-string"
+_CODE_UNDECLARED_SETTING = "undeclared-setting"
+_CODE_UNKNOWN_CREDENTIAL_PROVIDER = "unknown-credential-provider"
+_CODE_UNKNOWN_CREDENTIAL_REFERENCE = "unknown-credential-reference"
+
+# "~2" marks a truncated diagnostic pointer, and the finding pointer grammar refuses it: a "~"
+# there must introduce "~0" or "~1". This marker is legal and, in a finding as the core emits
+# one, unforgeable: safe_pointer_component escapes only unprintable characters into the
+# "\uXXXX" form and U+2026 is printable, so a declared key can never render as one.
+#
+# That holds as far as redaction and no further. redact_pointer decodes every component and
+# re-encodes it, and the decoder reads "\u2026" as an escape and writes the single printable
+# character back, so a redacted pointer carries a literal "…" where this marker was — which a
+# declared key containing "…" also renders as. Both interfaces redact through that one
+# function, so they agree with each other. Nothing collides, because the redaction tag carries
+# its own digest; what is lost is that in a *redacted* pointer the marker is a hint that the
+# pointer was truncated rather than proof of it.
+_LOCATION_TRUNCATION_MARKER = r"\u2026"
+# Truncation is lossy at two bounds — a declared key past 64 characters and the whole pointer
+# past 256 — so two different defects can otherwise arrive as one byte-identical finding twice.
+# The digest is taken over the untruncated pointer, so distinct pointers stay distinct and the
+# operator can still tell two findings apart. Hex only: the pointer grammar refuses "~" and "/".
+_LOCATION_DIGEST_LENGTH = 8
+
+
+# The checks whose findings the location-precedence rule arbitrates between. A role's own name
+# is the check identity for everything judged against that role's declared surface, including
+# its adapter-owned validator, so two problems that role reports at one pointer both survive.
+_CHECK_CREDENTIALS = "credentials"
+_CHECK_STORE = "store"
+_CHECK_WALK = "walk"
+
+# Where an adapter-owned validator has standing to report. Its own role's subtree, plus the
+# package content that belongs to no role: a schema mapping is declared once for the package
+# and the shipped genericrestapi validator legitimately reports at it under either role.
+_ROLE_INDEPENDENT_VALIDATOR_PREFIXES = ("/configuration/schema_mapping",)
+
+
+@dataclass(frozen=True, slots=True)
+class _AccumulatedFinding:
+    """One finding, the message the raise-first code produced for its site, and its check."""
+
+    finding: ValidationFinding
+    legacy_message: str
+    check: str = ""
+
+
+def _from_check(check: str, accumulated: list[_AccumulatedFinding]) -> list[_AccumulatedFinding]:
+    """Name the check one group of findings came from, which is what precedence is decided on."""
+    return [replace(item, check=check) for item in accumulated]
+
+
+def _unbounded_component(name: object) -> str:
+    """Escape one declared key for a pointer, with no length bound and so no information lost."""
+    return safe_pointer_component(str(name))
+
+
+def _location_digest(unbounded_location: str) -> str:
+    """Return the short tag that keeps two truncated pointers distinguishable."""
+    digest = blake2b(unbounded_location.encode(), digest_size=_LOCATION_DIGEST_LENGTH // 2)
+    return digest.hexdigest()
+
+
+def _marked_location(pointer: str, digested: str) -> str:
+    """Tag one pointer a lossy transform rewrote, so it cannot collide with another pointer.
+
+    ``digested`` is what the pointer looked like before the transform dropped anything. The
+    marker keeps the tag unforgeable and the digest keeps two pointers the transform mapped
+    together apart; the result is re-cut to the field bound because the tag is appended to it.
+    """
+    suffix = _LOCATION_TRUNCATION_MARKER + _location_digest(digested)
+    cut = pointer[: _MAX_FINDING_TEXT_LENGTH - len(suffix)]
+    # A cut can land inside an escape pair and leave a trailing "~", which the grammar refuses.
+    return cut.rstrip("~") + suffix
+
+
+def _finding_location(location: str, unbounded_location: str | None = None) -> str:
+    """Return one diagnostic pointer in the exact form ``ValidationFinding.location`` accepts.
+
+    ``unbounded_location`` is the same pointer built without either length bound. It is only
+    read when the pointer was actually truncated, and only to digest.
+    """
+    safe = location.replace(_TRUNCATION_MARKER, _LOCATION_TRUNCATION_MARKER)
+    # "~2" survives escaping only as a truncation marker, so its presence means a declared key
+    # was cut; an over-long pointer is the other bound. Either way information was dropped.
+    if _TRUNCATION_MARKER not in location and len(safe) <= _MAX_FINDING_TEXT_LENGTH:
+        return safe
+    return _marked_location(safe, location if unbounded_location is None else unbounded_location)
+
+
+def _finding(*, code: str, severity: Literal["error"], location: str, message: str) -> ValidationFinding:
+    """Build one finding whose stored pointer is still the pointer that was built.
+
+    ``ValidationFinding`` normalizes what it stores — ``str_strip_whitespace`` trims a pointer
+    whose last declared component ends in a space, and U+0020 is printable, so
+    ``safe_pointer_component`` passes it through for the model to drop afterwards. That is a
+    third lossy transform on a pointer alongside the two length bounds and redaction, and it
+    obeys the same rule: no lossy transform may map two distinct pointers onto one. Left
+    unmarked it deletes a finding outright, because ``_one_check_per_location`` then reads the
+    two as one ``(code, location)`` pair.
+
+    The check is the comparison rather than an escape for the space, so it holds for every
+    normalization the model may grow, not only the one that bites today.
+    """
+    finding = ValidationFinding(code=code, severity=severity, location=location, message=message)
+    if finding.location == location:
+        return finding
+    return ValidationFinding(
+        code=code,
+        severity=severity,
+        # Marked from what the model stored, so the second construction is a fixed point.
+        location=_marked_location(finding.location, location),
+        message=message,
+    )
+
+
+def _finding_message(message: str) -> str:
+    """Bound one finding message the way models.py bounds the text it renders."""
+    if len(message) <= _MAX_FINDING_TEXT_LENGTH:
+        return message
+    return message[: _MAX_FINDING_TEXT_LENGTH - len(_TRUNCATION_MARKER)] + _TRUNCATION_MARKER
+
+
+def _accumulated(
+    *,
+    code: str,
+    location: str,
+    message: str,
+    legacy_message: str | None = None,
+    unbounded_location: str | None = None,
+) -> _AccumulatedFinding:
+    """Build one error finding, carrying the shipped message when it differs from the finding's."""
+    return _AccumulatedFinding(
+        finding=_finding(
+            code=code,
+            severity="error",
+            location=_finding_location(location, unbounded_location),
+            message=_finding_message(message),
+        ),
+        legacy_message=message if legacy_message is None else legacy_message,
+    )
+
+
+def _setting_at_path(settings: Mapping[str, object], path: str) -> tuple[bool, object | None]:
+    current: object = settings
+    for component in path.split("."):
+        if not isinstance(current, Mapping) or component not in current:
+            return False, None
+        current = cast("Mapping[str, object]", current)[component]
+    return True, current
+
+
+def _settings_pointer(prefix: str, path: str) -> str:
+    """Build one settings pointer the same way the declared-content walk builds it.
+
+    The only place a declared setting path becomes a pointer. An owned location and the walk
+    must produce byte-identical strings, or a reference is accepted by one check and refused
+    by the next; a second formatter is how that divergence gets reintroduced.
+    """
+    return prefix + "".join(f"/{_bounded_component(component)}" for component in path.split("."))
+
+
+def _accumulate_reference_declarations(package: ConfigurationPackage) -> list[_AccumulatedFinding]:
+    """Validate provider names and identifiers without resolving credential values."""
+    accumulated: list[_AccumulatedFinding] = []
+    # Insertion order, not sorted: it decides which defect the wrapper reports.
+    for name, reference in package.credentials.items():
+        location = f"/credentials/{_bounded_component(name)}"
+        unbounded = f"/credentials/{_unbounded_component(name)}"
+        if reference.provider != "env":
+            accumulated.append(
+                _accumulated(
+                    code=_CODE_UNKNOWN_CREDENTIAL_PROVIDER,
+                    location=location,
+                    unbounded_location=unbounded,
+                    message=(
+                        f"credential reference {name!r} uses provider {reference.provider!r}, which is not installed"
+                    ),
+                )
+            )
+        if _ENV_IDENTIFIER.fullmatch(reference.identifier) is None:
+            accumulated.append(
+                _accumulated(
+                    code=_CODE_MALFORMED_CREDENTIAL_REFERENCE,
+                    location=location,
+                    unbounded_location=unbounded,
+                    message=f"credential reference {name!r} has an invalid environment identifier",
+                )
+            )
+    return accumulated
+
+
+def _accumulate_undeclared_settings(
+    *,
+    settings: Mapping[str, object],
+    allowed_settings: frozenset[str],
+    prefix: str,
+    render: Callable[[Iterable[str]], str],
+    owned_locations: list[str],
+) -> list[_AccumulatedFinding]:
+    """Report one finding per undeclared name, so N undeclared settings give N findings.
+
+    A name the surface does not declare is condemned whole: this check owns that setting and
+    everything under it. A name the surface does declare is not owned here, because judging
+    the name says nothing about the value.
+    """
+    unsupported = set(settings) - allowed_settings
+    if not unsupported:
+        return []
+    # The shipped code rendered the whole group into one message; that message stays the
+    # wrapper's, and each name gets its own finding and its own pointer.
+    legacy_message = render(unsupported)
+    accumulated: list[_AccumulatedFinding] = []
+    for name in sorted(unsupported):
+        location = f"{prefix}/{_bounded_component(name)}"
+        owned_locations.append(location)
+        accumulated.append(
+            _accumulated(
+                code=_CODE_UNDECLARED_SETTING,
+                location=location,
+                unbounded_location=f"{prefix}/{_unbounded_component(name)}",
+                message=render({name}),
+                legacy_message=legacy_message,
+            )
+        )
+    return accumulated
+
+
+def _accumulate_reference_node(
+    package: ConfigurationPackage,
+    value: object,
+    *,
+    location: str,
+) -> list[_AccumulatedFinding]:
+    """Validate one node at a declared credential-bearing setting path."""
+    if not isinstance(value, Mapping) or "$credential" not in value:
+        return [
+            _accumulated(
+                code=_CODE_INLINE_CREDENTIAL_VALUE,
+                location=location,
+                message=f"{location} contains an inline credential value",
+            )
+        ]
+    try:
+        node = CredentialReferenceNode.model_validate(value)
+    except ValidationError:
+        return [
+            _accumulated(
+                code=_CODE_MALFORMED_CREDENTIAL_REFERENCE,
+                location=location,
+                message=f"{location} contains a malformed credential reference",
+            )
+        ]
+    if node.reference_name not in package.credentials:
+        return [
+            _accumulated(
+                code=_CODE_UNKNOWN_CREDENTIAL_REFERENCE,
+                location=location,
+                message=f"{location} names unknown credential reference {node.reference_name!r}",
+            )
+        ]
+    return []
+
+
+def _accumulate_credential_paths(
+    package: ConfigurationPackage,
+    settings: Mapping[str, object],
+    paths: tuple[str, ...],
+    prefix: str,
+    owned_locations: list[str],
+) -> list[_AccumulatedFinding]:
+    """Judge every declared credential-bearing path present in these settings, and own it."""
+    accumulated: list[_AccumulatedFinding] = []
+    for path in paths:
+        present, value = _setting_at_path(settings, path)
+        if not present or value is None:
+            continue
+        location = _settings_pointer(prefix, path)
+        owned_locations.append(location)
+        accumulated.extend(_accumulate_reference_node(package, value, location=location))
+    return accumulated
+
+
+def _accumulate_url_setting(value: object, *, setting_name: str, location: str) -> list[_AccumulatedFinding]:
+    """Prove one declared endpoint setting carries no credential material and no scheme surprise."""
+    if not isinstance(value, str):
+        return [
+            _accumulated(
+                code=_CODE_SETTING_NOT_A_STRING,
+                location=location,
+                message=f"{location} must be declared as a string",
+            )
+        ]
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        parsed = None
+    if parsed is None or parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        return [
+            _accumulated(
+                code=_CODE_SETTING_CONTAINS_CREDENTIAL_MATERIAL,
+                location=location,
+                message=f"{location} cannot contain user information, query parameters, or fragments",
+            )
+        ]
+    if setting_name in _ABSOLUTE_URL_SETTING_NAMES:
+        if parsed.scheme not in _ALLOWED_URL_SCHEMES or not parsed.netloc:
+            return [
+                _accumulated(
+                    code=_CODE_ENDPOINT_NOT_ABSOLUTE,
+                    location=location,
+                    message=f"{location} must be an absolute http or https URL",
+                )
+            ]
+    elif parsed.scheme or parsed.netloc:
+        return [
+            _accumulated(
+                code=_CODE_ENDPOINT_NOT_RELATIVE,
+                location=location,
+                message=f"{location} must be a relative request path without a scheme or authority",
+            )
+        ]
+    return []
+
+
+def _is_finding_sequence(result: object) -> bool:
+    """Return whether a validator returned findings. A str is a Sequence and is not findings."""
+    if isinstance(result, (str, bytes)) or not isinstance(result, Sequence):
+        return False
+    return all(isinstance(item, ValidationFinding) for item in result)
+
+
+def _revalidated_finding(item: ValidationFinding) -> ValidationFinding:
+    """Rebuild one adapter-returned finding under the contract the core holds itself to.
+
+    ``model_construct`` runs no field validator, so an object can satisfy
+    ``isinstance(item, ValidationFinding)`` while carrying a severity outside the declared
+    vocabulary, a non-string location, or text past the bound. Full model validation is what
+    judges that, and the location and message go through the same bounds a core finding does.
+    Anything unusable raises, and the caller contains it.
+    """
+    validated = ValidationFinding.model_validate(item.model_dump())
+    if not (validated.location + validated.message).isprintable():
+        # The core escapes an unprintable declared key rather than passing it through, so an
+        # adapter may not put a raw control character into operator-facing text either.
+        msg = "adapter finding carries an unprintable character"
+        raise ValueError(msg)
+    return _finding(
+        code=validated.code,
+        severity=validated.severity,
+        location=_finding_location(validated.location),
+        message=_finding_message(validated.message),
+    )
+
+
+def _contained_validator_failure(
+    adapter_name: str,
+    *,
+    role: AdapterRole,
+    detail: str,
+) -> _AccumulatedFinding:
+    """Report a validator that failed, without carrying anything the validator said."""
+    return _accumulated(
+        code=_CODE_ADAPTER_VALIDATOR_FINDING,
+        location=f"/configuration/{role}",
+        message=f"adapter {adapter_name!r} configuration validator {detail} for the {role} role",
+    )
+
+
+def _accumulate_adapter_validator(
+    package: ConfigurationPackage,
+    capabilities: AdapterConfigurationCapabilities,
+    *,
+    role: AdapterRole,
+) -> list[_AccumulatedFinding]:
+    """Run one adapter-owned validator, keeping its own codes and locations."""
+    validator = capabilities.validator
+    if validator is None:
+        return []
+    # Everything the validator can influence stays inside one contained block. Its shape check
+    # iterates the returned object and an isinstance against an ABC can invoke a hostile
+    # __instancecheck__; sorting and joining read fields model_construct never validated. Move
+    # work into this block rather than out of it.
+    #
+    # "Everything" means every ordinary failure. SystemExit and KeyboardInterrupt derive from
+    # BaseException and are deliberately not caught: a validator that calls sys.exit or an
+    # operator pressing Ctrl-C ends the process, and turning either into one contained finding
+    # would be worse than the containment is worth.
+    detail = "failed"
+    try:
+        result = validator(package, role)
+        # Past the call, anything that goes wrong is about what came back, not about the run.
+        detail = "returned an unsupported result"
+        if not _is_finding_sequence(result):
+            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+        findings = sort_findings([_revalidated_finding(item) for item in result])
+        permitted = (f"/configuration/{role}", *_ROLE_INDEPENDENT_VALIDATOR_PREFIXES)
+        if not all(_is_within(item.location, permitted) for item in findings):
+            # An adapter owns its own role's declared surface and nothing else. Location
+            # precedence accepts the first check to report at a pointer, so a finding placed
+            # in the other role's subtree, the store's, or the credential declarations would
+            # delete the core's own finding there — including a credential-safety one. That
+            # is not precedence being wrong; it is a finding with no standing at that pointer.
+            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+        legacy_message = "; ".join(f"{_bounded_location(item.location)}: {item.message}" for item in findings)
+    # A third-party validator may raise anything at all; containing it is the contract.
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+    # One adapter can serve both roles, and a validator that cannot tell them apart reports the
+    # same package-level defect twice. Which of the two survives is decided at the presentation
+    # boundary, never here: the wrapper's message is element zero of this list.
+    return [_AccumulatedFinding(finding=item, legacy_message=legacy_message) for item in findings]
+
+
+def _accumulate_adapter(
+    package: ConfigurationPackage,
+    capabilities: AdapterConfigurationCapabilities,
+    *,
+    role: AdapterRole,
+    settings: Mapping[str, object],
+    owned_locations: list[str],
+) -> list[_AccumulatedFinding]:
+    """Run every check a declared adapter surface supports, in the shipped order."""
+    accumulated: list[_AccumulatedFinding] = []
+    if role not in capabilities.roles:
+        accumulated.append(
+            _accumulated(
+                code=_CODE_ADAPTER_ROLE_MISMATCH,
+                location=f"/configuration/{role}",
+                message=f"adapter {capabilities.adapter_name!r} does not support the {role} role",
+            )
+        )
+    prefix = f"/configuration/{role}/settings"
+    accumulated.extend(
+        _accumulate_undeclared_settings(
+            settings=settings,
+            allowed_settings=capabilities.allowed_settings,
+            prefix=prefix,
+            render=lambda names: (
+                f"adapter {capabilities.adapter_name!r} contains unsupported declared settings "
+                f"for the {role} role: {_render_setting_name_list(names)}"
+            ),
+            owned_locations=owned_locations,
+        )
+    )
+    for setting_name in sorted(capabilities.allowed_settings & _URL_SETTING_NAMES):
+        value = settings.get(setting_name)
+        if value is None:
+            continue
+        location = _settings_pointer(prefix, setting_name)
+        owned_locations.append(location)
+        accumulated.extend(_accumulate_url_setting(value, setting_name=setting_name, location=location))
+    accumulated.extend(_accumulate_adapter_validator(package, capabilities, role=role))
+    paths = capabilities.credential_setting_paths
+    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations))
+    return accumulated
+
+
+def _accumulate_store(package: ConfigurationPackage, owned_locations: list[str]) -> list[_AccumulatedFinding]:
+    """Refuse inline values and undeclared names at the declared store surface."""
+    store = package.configuration.store
+    if store is None:
+        return []
+    settings = store.settings or {}
+    capabilities = _STORE_CAPABILITIES.get(store.type)
+    if capabilities is None:
+        if not settings:
+            # An undeclared store type carrying nothing declares nothing unsafe. Shipped
+            # behaviour, preserved deliberately.
+            return []
+        # Settings cannot be judged against a surface that does not exist. Whether one of them
+        # is credential-bearing is precisely what an undeclared store type makes unknowable,
+        # so the store reports exactly one finding, the same way a missing adapter does.
+        owned_locations.append("/configuration/store/settings")
+        return [
+            _accumulated(
+                code=_CODE_MISSING_STORE_CAPABILITIES,
+                location="/configuration/store",
+                message=f"store type {store.type!r} has no configuration capability declaration",
+            )
+        ]
+    prefix = "/configuration/store/settings"
+    accumulated = _accumulate_undeclared_settings(
+        settings=settings,
+        allowed_settings=capabilities.allowed_settings,
+        prefix=prefix,
+        render=lambda names: (
+            f"store type {store.type!r} contains unsupported declared settings: {_render_setting_name_list(names)}"
+        ),
+        owned_locations=owned_locations,
+    )
+    paths = capabilities.credential_setting_paths
+    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations))
+    return accumulated
+
+
+def _is_within(location: str, prefixes: tuple[str, ...]) -> bool:
+    """Return whether one pointer is one of `prefixes` or sits beneath one of them."""
+    return any(location == prefix or location.startswith(f"{prefix}/") for prefix in prefixes)
+
+
+def _accumulate_reference_nodes(
+    value: object,
+    *,
+    location: str,
+    unbounded_location: str,
+    owned_locations: tuple[str, ...],
+    accumulated: list[_AccumulatedFinding],
+) -> None:
+    """Report every use of the reserved ``$credential`` key no surface check has authority over.
+
+    A surface check owns the setting it judged and everything beneath it, so a node under an
+    owned pointer belongs to a defect that check already reported — or sits in a subtree no
+    surface exists to judge. Reporting it here would give one defect a second, vaguer finding
+    at a deeper pointer.
+    """
+    # The one question, asked once per node. Pruning here rather than at the "$credential"
+    # test below is the same answer: every descendant of an owned pointer is within it too.
+    if _is_within(location, owned_locations):
+        return
+    if isinstance(value, Mapping):
+        if "$credential" in value:
+            accumulated.append(
+                _accumulated(
+                    code=_CODE_CREDENTIAL_PATH_NOT_DECLARED,
+                    location=location,
+                    unbounded_location=unbounded_location,
+                    message=f"{_bounded_location(location)} is not a credential-bearing setting",
+                )
+            )
+            return
+        # Insertion order, not sorted: it decides which defect the wrapper reports.
+        for key, item in value.items():
+            _accumulate_reference_nodes(
+                item,
+                location=f"{location}/{_bounded_component(key)}",
+                unbounded_location=f"{unbounded_location}/{_unbounded_component(key)}",
+                owned_locations=owned_locations,
+                accumulated=accumulated,
+            )
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _accumulate_reference_nodes(
+                item,
+                location=f"{location}/{index}",
+                unbounded_location=f"{unbounded_location}/{index}",
+                owned_locations=owned_locations,
+                accumulated=accumulated,
+            )
+
+
+def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...]:
+    """Run every check in the shipped execution order, never raising for a declared defect."""
+    accumulated: list[_AccumulatedFinding] = []
+    # Every pointer a surface check has authority over. A check appends the setting it judged,
+    # and a surface that turns out not to exist appends its whole settings subtree — the case
+    # where a check could not judge. The walk below reports nowhere within them.
+    owned_locations: list[str] = []
+    accumulated.extend(_from_check(_CHECK_CREDENTIALS, _accumulate_reference_declarations(package)))
+    accumulated.extend(_from_check(_CHECK_STORE, _accumulate_store(package, owned_locations)))
+    source = package.configuration.source
+    destination = package.configuration.destination
+    source_capabilities = BUILTIN_ADAPTER_CAPABILITIES.get(source.name)
+    destination_capabilities = BUILTIN_ADAPTER_CAPABILITIES.get(destination.name)
+    roles: tuple[tuple[AdapterRole, Any, AdapterConfigurationCapabilities | None], ...] = (
+        ("source", source, source_capabilities),
+        ("destination", destination, destination_capabilities),
+    )
+    for role, adapter, capabilities in roles:
+        if capabilities is None:
+            # Settings cannot be judged against a surface that does not exist, so this role
+            # reports exactly one finding and the rest of the package is unaffected.
+            accumulated.extend(
+                _from_check(
+                    role,
+                    [
+                        _accumulated(
+                            code=_CODE_MISSING_ADAPTER,
+                            location=f"/configuration/{role}",
+                            message=f"adapter {adapter.name!r} has no configuration capability declaration",
+                        )
+                    ],
+                )
+            )
+            owned_locations.append(f"/configuration/{role}/settings")
+            continue
+        accumulated.extend(
+            _from_check(
+                role,
+                _accumulate_adapter(
+                    package,
+                    capabilities,
+                    role=role,
+                    settings=adapter.settings or {},
+                    owned_locations=owned_locations,
+                ),
+            )
+        )
+    # Last: the surface checks above give a more precise reason for a node on an unsupported
+    # setting than "not credential-bearing" would.
+    walked: list[_AccumulatedFinding] = []
+    _accumulate_reference_nodes(
+        package.declared_content(),
+        location="",
+        unbounded_location="",
+        owned_locations=tuple(owned_locations),
+        accumulated=walked,
+    )
+    accumulated.extend(_from_check(_CHECK_WALK, walked))
+    return tuple(accumulated)
+
+
+def _one_check_per_location(accumulated: tuple[_AccumulatedFinding, ...]) -> list[ValidationFinding]:
+    """Keep, at each location, only what the first check to report there said.
+
+    At any one location one check is authoritative: a later check does not add a second finding
+    where an earlier one already reported, and no code repeats at a location. Execution order
+    decides which check that is. This runs at the presentation boundary and nowhere else — the
+    wrapper reads the untouched accumulation, so its compatibility message cannot depend on it.
+    """
+    owner: dict[str, str] = {}
+    seen: set[tuple[str, str]] = set()
+    kept: list[ValidationFinding] = []
+    for item in accumulated:
+        finding = item.finding
+        key = (finding.code, finding.location)
+        if key in seen or owner.setdefault(finding.location, item.check) != item.check:
+            continue
+        seen.add(key)
+        kept.append(finding)
+    return kept
+
+
+def collect_findings(package: ConfigurationPackage) -> tuple[ValidationFinding, ...]:
+    """Return every declared defect as a finding, in the stable cross-interface order.
+
+    Bounded at 256. Accumulation itself never stops early, because truncating in execution
+    order would make the surviving findings depend on the order the defects were declared in;
+    the cut happens after the sort instead. When it fires, one ``finding-limit-reached``
+    finding goes in its own sort position, which is first — its location is the empty pointer
+    and every real pointer begins with "/" — so the suppression is reported at the top rather
+    than buried at the end.
+    """
+    # sort_findings orders by (location, severity, code), and _one_check_per_location has
+    # already made (code, location) unique, so no two findings can tie there. Uniqueness is
+    # structural, which is why nothing breaks a tie before the cut below.
+    findings = sort_findings(_one_check_per_location(_accumulate(package)))
+    if len(findings) <= _MAX_REPORTED_FINDINGS:
+        return findings
+    suppressed = len(findings) - _MAX_REPORTED_FINDINGS
+    limit_reached = ValidationFinding(
+        code=_CODE_FINDING_LIMIT_REACHED,
+        severity="error",
+        location="",
+        message=f"{suppressed} further findings were not reported",
+    )
+    return sort_findings([limit_reached, *findings[:_MAX_REPORTED_FINDINGS]])
+
+
+def validate_package_credentials(package: ConfigurationPackage) -> None:
+    """Prove bundled adapter settings contain references rather than credential values."""
+    accumulated = _accumulate(package)
+    if accumulated:
+        # Element zero of the untruncated, execution-ordered accumulation: the defect the
+        # raise-first code reported, so the message is the one it produced.
+        raise CredentialConfigurationError(accumulated[0].legacy_message)

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -736,12 +736,18 @@ def collect_findings(package: ConfigurationPackage) -> tuple[ValidationFinding, 
     findings = sort_findings(_one_check_per_location(_accumulate(package)))
     if len(findings) <= _MAX_REPORTED_FINDINGS:
         return findings
-    suppressed = len(findings) - _MAX_REPORTED_FINDINGS
+    suppressed = findings[_MAX_REPORTED_FINDINGS:]
+    # The maximum severity among the *suppressed* findings: a suppressed error must not
+    # leave the presentation error-free, and warnings-only suppression must not turn an
+    # error-free package into a refused one.
+    sentinel_severity: Literal["error", "warning"] = (
+        "error" if any(item.severity == "error" for item in suppressed) else "warning"
+    )
     limit_reached = ValidationFinding(
         code=_CODE_FINDING_LIMIT_REACHED,
-        severity="error",
+        severity=sentinel_severity,
         location="",
-        message=f"{suppressed} further findings were not reported",
+        message=f"{len(suppressed)} further findings were not reported",
     )
     return sort_findings([limit_reached, *findings[:_MAX_REPORTED_FINDINGS]])
 

--- a/infrahub_sync/configuration/warnings.py
+++ b/infrahub_sync/configuration/warnings.py
@@ -1,0 +1,92 @@
+"""Contract section 4 warning families over one declared configuration package.
+
+The declared-content core (``validation.py``) emits errors only and its frozen code
+enumeration stays untouched; this module owns the warning channel's finding codes and
+their emission, mirroring the schema module's separation. The emission rule is closed:
+warnings are limited to intentional omissions and explicitly unqualified optional
+features, and nothing else — an adapter-returned warning is contained at the core's
+revalidation boundary, and a missing capability needed to determine safety stays an
+error, never a warning.
+
+The one family here today is the declared omission: one ``intentional-omission`` warning
+per ``omissions`` entry, at the declaration itself, so the validation report states
+declared intent rather than silence. An omission that names content a schema mapping
+also maps is a package defect, not a preference — the ``omission-contradicts-mapping``
+**error** replaces the warning at that location, which keeps the omissions section from
+silently rotting as mappings evolve.
+
+Messages are fixed templates. The only declared content that reaches one is the omission
+``reason``, verbatim: its model bound keeps template plus reason inside the finding-text
+limit, so nothing here needs the core's message truncation. Locations are fixed literals
+and list indices, never declared keys, so nothing here needs the core's pointer bounding
+either.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .models import ConfigurationPackage, ValidationFinding
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .models import _OmissionDeclaration
+
+_CODE_INTENTIONAL_OMISSION = "intentional-omission"
+_CODE_OMISSION_CONTRADICTS_MAPPING = "omission-contradicts-mapping"
+
+_OMISSION_MESSAGE = "declared content is intentionally omitted from synchronization"
+_CONTRADICTION_MESSAGE = "omission names content a schema mapping also maps"
+
+
+def _mapped_field_names(package: ConfigurationPackage) -> dict[str, frozenset[str]]:
+    """Return every mapped kind with the field names its mapping entries declare."""
+    mapped: dict[str, set[str]] = {}
+    for mapping in package.configuration.schema_mapping:
+        field_names = mapped.setdefault(mapping.name, set())
+        field_names.update(field.name for field in mapping.fields)
+    return {kind: frozenset(field_names) for kind, field_names in mapped.items()}
+
+
+def _contradicts(omission: _OmissionDeclaration, mapped: Mapping[str, frozenset[str]]) -> bool:
+    """Return whether one omission names content a schema mapping also maps."""
+    mapped_fields = mapped.get(omission.kind)
+    if mapped_fields is None:
+        return False
+    if omission.fields is None:
+        # The whole kind is declared omitted, and a mapping maps that kind.
+        return True
+    return any(field_name in mapped_fields for field_name in omission.fields)
+
+
+def accumulate_intentional_omissions(package: ConfigurationPackage) -> tuple[ValidationFinding, ...]:
+    """Report each declared omission at its declaration: a warning, or the contradiction error.
+
+    Declaration order, matching the core's insertion-order rule: when a contradiction is
+    the first error in execution order, its position here decides what the wrapper raises.
+    """
+    mapped = _mapped_field_names(package)
+    findings: list[ValidationFinding] = []
+    for index, omission in enumerate(package.omissions):
+        location = f"/omissions/{index}"
+        if _contradicts(omission, mapped):
+            findings.append(
+                ValidationFinding(
+                    code=_CODE_OMISSION_CONTRADICTS_MAPPING,
+                    severity="error",
+                    location=location,
+                    message=_CONTRADICTION_MESSAGE,
+                )
+            )
+            continue
+        message = _OMISSION_MESSAGE if omission.reason is None else f"{_OMISSION_MESSAGE}: {omission.reason}"
+        findings.append(
+            ValidationFinding(
+                code=_CODE_INTENTIONAL_OMISSION,
+                severity="warning",
+                location=location,
+                message=message,
+            )
+        )
+    return tuple(findings)

--- a/infrahub_sync/configuration/warnings.py
+++ b/infrahub_sync/configuration/warnings.py
@@ -8,12 +8,19 @@ features, and nothing else — an adapter-returned warning is contained at the c
 revalidation boundary, and a missing capability needed to determine safety stays an
 error, never a warning.
 
-The one family here today is the declared omission: one ``intentional-omission`` warning
-per ``omissions`` entry, at the declaration itself, so the validation report states
-declared intent rather than silence. An omission that names content a schema mapping
-also maps is a package defect, not a preference — the ``omission-contradicts-mapping``
-**error** replaces the warning at that location, which keeps the omissions section from
-silently rotting as mappings evolve.
+The declared-omission family: one ``intentional-omission`` warning per ``omissions``
+entry, at the declaration itself, so the validation report states declared intent rather
+than silence. An omission that names content a schema mapping also maps is a package
+defect, not a preference — the ``omission-contradicts-mapping`` **error** replaces the
+warning at that location, which keeps the omissions section from silently rotting as
+mappings evolve.
+
+The unqualified-optional-feature family: a package declaring the optional ``incremental``
+feature against a source whose capability declaration does not qualify it silently runs
+full extraction, and ``optional-feature-unqualified`` names that declaration. A source
+with no capability declaration at all stays the core's own error — a missing capability
+needed to determine safety is an error, not a warning — so this family reports nothing
+where that error already owns the role.
 
 Messages are fixed templates. The only declared content that reaches one is the omission
 ``reason``, verbatim: its model bound keeps template plus reason inside the finding-text
@@ -26,6 +33,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .capabilities import BUILTIN_ADAPTER_CAPABILITIES
 from .models import ConfigurationPackage, ValidationFinding
 
 if TYPE_CHECKING:
@@ -35,9 +43,13 @@ if TYPE_CHECKING:
 
 _CODE_INTENTIONAL_OMISSION = "intentional-omission"
 _CODE_OMISSION_CONTRADICTS_MAPPING = "omission-contradicts-mapping"
+_CODE_OPTIONAL_FEATURE_UNQUALIFIED = "optional-feature-unqualified"
 
 _OMISSION_MESSAGE = "declared content is intentionally omitted from synchronization"
 _CONTRADICTION_MESSAGE = "omission names content a schema mapping also maps"
+_UNQUALIFIED_INCREMENTAL_MESSAGE = (
+    "incremental extraction is declared, but the source adapter does not declare support for it"
+)
 
 
 def _mapped_field_names(package: ConfigurationPackage) -> dict[str, frozenset[str]]:
@@ -90,3 +102,25 @@ def accumulate_intentional_omissions(package: ConfigurationPackage) -> tuple[Val
             )
         )
     return tuple(findings)
+
+
+def accumulate_unqualified_optional_features(package: ConfigurationPackage) -> tuple[ValidationFinding, ...]:
+    """Warn where a declared optional feature has no capability that qualifies it.
+
+    One optional feature exists today: ``incremental``. A source adapter with no
+    capability declaration reports nothing here — the core's missing-adapter error owns
+    that role and its subtree is unevaluable.
+    """
+    if package.configuration.incremental is None:
+        return ()
+    capabilities = BUILTIN_ADAPTER_CAPABILITIES.get(package.configuration.source.name)
+    if capabilities is None or capabilities.incremental_extraction:
+        return ()
+    return (
+        ValidationFinding(
+            code=_CODE_OPTIONAL_FEATURE_UNQUALIFIED,
+            severity="warning",
+            location="/configuration/incremental",
+            message=_UNQUALIFIED_INCREMENTAL_MESSAGE,
+        ),
+    )

--- a/infrahub_sync/potenda/__init__.py
+++ b/infrahub_sync/potenda/__init__.py
@@ -4,8 +4,6 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, cast
 
-from diffsync.enum import DiffSyncFlags
-
 # The destination SDK's error base, imported for the apply path's exception boundary below and
 # for nothing else. It is the one module-level import here that is not cheap, and it is
 # unavoidable: the boundary has to *name* the library whose rejections are operational, and
@@ -20,7 +18,7 @@ from infrahub_sdk.exceptions import (
 )
 from tqdm import tqdm
 
-from infrahub_sync import IncrementalConfig
+from infrahub_sync import IncrementalConfig, resolve_effective_diffsync_flags
 
 # Imported at module level, unlike this module's other `infrahub_sync` imports: these four
 # pull nothing beyond pydantic and the standard library — the write-surface protocol pulls
@@ -80,6 +78,7 @@ if TYPE_CHECKING:
 
     from diffsync import Adapter
     from diffsync.diff import Diff
+    from diffsync.enum import DiffSyncFlags
 
     from infrahub_sync import SyncInstance
     from infrahub_sync.plan.models import PlanManifest, VerificationFailure
@@ -194,16 +193,12 @@ class Potenda:
         if verbosity is not None:
             logging.getLogger("diffsync").setLevel(verbosity)
 
-        # Combine DiffSyncFlags from the configuration. `config` is typed as
-        # SyncInstance but tests pass None — guard explicitly.
-        self.flags: DiffSyncFlags = DiffSyncFlags.NONE
-        if self.config is not None:
-            for flag in self.config.diffsync_flags or []:
-                self.flags |= flag if isinstance(flag, DiffSyncFlags) else DiffSyncFlags[flag]
-
-        # Fallback to `SKIP_UNMATCHED_DST` if nothing is define
-        if self.flags == DiffSyncFlags.NONE:
-            self.flags = DiffSyncFlags.SKIP_UNMATCHED_DST
+        # Effective DiffSync flags come from the one shared SYNC-78 rule —
+        # never interpreted inline here. `config` is typed as SyncInstance but
+        # tests pass None — guard explicitly.
+        self.flags: DiffSyncFlags = resolve_effective_diffsync_flags(
+            self.config.diffsync_flags if self.config is not None else None
+        )
 
     @property
     def last_applied_plan_action_counts(self) -> dict[str, int] | None:

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -673,6 +673,24 @@ def _require_argument_type(value: object, *, name: str, expected: type) -> None:
         raise ConfigsRequestError(msg)
 
 
+def _require_registry_version(value: object) -> None:
+    """Refuse a registry_version outside the domain the registry can ever allocate.
+
+    Exactly ``int`` — no subclass — and strictly positive, as the caller's own input rather
+    than the store's answer. ``bool`` is an ``int`` subclass, so an ``isinstance`` guard let
+    ``registry_version=True`` reach SQLite, compare equal to 1, and silently resolve version
+    1; and the registry allocates versions from 1, so ``0`` and ``-1`` are not versions that
+    happen to be absent — reporting them ``not-found`` claims the store answered a question
+    it can never be asked.
+    """
+    if type(value) is not int:
+        msg = f"registry_version must be int, not {type(value).__name__}"
+        raise ConfigsRequestError(msg)
+    if value <= 0:
+        msg = f"registry_version must be a positive integer, not {value}"
+        raise ConfigsRequestError(msg)
+
+
 def _parse(package: Mapping[str, Any]) -> ConfigurationPackage:
     """Parse declared JSON-native content, refusing any prebuilt package instance.
 
@@ -807,7 +825,7 @@ def get_version(
     cannot race. The store's blended single-lookup reason is untouched; ``validate`` keeps it.
     """
     _require_argument_type(config_id, name="config_id", expected=str)
-    _require_argument_type(registry_version, name="registry_version", expected=int)
+    _require_registry_version(registry_version)
     projection = _projection(product_cache_location)
     _require_configuration(projection, config_id)
     stored = projection.lookup_configuration_version(config_id, registry_version).value
@@ -838,7 +856,7 @@ def validate(
     ``sort_findings`` contract, and records the judged snapshot's fingerprint.
     """
     _require_argument_type(config_id, name="config_id", expected=str)
-    _require_argument_type(registry_version, name="registry_version", expected=int)
+    _require_registry_version(registry_version)
     if destination_schema is not None:
         _require_argument_type(destination_schema, name="destination_schema", expected=DestinationSchemaOptions)
     projection = _projection(product_cache_location)

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -139,18 +139,6 @@ class ConfigsInternalError(ConfigsError):
     family: ClassVar[str] = "internal"
 
 
-# The only two things the boundary infers from an exception no arm named, and it infers
-# nothing else. A filesystem or SQLite error can only have come from the store, and this
-# module parses no YAML but a caller's, so a parse error can only be about caller content.
-# A decode or a recursion error is deliberately *not* here: either can come from a defect in
-# this module as easily as from a caller's file, and guessing ``request`` for an unattributable
-# failure blames the operator's input for something they cannot fix. An arm that knows what it
-# was reading names those; whatever is left is unclassified and says so.
-_BOUNDARY_FAMILIES: tuple[tuple[tuple[type[Exception], ...], type[ConfigsError]], ...] = (
-    ((OSError, sqlite3.Error), ConfigsStorageError),
-    ((yaml.YAMLError,), ConfigsRequestError),
-)
-
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -159,25 +147,6 @@ _R = TypeVar("_R")
 # compare this against the module's public functions, so an operation added without the
 # boundary fails them.
 _GUARDED_OPERATIONS: set[str] = set()
-
-
-def _boundary_refusal(operation: str, exc: Exception) -> ConfigsError:
-    """Return the declared refusal one unnamed failure maps to.
-
-    Nothing reaches the text from the exception — not even its type name. An exception no
-    arm named can have been constructed by a hostile caller argument (a
-    ``product_cache_location`` whose ``__str__`` raises it), so its class is untrusted and
-    a metaclass executes on the ``__name__`` read — which used to escape this module as a
-    raw untyped error. The family alone is inferred, by ``isinstance`` against the
-    declared table, which reads no attribute off the exception. The arms inside the
-    operations that do carry a type name do so only for exceptions trusted code
-    constructed. The family is what classifies the refusal, and both interfaces render it.
-    """
-    refusal = next(
-        (family for types, family in _BOUNDARY_FAMILIES if isinstance(exc, types)),
-        ConfigsInternalError,
-    )
-    return refusal(f"configs {operation} failed")
 
 
 def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
@@ -189,6 +158,23 @@ def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
     raw traceback outside the one vocabulary both interfaces map. Enumerating exception types
     at each site is what this replaces: four escapes were found that way, one at a time, and
     each fix left the next one live.
+
+    Classification is by ``except`` clause only, which matches the exception's actual type
+    without touching the instance. ``isinstance`` is itself inspection — it consults the
+    instance's ``__class__``, a read a hostile property executes on — and an exception no
+    arm named can have been constructed by a hostile caller argument (a
+    ``product_cache_location`` whose ``__str__`` raises it), so a runtime classification
+    table used to escape this module as a raw untyped error. Nothing reaches the text from
+    the exception either: one fixed message per operation.
+
+    The boundary infers only two families from an exception no arm named, and nothing
+    else. A filesystem or SQLite error can only have come from the store, and this module
+    parses no YAML but a caller's, so a parse error can only be about caller content. A
+    decode or a recursion error is deliberately *not* inferred: either can come from a
+    defect in this module as easily as from a caller's file, and guessing ``request`` for
+    an unattributable failure blames the operator's input for something they cannot fix.
+    An arm that knows what it was reading names those; whatever is left is unclassified
+    and says so.
 
     Three rules it keeps:
 
@@ -204,6 +190,7 @@ def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
     # plain module-level function, so the fallback never fires.
     name = getattr(operation, "__name__", "operation")
     _GUARDED_OPERATIONS.add(name)
+    refusal = f"configs {name} failed"
 
     @wraps(operation)
     def guarded(*args: _P.args, **kwargs: _P.kwargs) -> _R:
@@ -211,8 +198,12 @@ def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
             return operation(*args, **kwargs)
         except ConfigsError:
             raise
-        except Exception as exc:  # noqa: BLE001 - boundary translation, always re-raised typed
-            raise _boundary_refusal(name, exc) from None
+        except (OSError, sqlite3.Error):
+            raise ConfigsStorageError(refusal) from None
+        except yaml.YAMLError:
+            raise ConfigsRequestError(refusal) from None
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # The totality rule: re-raised typed, nothing read.
+            raise ConfigsInternalError(refusal) from None
 
     return guarded
 
@@ -672,11 +663,14 @@ def _require_argument_type(value: object, *, name: str, expected: type) -> None:
     SQLite and comes back as ``sqlite3.ProgrammingError`` — which the boundary can only read as
     ``storage``, sending an operator to look at their disk for a defect in their own call. Type
     is all this checks: whether a well-typed identifier exists is the store's answer, and a
-    missing one is already ``not-found``. The refusal reads nothing from the value — not its
-    class's ``__name__``, which a metaclass executes on; ``expected`` is this module's own
-    trusted type object, so naming it is safe.
+    missing one is already ``not-found``. The guard reads nothing from the value: it matches
+    ``type(value)`` identity alone — not ``isinstance``, which consults the instance's
+    ``__class__`` (a read a hostile property executes on) and would admit subclasses — and
+    its refusal names nothing about the value either, not its class's ``__name__``, which a
+    metaclass executes on. ``expected`` is this module's own trusted type object, so naming
+    it is safe.
     """
-    if not isinstance(value, expected):
+    if type(value) is not expected:  # pylint: disable=unidiomatic-typecheck  # Exact type; isinstance reads the instance.
         msg = f"{name} must be {expected.__name__}"
         raise ConfigsRequestError(msg)
 

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -674,21 +674,28 @@ def _require_argument_type(value: object, *, name: str, expected: type) -> None:
         raise ConfigsRequestError(msg)
 
 
+# The registry's whole allocatable range. Versions are allocated from 1 and stored as
+# SQLite INTEGER — a signed 64-bit value — so no stored version can ever exceed this.
+_MAX_REGISTRY_VERSION = 2**63 - 1
+
+
 def _require_registry_version(value: object) -> None:
     """Refuse a registry_version outside the domain the registry can ever allocate.
 
-    Exactly ``int`` — no subclass — and strictly positive, as the caller's own input rather
-    than the store's answer. ``bool`` is an ``int`` subclass, so an ``isinstance`` guard let
+    Exactly ``int`` — no subclass — and within ``1..=_MAX_REGISTRY_VERSION``, as the
+    caller's own input rather than the store's answer, so every integer is classified
+    before SQLite sees it. ``bool`` is an ``int`` subclass, so an ``isinstance`` guard let
     ``registry_version=True`` reach SQLite, compare equal to 1, and silently resolve version
-    1; and the registry allocates versions from 1, so ``0`` and ``-1`` are not versions that
+    1; the registry allocates versions from 1, so ``0`` and ``-1`` are not versions that
     happen to be absent — reporting them ``not-found`` claims the store answered a question
-    it can never be asked.
+    it can never be asked; and the store's INTEGER is signed 64-bit, so an integer above
+    the range is equally unaskable — it used to surface as SQLite's own ``OverflowError``.
     """
     if type(value) is not int:  # pylint: disable=unidiomatic-typecheck  # bool must not pass.
         msg = f"registry_version must be int, not {type(value).__name__}"
         raise ConfigsRequestError(msg)
-    if value <= 0:
-        msg = f"registry_version must be a positive integer, not {value}"
+    if not 1 <= value <= _MAX_REGISTRY_VERSION:
+        msg = f"registry_version must be in the registry's allocatable range 1..{_MAX_REGISTRY_VERSION}, not {value}"
         raise ConfigsRequestError(msg)
 
 

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -683,7 +683,7 @@ def _require_registry_version(value: object) -> None:
     happen to be absent — reporting them ``not-found`` claims the store answered a question
     it can never be asked.
     """
-    if type(value) is not int:
+    if type(value) is not int:  # pylint: disable=unidiomatic-typecheck  # bool must not pass.
         msg = f"registry_version must be int, not {type(value).__name__}"
         raise ConfigsRequestError(msg)
     if value <= 0:

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -707,21 +707,16 @@ def _require_json_native_package(package: object) -> None:
     ``type(...)`` identity before any protocol operation runs on the untrusted value — no
     method call, no attribute read, no ``__class__`` consultation, no ``isinstance``
     against an ABC. A subclass of any of these can override every hook the service would
-    otherwise invoke, so no subclass is in the domain. The recursive walk is the model
+    otherwise invoke, so no subclass is in the domain. The refusal reads nothing either —
+    not the class's ``__mro__`` or ``__name__``, both of which a metaclass executes on —
+    so one fixed message covers every out-of-domain value, a prebuilt
+    :class:`ConfigurationPackage` instance included. The recursive walk is the model
     layer's own :func:`_require_json_native`, so the service's structural acceptance and
     the parse boundary agree by construction; its refusals are value-free (location and
     reason only), so nothing here echoes the object either.
     """
-    package_type = type(package)
-    if package_type is not dict:
-        if ConfigurationPackage in package_type.__mro__:
-            # A prebuilt instance keeps its own refusal: it can carry behavior validation
-            # never judged (a subclass overriding ``declared_content()`` can persist an
-            # inline secret, ``model_construct`` skips validation entirely), and a caller
-            # holding an instance holds the declared content anyway.
-            msg = "package must be declared JSON-native content, not a prebuilt ConfigurationPackage instance"
-            raise ConfigsRequestError(msg)
-        msg = f"package must be a JSON-native dict, not {package_type.__name__}"
+    if type(package) is not dict:  # pylint: disable=unidiomatic-typecheck  # Exact dict only; no subclass.
+        msg = "package must be a JSON-native dict of declared content"
         raise ConfigsRequestError(msg)
     try:
         _require_json_native(package)

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
@@ -66,7 +67,7 @@ from infrahub_sync.product_store.store import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Sequence
 
     from infrahub_sync.product_store.models import ConfigurationSummary, ConfigurationVersion
 
@@ -672,10 +673,21 @@ def _require_argument_type(value: object, *, name: str, expected: type) -> None:
         raise ConfigsRequestError(msg)
 
 
-def _parse(package: Mapping[str, Any] | ConfigurationPackage) -> ConfigurationPackage:
-    """Return the declared package, reporting a parse failure in the shared vocabulary."""
+def _parse(package: Mapping[str, Any]) -> ConfigurationPackage:
+    """Parse declared JSON-native content, refusing any prebuilt package instance.
+
+    The write boundary accepts declared content only and always routes it through
+    ``parse_configuration_package``, so what the store persists is exactly what the shared
+    parser validated. A prebuilt :class:`ConfigurationPackage` — the exact class included —
+    is refused as the caller's own input: an instance can carry behavior validation never
+    judged (a subclass overriding ``declared_content()`` can persist an inline secret whose
+    validated fields hold only references, and ``model_construct`` skips validation
+    entirely), and a caller holding an instance holds the declared content anyway.
+    """
     if isinstance(package, ConfigurationPackage):
-        return package
+        msg = "package must be declared JSON-native content, not a prebuilt ConfigurationPackage instance"
+        raise ConfigsRequestError(msg)
+    _require_argument_type(package, name="package", expected=Mapping)
     try:
         return parse_configuration_package(dict(package))
     except ConfigurationPackageParseError as exc:
@@ -694,13 +706,15 @@ def _validation_refusal(exc: CredentialConfigurationError, package: Configuratio
 @_service_boundary
 def register(
     *,
-    package: Mapping[str, Any] | ConfigurationPackage,
+    package: Mapping[str, Any],
     product_cache_location: str | Path | None,
 ) -> RegisteredConfiguration:
     """Register a brand-new declared configuration and return it with its first version.
 
-    Validation happens inside the store, before anything is persisted, so an invalid package
-    raises and is never registered. The findings surface is :func:`validate`.
+    ``package`` is declared JSON-native content; a prebuilt package instance is refused
+    (:func:`_parse`). Validation happens inside the store, before anything is persisted, so
+    an invalid package raises and is never registered. The findings surface is
+    :func:`validate`.
     """
     projection = _projection(product_cache_location)
     parsed = _parse(package)
@@ -721,10 +735,14 @@ def register(
 def create_version(
     *,
     config_id: str,
-    package: Mapping[str, Any] | ConfigurationPackage,
+    package: Mapping[str, Any],
     product_cache_location: str | Path | None,
 ) -> RegisteredVersion:
-    """Add one version to an existing configuration, or return the identical stored one."""
+    """Add one version to an existing configuration, or return the identical stored one.
+
+    ``package`` is declared JSON-native content; a prebuilt package instance is refused
+    (:func:`_parse`).
+    """
     _require_argument_type(config_id, name="config_id", expected=str)
     projection = _projection(product_cache_location)
     parsed = _parse(package)

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -692,6 +692,18 @@ def create_version(
 
 
 @_service_boundary
+def list_configs(*, product_cache_location: str | Path | None) -> tuple[ConfigurationSummary, ...]:
+    """Return every registered configuration exactly once, oldest first with an ID tiebreak.
+
+    The order is the store's own ``ORDER BY created_at, config_id`` — deterministic and total,
+    never a re-sort in this layer. An empty registry is a real answer here, unlike the scoped
+    reads: there is no identifier whose absence could make it a not-found.
+    """
+    projection = _projection(product_cache_location)
+    return projection.list_configurations()
+
+
+@_service_boundary
 def validate(
     *,
     config_id: str,

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -43,11 +43,16 @@ from infrahub_sync.configuration import (
     ValidationFinding,
     collect_findings,
     parse_configuration_package,
+    sort_findings,
 )
 from infrahub_sync.configuration.models import (
     _MAX_FINDING_TEXT_LENGTH,
     _POINTER_CHARACTER_ESCAPES,
     safe_pointer_component,
+)
+from infrahub_sync.configuration.schema_validation import (
+    DestinationSchemaOptions,
+    collect_destination_schema_findings,
 )
 from infrahub_sync.configuration.validation import _location_digest
 from infrahub_sync.execution import REDACTED, redact
@@ -520,12 +525,19 @@ class RegisteredVersion:
 
 @dataclass(frozen=True, slots=True)
 class ValidationReport:
-    """Every declared defect in one registered version, already in contract order."""
+    """Every declared defect in one registered version, already in contract order.
+
+    ``destination_schema_fingerprint`` is the identity of the destination schema snapshot
+    the schema checks judged — ``None`` whenever no snapshot was read: the default path,
+    a non-declaring destination, or a failed read. It is what makes "same package, same
+    schema snapshot, same report" auditable rather than asserted.
+    """
 
     config_id: str
     registry_version: int
     package_checksum: str
     findings: tuple[ValidationFinding, ...]
+    destination_schema_fingerprint: str | None = None
 
 
 @_service_boundary
@@ -793,15 +805,24 @@ def validate(
     config_id: str,
     registry_version: int,
     product_cache_location: str | Path | None,
+    destination_schema: DestinationSchemaOptions | None = None,
 ) -> ValidationReport:
     """Report every declared defect in one registered version, in contract order.
 
     The version is re-read from the registry and validated against the *current* adapter
     declarations, which is why a package that was accepted at registration can report
     findings later.
+
+    ``destination_schema`` is the explicit opt-in contract section 4 names ``validate``
+    the carrier of: ``None`` — the default — keeps the declared-content-only behavior
+    byte-identical, with zero schema reads and zero network I/O. An explicit options
+    object adds the destination schema checks, merges their findings under the same
+    ``sort_findings`` contract, and records the judged snapshot's fingerprint.
     """
     _require_argument_type(config_id, name="config_id", expected=str)
     _require_argument_type(registry_version, name="registry_version", expected=int)
+    if destination_schema is not None:
+        _require_argument_type(destination_schema, name="destination_schema", expected=DestinationSchemaOptions)
     projection = _projection(product_cache_location)
     lookup = projection.lookup_configuration_version(config_id, registry_version)
     stored = lookup.value
@@ -809,9 +830,16 @@ def validate(
         msg = f"configuration {config_id!r} has no registered version {registry_version} ({lookup.reason})"
         raise ConfigsNotFoundError(msg)
     parsed = _parse(stored.declared_content)
+    findings = collect_findings(parsed)
+    fingerprint: str | None = None
+    if destination_schema is not None:
+        schema_validation = collect_destination_schema_findings(parsed)
+        findings = sort_findings((*findings, *schema_validation.findings))
+        fingerprint = schema_validation.schema_fingerprint
     return ValidationReport(
         config_id=stored.config_id,
         registry_version=stored.registry_version,
         package_checksum=stored.package_checksum,
-        findings=collect_findings(parsed),
+        findings=findings,
+        destination_schema_fingerprint=fingerprint,
     )

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -96,9 +96,22 @@ class ConfigsValidationError(ConfigsError):
 
 
 class ConfigsNotFoundError(ConfigsError):
-    """The requested configuration or version is not in the registry."""
+    """The requested configuration or version is not in the registry.
+
+    ``reason`` is the machine-readable half of the refusal: a stable value naming *which*
+    absence this is, so service-boundary can map a missing configuration and a missing
+    version of an existing configuration to two different status codes without parsing the
+    message. The store's own version lookup blends the two cases into one reason, so the
+    distinction is made here, where the two-step read (configuration first, then version)
+    knows which step failed. It defaults to the family itself for refusals that predate the
+    distinction and have exactly one absence to name.
+    """
 
     family: ClassVar[str] = "not-found"
+
+    def __init__(self, message: str, *, reason: str = "not-found") -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class ConfigsStorageError(ConfigsError):
@@ -610,6 +623,29 @@ def _projection(product_cache_location: str | Path | None) -> ProductProjection:
         raise ConfigsStorageError(msg) from None
 
 
+# The two machine-readable absence values the read operations distinguish (envelope AR3).
+# ``CONFIGURATION_NOT_FOUND_REASON`` matches the store's own lookup reason for the same
+# absence; the version value names the case the store cannot: the configuration exists and
+# the requested version does not.
+CONFIGURATION_NOT_FOUND_REASON = "configuration-not-found"
+CONFIGURATION_VERSION_NOT_FOUND_REASON = "configuration-version-not-found"
+
+
+def _require_configuration(projection: ProductProjection, config_id: str) -> ConfigurationSummary:
+    """Return one registered configuration's summary, refusing absence by name.
+
+    The first step of every scoped read: the store's version queries answer a missing
+    configuration and a missing version identically (an empty tuple, or one blended
+    not-found reason), so the configuration is resolved first and its absence gets its own
+    machine-readable value. Deletion does not exist, so the two-step read cannot race.
+    """
+    summary = projection.lookup_configuration(config_id).value
+    if summary is None:
+        msg = f"configuration {config_id!r} is not registered"
+        raise ConfigsNotFoundError(msg, reason=CONFIGURATION_NOT_FOUND_REASON)
+    return summary
+
+
 def _require_argument_type(value: object, *, name: str, expected: type) -> None:
     """Refuse a wrong-typed public argument as the caller's own input, before the store sees it.
 
@@ -701,6 +737,54 @@ def list_configs(*, product_cache_location: str | Path | None) -> tuple[Configur
     """
     projection = _projection(product_cache_location)
     return projection.list_configurations()
+
+
+@_service_boundary
+def get_config(*, config_id: str, product_cache_location: str | Path | None) -> ConfigurationSummary:
+    """Return one registered configuration's summary, refusing absence rather than guessing."""
+    _require_argument_type(config_id, name="config_id", expected=str)
+    projection = _projection(product_cache_location)
+    return _require_configuration(projection, config_id)
+
+
+@_service_boundary
+def list_versions(*, config_id: str, product_cache_location: str | Path | None) -> tuple[ConfigurationVersion, ...]:
+    """Return every version of one configuration, ordered by ``registry_version`` ascending.
+
+    A missing configuration refuses — never a silent empty tuple, which would be
+    indistinguishable from a real answer about a registered configuration. The order is the
+    store's own ``ORDER BY registry_version``, not a re-sort in this layer.
+    """
+    _require_argument_type(config_id, name="config_id", expected=str)
+    projection = _projection(product_cache_location)
+    _require_configuration(projection, config_id)
+    return projection.list_configuration_versions(config_id)
+
+
+@_service_boundary
+def get_version(
+    *,
+    config_id: str,
+    registry_version: int,
+    product_cache_location: str | Path | None,
+) -> ConfigurationVersion:
+    """Return one immutable registered version exactly as it was persisted.
+
+    Two lookups, so the two absences stay distinct (envelope AR3): the configuration first —
+    its absence refuses with :data:`CONFIGURATION_NOT_FOUND_REASON` — then the version, whose
+    absence on an existing configuration refuses with
+    :data:`CONFIGURATION_VERSION_NOT_FOUND_REASON`. Deletion does not exist, so the two steps
+    cannot race. The store's blended single-lookup reason is untouched; ``validate`` keeps it.
+    """
+    _require_argument_type(config_id, name="config_id", expected=str)
+    _require_argument_type(registry_version, name="registry_version", expected=int)
+    projection = _projection(product_cache_location)
+    _require_configuration(projection, config_id)
+    stored = projection.lookup_configuration_version(config_id, registry_version).value
+    if stored is None:
+        msg = f"configuration {config_id!r} has no registered version {registry_version}"
+        raise ConfigsNotFoundError(msg, reason=CONFIGURATION_VERSION_NOT_FOUND_REASON)
+    return stored
 
 
 @_service_boundary

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
-from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar
 
 import yaml
+from pydantic_core import PydanticCustomError
 
 from infrahub_sync.configuration import (
     ConfigurationPackage,
@@ -49,6 +49,7 @@ from infrahub_sync.configuration import (
 from infrahub_sync.configuration.models import (
     _MAX_FINDING_TEXT_LENGTH,
     _POINTER_CHARACTER_ESCAPES,
+    _require_json_native,
     safe_pointer_component,
 )
 from infrahub_sync.configuration.schema_validation import (
@@ -67,7 +68,7 @@ from infrahub_sync.product_store.store import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
 
     from infrahub_sync.product_store.models import ConfigurationSummary, ConfigurationVersion
 
@@ -691,21 +692,46 @@ def _require_registry_version(value: object) -> None:
         raise ConfigsRequestError(msg)
 
 
-def _parse(package: Mapping[str, Any]) -> ConfigurationPackage:
-    """Parse declared JSON-native content, refusing any prebuilt package instance.
+def _require_json_native_package(package: object) -> None:
+    """Refuse anything but recursively exact JSON-native data, without invoking it.
 
-    The write boundary accepts declared content only and always routes it through
-    ``parse_configuration_package``, so what the store persists is exactly what the shared
-    parser validated. A prebuilt :class:`ConfigurationPackage` — the exact class included —
-    is refused as the caller's own input: an instance can carry behavior validation never
-    judged (a subclass overriding ``declared_content()`` can persist an inline secret whose
-    validated fields hold only references, and ``model_construct`` skips validation
-    entirely), and a caller holding an instance holds the declared content anyway.
+    The closed acceptance property of the write boundary: exact ``dict``/``list``
+    containers with exact ``str``/``int``/``float``/``bool``/``None`` leaves, judged by
+    ``type(...)`` identity before any protocol operation runs on the untrusted value — no
+    method call, no attribute read, no ``__class__`` consultation, no ``isinstance``
+    against an ABC. A subclass of any of these can override every hook the service would
+    otherwise invoke, so no subclass is in the domain. The recursive walk is the model
+    layer's own :func:`_require_json_native`, so the service's structural acceptance and
+    the parse boundary agree by construction; its refusals are value-free (location and
+    reason only), so nothing here echoes the object either.
     """
-    if isinstance(package, ConfigurationPackage):
-        msg = "package must be declared JSON-native content, not a prebuilt ConfigurationPackage instance"
+    package_type = type(package)
+    if package_type is not dict:
+        if ConfigurationPackage in package_type.__mro__:
+            # A prebuilt instance keeps its own refusal: it can carry behavior validation
+            # never judged (a subclass overriding ``declared_content()`` can persist an
+            # inline secret, ``model_construct`` skips validation entirely), and a caller
+            # holding an instance holds the declared content anyway.
+            msg = "package must be declared JSON-native content, not a prebuilt ConfigurationPackage instance"
+            raise ConfigsRequestError(msg)
+        msg = f"package must be a JSON-native dict, not {package_type.__name__}"
         raise ConfigsRequestError(msg)
-    _require_argument_type(package, name="package", expected=Mapping)
+    try:
+        _require_json_native(package)
+    except PydanticCustomError as exc:
+        msg = f"package must be recursively JSON-native declared content: {exc}"
+        raise ConfigsRequestError(msg) from None
+
+
+def _parse(package: Mapping[str, Any]) -> ConfigurationPackage:
+    """Parse declared JSON-native content, requiring exactly that shape before anything else.
+
+    Structural acceptance (:func:`_require_json_native_package`) runs first, so only a
+    recursively exact JSON-native ``dict`` ever reaches ``parse_configuration_package`` —
+    what the store persists is exactly what the shared parser validated, and a hostile or
+    merely non-native value is refused as the caller's own input without being invoked.
+    """
+    _require_json_native_package(package)
     try:
         return parse_configuration_package(dict(package))
     except ConfigurationPackageParseError as exc:

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -1,0 +1,721 @@
+"""The shared ``configs`` application service.
+
+This module sits below both interfaces, in ``standalone.py``'s position. It owns validation
+invocation, finding ordering, store access and record projection; ``cli.py`` parses options
+and renders what comes back, and ``api/v1`` builds typed requests and projects the same
+records into its redacted result models. Neither interface constructs a finding, sorts one,
+or decides what a failure means.
+
+**One error vocabulary, mapped twice.** Everything this module refuses raises a
+:class:`ConfigsError` carrying a ``family``. The CLI renders it through
+``print_error_and_abort`` and the Python API translates it into its public boundary error,
+but both read the same ``family`` from the same exception — which is the gap envelope OES-19
+found in the run lifecycle, where the CLI catches narrow types and the API catches broadly.
+
+**Total by construction, not by enumeration.** Every public operation carries
+:func:`_service_boundary`, so no exception leaves this module outside that vocabulary. The
+arms inside an operation still decide the family and the message wherever they know what was
+being read; the boundary is only what makes the claim hold for what they did not name.
+
+**Bounded deviation from contract section 6, stated so a reviewer does not read it as an
+unnoticed violation.** The run lifecycle above ``execute_standalone`` is deliberately *not*
+unified into a service like this one. ``api/v1.plan()`` and its ``cli.py`` counterpart are
+two different, correct error contracts over one shared call, which is what contract section 6
+asks interfaces to do (envelope OES-19). Nothing here changes that.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from functools import wraps
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar
+
+import yaml
+
+from infrahub_sync.configuration import (
+    ConfigurationPackage,
+    ConfigurationPackageParseError,
+    CredentialConfigurationError,
+    ValidationFinding,
+    collect_findings,
+    parse_configuration_package,
+)
+from infrahub_sync.configuration.models import (
+    _MAX_FINDING_TEXT_LENGTH,
+    _POINTER_CHARACTER_ESCAPES,
+    safe_pointer_component,
+)
+from infrahub_sync.configuration.validation import _location_digest
+from infrahub_sync.execution import REDACTED, redact
+from infrahub_sync.product_store.standalone import ProductCacheLocationError, resolve_product_cache_location
+from infrahub_sync.product_store.store import (
+    ConfigurationNotFoundError,
+    ConfigurationVersionAllocationError,
+    DuplicateConfigurationError,
+    ProductProjection,
+    local_product_projection,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    from infrahub_sync.product_store.models import ConfigurationSummary, ConfigurationVersion
+
+
+class ConfigsError(Exception):
+    """Base of the one error vocabulary both ``configs`` interfaces map.
+
+    ``family`` is the declared vocabulary. It is what an interface maps, so a new failure
+    mode joins an existing family or adds one here — never at a boundary.
+    """
+
+    family: ClassVar[str] = "configs"
+    # Declared on the base so a boundary reads findings off any refusal without naming a
+    # narrow type. Only a validation refusal ever carries them.
+    findings: tuple[ValidationFinding, ...] = ()
+
+
+class ConfigsRequestError(ConfigsError):
+    """The caller's own input is unusable: a bad store location or unparseable content."""
+
+    family: ClassVar[str] = "request"
+
+
+class ConfigsValidationError(ConfigsError):
+    """A declared package was refused by validation and therefore was not persisted."""
+
+    family: ClassVar[str] = "validation"
+
+    def __init__(self, message: str, *, findings: tuple[ValidationFinding, ...] = ()) -> None:
+        super().__init__(message)
+        self.findings = findings
+
+
+class ConfigsNotFoundError(ConfigsError):
+    """The requested configuration or version is not in the registry."""
+
+    family: ClassVar[str] = "not-found"
+
+
+class ConfigsStorageError(ConfigsError):
+    """The durable store refused the operation for a reason the caller cannot fix by input."""
+
+    family: ClassVar[str] = "storage"
+
+
+class ConfigsInternalError(ConfigsError):
+    """The service failed for a reason it cannot classify: the boundary's documented default.
+
+    Neither the caller's input nor the store — a defect in this service, or a dependency
+    raising something no arm here has met. It exists so the vocabulary can be total without
+    any refusal having to guess a family it does not know, and so an operator reading
+    ``internal`` looks for a bug to report rather than at their own file or their own disk.
+    """
+
+    family: ClassVar[str] = "internal"
+
+
+# The only two things the boundary infers from an exception no arm named, and it infers
+# nothing else. A filesystem or SQLite error can only have come from the store, and this
+# module parses no YAML but a caller's, so a parse error can only be about caller content.
+# A decode or a recursion error is deliberately *not* here: either can come from a defect in
+# this module as easily as from a caller's file, and guessing ``request`` for an unattributable
+# failure blames the operator's input for something they cannot fix. An arm that knows what it
+# was reading names those; whatever is left is unclassified and says so.
+_BOUNDARY_FAMILIES: tuple[tuple[tuple[type[Exception], ...], type[ConfigsError]], ...] = (
+    ((OSError, sqlite3.Error), ConfigsStorageError),
+    ((yaml.YAMLError,), ConfigsRequestError),
+)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+# The inventory of guarded operations, written by the boundary itself as the module is
+# imported. Coverage is therefore not a list anyone maintains by hand: the service's own tests
+# compare this against the module's public functions, so an operation added without the
+# boundary fails them.
+_GUARDED_OPERATIONS: set[str] = set()
+
+
+def _boundary_refusal(operation: str, exc: Exception) -> ConfigsError:
+    """Return the declared refusal one unnamed failure maps to.
+
+    Only the exception *type* reaches the text. A third-party message can quote a caller path
+    or third-party content, and every arm in this module carries the type alone for the same
+    reason. The family is what classifies the refusal, and both interfaces render it.
+    """
+    refusal = next(
+        (family for types, family in _BOUNDARY_FAMILIES if isinstance(exc, types)),
+        ConfigsInternalError,
+    )
+    return refusal(f"configs {operation} failed: {type(exc).__name__}")
+
+
+def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Make one public service operation total over the declared vocabulary.
+
+    The arms inside an operation stay, and stay authoritative: they know what they were
+    reading, so they give the precise family and the message an operator can act on. This is
+    what makes the vocabulary *total* — it catches what no arm named, so nothing leaves as a
+    raw traceback outside the one vocabulary both interfaces map. Enumerating exception types
+    at each site is what this replaces: four escapes were found that way, one at a time, and
+    each fix left the next one live.
+
+    Three rules it keeps:
+
+    * A :class:`ConfigsError` already raised propagates untouched and is never re-wrapped, so
+      an arm's family and message always win over this mapping.
+    * ``BaseException`` is not caught. ``SystemExit`` and ``KeyboardInterrupt`` still
+      propagate, which is the decision the run boundary in ``execution.py`` already made.
+    * Coverage is not a list kept in step by hand: what this records in
+      :data:`_GUARDED_OPERATIONS` is what the service's own tests enumerate, so a public
+      operation added without the boundary fails them.
+    """
+    # A ``Callable`` carries no ``__name__`` in the type system. Everything this decorates is a
+    # plain module-level function, so the fallback never fires.
+    name = getattr(operation, "__name__", "operation")
+    _GUARDED_OPERATIONS.add(name)
+
+    @wraps(operation)
+    def guarded(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return operation(*args, **kwargs)
+        except ConfigsError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - boundary translation, always re-raised typed
+            raise _boundary_refusal(name, exc) from None
+
+    return guarded
+
+
+# Every escape ``_escape_pointer_character`` can write, read backwards. "~0" and "~1" are the
+# two the pointer grammar cares about, and inverting only those was enough to keep the grammar
+# satisfied — but a declared key holding any of the others never matched a collected value, so
+# it was never redacted. ":" is the one that decides this: ``_add_url_userinfo`` collects a
+# credential as "user:password", which makes the most common collected-secret shape the one an
+# escape-blind match cannot find.
+_POINTER_ESCAPE_DECODINGS = {escaped: character for character, escaped in _POINTER_CHARACTER_ESCAPES.items()}
+# Longest first. Defensive, not load-bearing against the table as it stands: the only entries
+# longer than two characters are "\\u003a" and "\\u003b", and the two characters they open with
+# are "\\u", which is not itself an entry — so no shorter entry can be matched inside a longer
+# one and today the scan decodes the same text in either order. What the order rules out is a
+# future entry that *is* a prefix of a longer one, which would otherwise be consumed first and
+# leave the rest of the longer escape as literal text. Nothing can observe this ordering until
+# such an entry exists, so nothing tests it.
+_POINTER_ESCAPE_LENGTHS = sorted({len(escaped) for escaped in _POINTER_ESCAPE_DECODINGS}, reverse=True)
+# The table names two codepoints explicitly; every other unprintable one is written in the same
+# form with its own hexadecimal value, and parsing it is what tells an escaped backslash apart
+# from the backslash that opens an escape.
+_GENERIC_POINTER_ESCAPE = re.compile(r"\\u(?P<short>[0-9a-f]{4})|\\U(?P<long>[0-9a-f]{8})")
+_MAX_CODEPOINT = 0x10FFFF
+
+
+def _decode_pointer_component(component: str) -> str:
+    """Return the declared key one escaped pointer component stands for.
+
+    Every escape, not only the two separators. A left-to-right scan, not a sequence of
+    replacements: the escapes overlap, and one leading backslash opens three different
+    readings — an escaped backslash, an escaped colon, and an unprintable character written in
+    hexadecimal. Only consuming a whole escape before looking at what follows it tells them
+    apart, and only then is the result the declared key a collected value can be matched
+    against.
+
+    An escape the scan does not recognise is passed through one character at a time, which is
+    what a location the core did not build can contain.
+    """
+    decoded: list[str] = []
+    index = 0
+    while index < len(component):
+        escaped = next(
+            (
+                component[index : index + length]
+                for length in _POINTER_ESCAPE_LENGTHS
+                if component[index : index + length] in _POINTER_ESCAPE_DECODINGS
+            ),
+            None,
+        )
+        if escaped is not None:
+            decoded.append(_POINTER_ESCAPE_DECODINGS[escaped])
+            index += len(escaped)
+            continue
+        generic = _GENERIC_POINTER_ESCAPE.match(component, index)
+        codepoint = _MAX_CODEPOINT + 1 if generic is None else int(generic["short"] or generic["long"], 16)
+        if generic is not None and codepoint <= _MAX_CODEPOINT:
+            decoded.append(chr(codepoint))
+            index = generic.end()
+            continue
+        decoded.append(component[index])
+        index += 1
+    return "".join(decoded)
+
+
+def _encode_pointer_component(key: str) -> str:
+    """Return the escaped pointer component one declared key is written as.
+
+    The one escaping function the core itself uses, so the pointer this rebuilds is written the
+    way the pointer it took apart was, and ``_decode_pointer_component`` inverts it exactly.
+    """
+    return safe_pointer_component(key)
+
+
+def redact_pointer(location: str, secrets: Sequence[str]) -> str:
+    """Redact the declared keys a finding pointer quotes, tagged so it stays distinguishable.
+
+    A pointer is built from declared keys, so it can carry a collected value. The value is
+    matched against each *decoded* key — decoded through the whole escape table, because
+    ``_add_url_userinfo`` collects a credential as "user:password" and a pointer writes that
+    colon as "\u003a", so an escape-blind match misses the most common collected shape there
+    is. The result is escaped again on the way back, so no replacement can orphan a "~0"/"~1"
+    escape or introduce a separator: the escapes in the returned pointer are written after
+    redaction, not edited by it. That is also why a value
+    carrying "/" or "~" is caught — it is invisible in a component's escaped text — and why a
+    value that only appears across the "/" between two components is not: that "/" is
+    structure, not declared content.
+
+    Redaction is lossy, so it obeys the rule truncation already obeys in ``validation.py``: two
+    distinct pointers may not collapse into one. A redacted pointer therefore ends with the
+    redaction marker and the same short digest a truncated pointer carries — one mechanism, not
+    a second one to keep in step. Nothing is appended when no key was replaced.
+
+    **The digest is taken over the whole unredacted pointer, not over the component that was
+    replaced.** In the case this exists for, the replaced component *is* a current credential
+    value, so digesting the component alone would publish an unsalted hash of a secret: the same
+    tag wherever that value appears, in any report, joinable against a precomputed table of
+    candidate values. Digesting the pointer binds the value to the declared path it was found
+    at, so the tag is not a portable fingerprint. It is still a confirmation oracle for someone
+    who guesses the value and can see the surrounding path, which is accepted here: a tag over
+    the pointer's *position* rather than its content is identical for the two findings this
+    exists to separate and would leave them indistinguishable. Both interfaces redact through
+    this function, so the tag cannot differ between them.
+
+    One thing the round-trip does not preserve: ``validation.py``'s truncation marker is the
+    six-character text ``\u2026``, which the decoder reads as an escape and the encoder writes
+    back as the single printable character it stands for. A redacted pointer therefore shows a
+    literal "…" where an unredacted one shows the marker, and a declared key containing "…"
+    shows the same thing — so in a redacted pointer that character is a hint that truncation
+    happened, not proof of it. Nothing collides: the tag appended here carries its own digest.
+    """
+    components: list[str] = []
+    replaced = False
+    for component in location.split("/"):
+        key = _decode_pointer_component(component)
+        cleaned = redact(key, secrets)
+        replaced = replaced or cleaned != key
+        components.append(_encode_pointer_component(cleaned))
+    if not replaced:
+        return location
+    redacted = "/".join(components)
+    tag = REDACTED + _location_digest(location)
+    room = _MAX_FINDING_TEXT_LENGTH - len(tag)
+    if len(redacted) > room:
+        # The replacement can be longer than what it replaced, so the field's own bound is
+        # re-applied. This cut is the one place a "~" can still be separated from the character
+        # that completes it, so a trailing "~" is dropped; the tag survives the cut because it
+        # is appended after it.
+        redacted = redacted[:room].rstrip("~")
+    return redacted + tag
+
+
+# The forms a declared key reaches a finding *message* in. A message is not a pointer: it is
+# free text that already carries "/" as structure and quotation as prose, so it cannot be
+# decoded and re-encoded the way ``redact_pointer`` takes a pointer apart. The secret is
+# encoded instead, which is exact — and one derivation covers both producers, because both
+# start from ``safe_pointer_component``:
+#
+# * ``_bounded_location`` embeds an escaped pointer directly, so a key appears exactly as
+#   ``safe_pointer_component`` writes it: one backslash before "u003a".
+# * ``_render_setting_name_list`` escapes and then hands the result to ``json.dumps``, so the
+#   same key appears with every backslash doubled and every non-ASCII character re-escaped.
+#
+# The second form is therefore ``json.dumps`` of the first, not a second rule to keep in step
+# with it: whatever the escaping table becomes, both forms follow it.
+#
+# A third *renderer* — not a third spelling of the same table — does exist, and it is Python's
+# own ``repr``. Several producers write caller-declared text through "!r": an adapter name, a
+# store type, a credential reference name, a config_id, a path. For a printable character
+# ``repr`` agrees with a form already covered, but for a non-printable one it does not: the
+# pointer table writes the six characters "\u0001" and ``repr`` writes "\x01", so an
+# escaped-form match never finds it. The third form is therefore ``repr`` applied to the
+# secret, derived the same way the JSON form is — by running the real renderer, not by
+# restating what it emits.
+#
+# What this returns is therefore four *known* renderings of a collected value, and not every
+# rendering of it. Nobody has shown the producer set is closed, and one producer outside it is
+# already known: ``_render_context_pointer`` in ``configuration/models.py`` escapes a parse
+# diagnostic's pointer a fifth way, and a value holding ":" together with a '"' or a non-ASCII
+# character reaches a parse refusal in a form none of the four match. Enumerating renderings is
+# the wrong mechanism at that point and escaping belongs at a single chokepoint instead, which
+# is a change this function does not make.
+def _message_secret_forms(secrets: Sequence[str]) -> tuple[str, ...]:
+    """Return every collected value together with the encodings a message writes it as."""
+    forms: set[str] = set()
+    for secret in secrets:
+        escaped = _encode_pointer_component(secret)
+        # Quotes stripped in both derived forms: what is wanted is the content between the
+        # renderer's own quotes, which is what a message embeds. ``repr`` chooses its quote
+        # character from the content — a value holding "'" is written in double quotes — so the
+        # pair is stripped by position rather than by naming one of them.
+        forms.update(
+            (
+                secret,
+                escaped,
+                json.dumps(escaped, ensure_ascii=True)[1:-1],
+                repr(secret)[1:-1],
+            )
+        )
+    # Longest first, matching ``collect_secret_values``, so an encoded form is replaced before
+    # any shorter form contained inside it.
+    return tuple(sorted(forms, key=lambda form: (-len(form), form)))
+
+
+def redact_message(text: str, secrets: Sequence[str]) -> str:
+    """Remove the known renderings of every collected value from one piece of free text.
+
+    **The one entry point for free text, so a surface that renders it cannot redact it a
+    weaker way.** The surfaces that show an operator or a caller text the core built from
+    declared content go through here: a finding's message, the refusal the command line logs,
+    and the ``message`` of the public boundary error. The expansion is what makes it
+    escape-aware, and applying it here rather than at each surface is what stops one surface
+    from drifting behind :func:`redact_finding` again.
+
+    **It matches renderings; it does not escape at the point of writing, and the difference is
+    where its two known limits come from.** What is verified is that the four renderings
+    :func:`_message_secret_forms` derives are removed at all seven enumerated exits, on the
+    in-bound and the out-bound pass. What is not claimed is that those four are every
+    rendering:
+
+    * A parse diagnostic's pointer is escaped by ``_render_context_pointer``, which is a fifth
+      escaping this does not derive. A collected value holding ":" together with a '"' or a
+      non-ASCII character survives in a parse refusal.
+    * ``_bounded_component`` cuts a declared key at 64 characters *before* escaping it, so a
+      longer key reaches a message as a prefix of itself. Whole-value matching cannot find a
+      prefix, and no matching rule can — this one is not closable here.
+    """
+    return redact(text, _message_secret_forms(secrets))
+
+
+# The one never-redacted rule, held here and read by every boundary rather than restated at
+# any of them. Each field named here carries a closed vocabulary the core chose rather than
+# anything a caller supplied: a finding's ``code`` and ``severity``, and the ``family``,
+# ``operation`` and ``outcome`` of a refusal. Redacting one rewrites a stable machine
+# identifier into an environment-dependent one, and can produce a value the field's own
+# pattern refuses — which turns a returned refusal into a raised validation error at one
+# boundary and a corrupted code at the other.
+#
+# The refusal half is the same defect as the finding half, one level up, and was left open
+# when the finding half was closed: an environment holding a collected value equal to
+# "storage" made an error's ``family`` attribute say "storage" while the dump of the same
+# error said "***", and made the command line label the refusal "***" — the token both
+# interfaces render for one error meaning, gone environment-dependent.
+#
+# Only a message and a pointer quote declared content. Whatever is not named here is redacted,
+# so a field added later is redacted by default rather than exposed by it.
+UNREDACTED_VOCABULARY_FIELDS = frozenset({"code", "severity", "family", "operation", "outcome"})
+
+
+def is_closed_vocabulary_field(field: str) -> bool:
+    """Return whether a public field's value is a vocabulary the core chose, not caller data.
+
+    The predicate rather than the set, so a boundary that cannot call
+    :func:`redact_public_field` — because it matches its caller-derived text a different way —
+    still reads the exemption from here instead of naming the exempt fields again.
+    """
+    return field in UNREDACTED_VOCABULARY_FIELDS
+
+
+def redact_public_field(field: str, value: str, secrets: Sequence[str]) -> str:
+    """Redact one public field by the rule its *name* selects, wherever the field arrives.
+
+    **The whole rule, in one function, so a finding or a refusal cannot be redacted two ways.**
+    A finding reaches a boundary either as the model or as a serialized mapping, and both
+    shapes are the same four fields under the same rule — but each shape had its own copy of
+    it, and when the message rule was made escape-aware only one copy was. This is what the two
+    shapes now call, so there is nothing left for them to disagree about. A refusal's own
+    fields are the identical rule one level up: ``family``, ``operation`` and ``outcome`` are
+    closed vocabularies, and ``message`` is caller-derived free text.
+
+    **Both caller-derived fields are matched escape-aware, and they have to be by two different
+    mechanisms.** A finding message quotes the same declared key its pointer does, escaped by
+    the same function — so a plain match over the message let the credential the pointer
+    hardening exists for through on the same output line. The pointer is structure and is taken
+    apart (:func:`redact_pointer`); the message is free text and cannot be, so the secret is
+    encoded into the forms a message writes it as instead (:func:`redact_message`).
+
+    A field this does not name is free text and is redacted as such, which is what makes
+    :data:`UNREDACTED_VOCABULARY_FIELDS` the exception list rather than the rule.
+    """
+    if is_closed_vocabulary_field(field):
+        return value
+    if field == "location":
+        return redact_pointer(value, secrets)
+    return redact_message(value, secrets)
+
+
+def redact_finding(finding: ValidationFinding, secrets: Sequence[str]) -> ValidationFinding:
+    """Return one finding with no current credential value in its caller-derived text.
+
+    Which field gets which rule is :func:`redact_public_field`'s decision, not this function's,
+    so the serialized-mapping shape at a boundary applies the identical rule. The fields are
+    read off the finding rather than named here, so a string field added to
+    :class:`ValidationFinding` later is redacted by default rather than exposed by omission.
+    """
+    return finding.model_copy(
+        update={
+            field: redact_public_field(field, value, secrets)
+            for field, value in finding.model_dump().items()
+            if isinstance(value, str)
+        }
+    )
+
+
+def describe(error: ConfigsError, secrets: Sequence[str]) -> str:
+    """Return the one operator-facing refusal text both interfaces render, already redacted.
+
+    The family leads, so the vocabulary a reviewer reads in this module is the vocabulary an
+    operator sees at a command line and a caller reads off the public API error.
+
+    **Redacted here, per field, rather than by the caller over the rendered line.** The line is
+    a closed vocabulary followed by caller-derived free text, and a match over the whole line
+    cannot tell them apart: an environment holding a collected value equal to "not-found"
+    turned the label of every not-found refusal into "***". Each half therefore goes through
+    :func:`redact_public_field` under its own name, which is the same rule the public error
+    dump applies to the same two values.
+    """
+    family = redact_public_field("family", type(error).family, secrets)
+    return f"{family}: {redact_public_field('message', str(error), secrets)}"
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredConfiguration:
+    """A newly registered configuration together with its first version."""
+
+    configuration: ConfigurationSummary
+    version: ConfigurationVersion
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredVersion:
+    """One configuration version, and whether this call is what created it."""
+
+    version: ConfigurationVersion
+    created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationReport:
+    """Every declared defect in one registered version, already in contract order."""
+
+    config_id: str
+    registry_version: int
+    package_checksum: str
+    findings: tuple[ValidationFinding, ...]
+
+
+@_service_boundary
+def load_package_content(path: str | Path) -> dict[str, Any]:
+    """Read one declared package file as JSON-native content.
+
+    ``yaml.safe_load`` reads JSON as well as YAML, so one code path serves both file forms.
+    Whether the result is a legal package is :func:`parse_configuration_package`'s decision,
+    not this function's.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        # UnicodeDecodeError is a ValueError, not an OSError: a package saved as CP1252 rather
+        # than UTF-8 opens and reads and then fails on one byte. It is the likeliest of these
+        # mistakes to reach an operator, and it is the caller's file either way, so it belongs
+        # to the same refusal as a file that cannot be opened at all. The type is what names
+        # which of the two happened.
+        msg = f"declared package file {str(path)!r} could not be read: {type(exc).__name__}"
+        raise ConfigsRequestError(msg) from None
+    try:
+        content = yaml.safe_load(text)
+    except (yaml.YAMLError, RecursionError):
+        # RecursionError is not a YAMLError: the parser recurses once per nesting level, so a
+        # deeply nested file exhausts the interpreter stack instead of being reported as bad
+        # syntax. Both are the same refusal - the caller's file is not readable as a package.
+        msg = f"declared package file {str(path)!r} is not valid JSON or YAML"
+        raise ConfigsRequestError(msg) from None
+    if not isinstance(content, dict):
+        msg = f"declared package file {str(path)!r} does not contain a package object"
+        raise ConfigsRequestError(msg)
+    if not _needs_json_coercion(content):
+        return content
+    # json round-trip: YAML admits scalars a declared package may not carry. ``default=str``
+    # does not hand those to the parse boundary — it stringifies them first, so an unquoted
+    # YAML date arrives as the string "2024-01-01" and is accepted wherever a string is legal.
+    # Two consequences, both deliberate and both worth knowing about. The stored content is
+    # then not byte-for-byte what the operator wrote; and the interfaces diverge, because the
+    # API path is handed JSON-native content directly and refuses the same value with
+    # ConfigurationPackageParseError. Reading a YAML date as text is conventional, so this
+    # coerces rather than refuses — but it is coercion, not a precise report.
+    try:
+        return json.loads(json.dumps(content, default=str))
+    except (TypeError, ValueError):
+        # Not every dump failure is coercible, and the probe above cannot tell the difference:
+        # it reads *any* refusal as "coercion needed", so the coercion itself is where the rest
+        # have to be refused. Two shapes reach here, both legal YAML. An anchor that contains
+        # itself describes an infinite structure and raises ValueError("Circular reference
+        # detected"); a date used as a mapping key raises TypeError, because ``default=str``
+        # stringifies values and not keys. The caller's file is what cannot be read as a
+        # package, so this is the same request refusal as unparseable syntax.
+        msg = f"declared package file {str(path)!r} describes content JSON cannot represent"
+        raise ConfigsRequestError(msg) from None
+
+
+def _needs_json_coercion(content: Mapping[str, Any]) -> bool:
+    """Return whether `content` holds a value the JSON-native parse boundary would reject.
+
+    Any dump failure reads as "coercion needed", including the ones no coercion can fix. The
+    caller is where those are refused.
+    """
+    try:
+        json.dumps(content, allow_nan=False)
+    except (TypeError, ValueError):
+        return True
+    return False
+
+
+def _projection(product_cache_location: str | Path | None) -> ProductProjection:
+    """Open the configuration registry, refusing an absent or non-absolute store location.
+
+    Absence is a refusal rather than a fallback: unlike a run, a registry has nowhere to live
+    without an explicit store. Only the absoluteness half of the rule is shared with the run
+    commands (envelope OES-21).
+    """
+    if product_cache_location is None or not str(product_cache_location).strip():
+        msg = "product_cache_location is required: the configuration registry has no store without one"
+        raise ConfigsRequestError(msg)
+    try:
+        location = resolve_product_cache_location(product_cache_location)
+    except ProductCacheLocationError as exc:
+        raise ConfigsRequestError(str(exc)) from None
+    try:
+        return local_product_projection(location)
+    except ValueError as exc:
+        raise ConfigsStorageError(str(exc)) from None
+    except OSError as exc:
+        # Opening the registry creates the store's own directories, so the filesystem refuses
+        # here before any query runs: a file where a directory belongs, or a cache root nothing
+        # may write to. That is a storage refusal, not a raw traceback out of the one declared
+        # vocabulary both interfaces map. Only the exception type is carried, matching
+        # ``load_package_content`` - the errno text names paths the caller already supplied and
+        # adds nothing an operator can act on.
+        msg = f"product cache location {str(location)!r} could not be opened as a store: {type(exc).__name__}"
+        raise ConfigsStorageError(msg) from None
+
+
+def _require_argument_type(value: object, *, name: str, expected: type) -> None:
+    """Refuse a wrong-typed public argument as the caller's own input, before the store sees it.
+
+    An identifier is passed to the registry as a query parameter, so a wrong-typed one reaches
+    SQLite and comes back as ``sqlite3.ProgrammingError`` — which the boundary can only read as
+    ``storage``, sending an operator to look at their disk for a defect in their own call. Type
+    is all this checks: whether a well-typed identifier exists is the store's answer, and a
+    missing one is already ``not-found``.
+    """
+    if not isinstance(value, expected):
+        msg = f"{name} must be {expected.__name__}, not {type(value).__name__}"
+        raise ConfigsRequestError(msg)
+
+
+def _parse(package: Mapping[str, Any] | ConfigurationPackage) -> ConfigurationPackage:
+    """Return the declared package, reporting a parse failure in the shared vocabulary."""
+    if isinstance(package, ConfigurationPackage):
+        return package
+    try:
+        return parse_configuration_package(dict(package))
+    except ConfigurationPackageParseError as exc:
+        raise ConfigsRequestError(str(exc)) from None
+
+
+def _validation_refusal(exc: CredentialConfigurationError, package: ConfigurationPackage) -> ConfigsValidationError:
+    """Turn the store's single-message refusal into the full ordered finding set.
+
+    The store raises on the first defect because registration must reject before it persists.
+    Collecting here is what makes the same package report N findings rather than one.
+    """
+    return ConfigsValidationError(str(exc), findings=collect_findings(package))
+
+
+@_service_boundary
+def register(
+    *,
+    package: Mapping[str, Any] | ConfigurationPackage,
+    product_cache_location: str | Path | None,
+) -> RegisteredConfiguration:
+    """Register a brand-new declared configuration and return it with its first version.
+
+    Validation happens inside the store, before anything is persisted, so an invalid package
+    raises and is never registered. The findings surface is :func:`validate`.
+    """
+    projection = _projection(product_cache_location)
+    parsed = _parse(package)
+    try:
+        version = projection.create_configuration(parsed)
+    except CredentialConfigurationError as exc:
+        raise _validation_refusal(exc, parsed) from None
+    except DuplicateConfigurationError as exc:
+        raise ConfigsStorageError(str(exc)) from None
+    summary = projection.lookup_configuration(version.config_id).value
+    if summary is None:
+        msg = f"configuration {version.config_id!r} was registered but cannot be read back"
+        raise ConfigsStorageError(msg)
+    return RegisteredConfiguration(configuration=summary, version=version)
+
+
+@_service_boundary
+def create_version(
+    *,
+    config_id: str,
+    package: Mapping[str, Any] | ConfigurationPackage,
+    product_cache_location: str | Path | None,
+) -> RegisteredVersion:
+    """Add one version to an existing configuration, or return the identical stored one."""
+    _require_argument_type(config_id, name="config_id", expected=str)
+    projection = _projection(product_cache_location)
+    parsed = _parse(package)
+    try:
+        version, created = projection.add_configuration_version(config_id, parsed)
+    except CredentialConfigurationError as exc:
+        raise _validation_refusal(exc, parsed) from None
+    except ConfigurationNotFoundError as exc:
+        raise ConfigsNotFoundError(str(exc)) from None
+    except ConfigurationVersionAllocationError as exc:
+        raise ConfigsStorageError(str(exc)) from None
+    return RegisteredVersion(version=version, created=created)
+
+
+@_service_boundary
+def validate(
+    *,
+    config_id: str,
+    registry_version: int,
+    product_cache_location: str | Path | None,
+) -> ValidationReport:
+    """Report every declared defect in one registered version, in contract order.
+
+    The version is re-read from the registry and validated against the *current* adapter
+    declarations, which is why a package that was accepted at registration can report
+    findings later.
+    """
+    _require_argument_type(config_id, name="config_id", expected=str)
+    _require_argument_type(registry_version, name="registry_version", expected=int)
+    projection = _projection(product_cache_location)
+    lookup = projection.lookup_configuration_version(config_id, registry_version)
+    stored = lookup.value
+    if stored is None:
+        msg = f"configuration {config_id!r} has no registered version {registry_version} ({lookup.reason})"
+        raise ConfigsNotFoundError(msg)
+    parsed = _parse(stored.declared_content)
+    return ValidationReport(
+        config_id=stored.config_id,
+        registry_version=stored.registry_version,
+        package_checksum=stored.package_checksum,
+        findings=collect_findings(parsed),
+    )

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -164,15 +164,20 @@ _GUARDED_OPERATIONS: set[str] = set()
 def _boundary_refusal(operation: str, exc: Exception) -> ConfigsError:
     """Return the declared refusal one unnamed failure maps to.
 
-    Only the exception *type* reaches the text. A third-party message can quote a caller path
-    or third-party content, and every arm in this module carries the type alone for the same
-    reason. The family is what classifies the refusal, and both interfaces render it.
+    Nothing reaches the text from the exception — not even its type name. An exception no
+    arm named can have been constructed by a hostile caller argument (a
+    ``product_cache_location`` whose ``__str__`` raises it), so its class is untrusted and
+    a metaclass executes on the ``__name__`` read — which used to escape this module as a
+    raw untyped error. The family alone is inferred, by ``isinstance`` against the
+    declared table, which reads no attribute off the exception. The arms inside the
+    operations that do carry a type name do so only for exceptions trusted code
+    constructed. The family is what classifies the refusal, and both interfaces render it.
     """
     refusal = next(
         (family for types, family in _BOUNDARY_FAMILIES if isinstance(exc, types)),
         ConfigsInternalError,
     )
-    return refusal(f"configs {operation} failed: {type(exc).__name__}")
+    return refusal(f"configs {operation} failed")
 
 
 def _service_boundary(operation: Callable[_P, _R]) -> Callable[_P, _R]:
@@ -667,10 +672,12 @@ def _require_argument_type(value: object, *, name: str, expected: type) -> None:
     SQLite and comes back as ``sqlite3.ProgrammingError`` — which the boundary can only read as
     ``storage``, sending an operator to look at their disk for a defect in their own call. Type
     is all this checks: whether a well-typed identifier exists is the store's answer, and a
-    missing one is already ``not-found``.
+    missing one is already ``not-found``. The refusal reads nothing from the value — not its
+    class's ``__name__``, which a metaclass executes on; ``expected`` is this module's own
+    trusted type object, so naming it is safe.
     """
     if not isinstance(value, expected):
-        msg = f"{name} must be {expected.__name__}, not {type(value).__name__}"
+        msg = f"{name} must be {expected.__name__}"
         raise ConfigsRequestError(msg)
 
 
@@ -692,7 +699,8 @@ def _require_registry_version(value: object) -> None:
     the range is equally unaskable — it used to surface as SQLite's own ``OverflowError``.
     """
     if type(value) is not int:  # pylint: disable=unidiomatic-typecheck  # bool must not pass.
-        msg = f"registry_version must be int, not {type(value).__name__}"
+        # Fixed message: reading the class's __name__ executes a hostile metaclass.
+        msg = "registry_version must be int"
         raise ConfigsRequestError(msg)
     if not 1 <= value <= _MAX_REGISTRY_VERSION:
         msg = f"registry_version must be in the registry's allocatable range 1..{_MAX_REGISTRY_VERSION}, not {value}"

--- a/infrahub_sync/product_store/standalone.py
+++ b/infrahub_sync/product_store/standalone.py
@@ -43,6 +43,36 @@ class StandaloneProductRecordError(Exception):
     """A configured standalone projection cannot continue the requested run."""
 
 
+class ProductCacheLocationError(StandaloneProductRecordError, ValueError):
+    """The declared product-cache location breaks the one rule every entry point shares.
+
+    It is a ``ValueError`` as well as a projection refusal so a Pydantic field validator can
+    let it propagate unchanged, which is how the Python API reaches the same rule as the CLI
+    instead of restating it (envelope OES-21).
+    """
+
+
+def resolve_product_cache_location(value: str | Path) -> Path:
+    """Return the absolute product-cache root for `value`, or refuse it.
+
+    The one rule, in one place: ``~`` is expanded, and what remains must be absolute. Every
+    entry point that accepts a product-cache location calls this — the CLI run commands
+    through :func:`execute_standalone`, the version 1 Python API through its request models,
+    and the ``configs`` service. Only absoluteness is shared: whether a *missing* location is
+    a refusal or a legacy fallback belongs to the caller, because the run commands treat
+    ``None`` as cache-only behavior while the registry has no meaning without a store.
+    """
+    try:
+        expanded = Path(value).expanduser()
+    except RuntimeError:
+        msg = f"product_cache_location has an unresolvable user home: {str(value)!r}"
+        raise ProductCacheLocationError(msg) from None
+    if not expanded.is_absolute():
+        msg = f"product_cache_location must be absolute after user expansion: {str(value)!r}"
+        raise ProductCacheLocationError(msg)
+    return expanded
+
+
 def _review_document(run_id: str, saved: SavedPlan) -> SavedPlanReviewArtifact:
     return SavedPlanReviewArtifact(
         run_id=run_id,
@@ -209,11 +239,10 @@ def _prepare_projection(
         msg = f"run_id is required for configured standalone operation={operation}"
         raise StandaloneProductRecordError(msg)
 
-    try:
-        cache_location = Path(product_cache_location).expanduser()
-    except RuntimeError:
-        msg = f"product cache path has an unresolvable user home: {str(product_cache_location)!r}"
-        raise StandaloneProductRecordError(msg) from None
+    # The one shared rule (envelope OES-21). Before this, the CLI reached absoluteness only
+    # through the projection constructor's own check and reported a different sentence than
+    # the Python API did for the same input.
+    cache_location = resolve_product_cache_location(product_cache_location)
     try:
         projection = local_product_projection(cache_location)
     except ValueError as exc:

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -150,6 +150,9 @@ _JSON_MAPPING_ADAPTER = TypeAdapter(dict[str, Any])
 
 _INSERT_CONFIGURATION = "INSERT INTO configurations (config_id, created_at) VALUES (?, ?)"
 _SELECT_CONFIGURATION = "SELECT config_id, created_at FROM configurations WHERE config_id = ?"
+# The one stated configurations listing order. ``created_at`` alone is not total — the clock
+# can give two registrations one timestamp — so ``config_id`` makes the order deterministic.
+_SELECT_CONFIGURATIONS = "SELECT config_id, created_at FROM configurations ORDER BY created_at, config_id"
 _INSERT_CONFIGURATION_VERSION = """INSERT INTO configuration_versions (config_id, registry_version, package_checksum,
 declared_content, created_at) VALUES (?, ?, ?, ?, ?)"""
 _SELECT_CONFIGURATION_VERSION = """SELECT config_id, registry_version, package_checksum, declared_content, created_at
@@ -307,6 +310,8 @@ class _RunStore(Protocol):  # pylint: disable=too-many-public-methods
     def lookup_configuration_version(
         self, config_id: str, registry_version: int
     ) -> LookupResult[ConfigurationVersion]: ...
+
+    def list_configurations(self) -> tuple[ConfigurationSummary, ...]: ...
 
     def list_configuration_versions(self, config_id: str) -> tuple[ConfigurationVersion, ...]: ...
 
@@ -1065,6 +1070,20 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
             return LookupResult(value=None, reason="configuration-version-not-found")
         return LookupResult(value=_configuration_version_from_row(row))
 
+    def list_configurations(self) -> tuple[ConfigurationSummary, ...]:
+        """Return every registered configuration in the one stated order (see the SQL)."""
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(self._sql(_SELECT_CONFIGURATIONS))
+                rows = cursor.fetchall()
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        return tuple(ConfigurationSummary(config_id=row[0], created_at=row[1]) for row in rows)
+
     def list_configuration_versions(self, config_id: str) -> tuple[ConfigurationVersion, ...]:
         connection = self._connect()
         try:
@@ -1486,6 +1505,10 @@ class ProductProjection:
     def lookup_configuration_version(self, config_id: str, registry_version: int) -> LookupResult[ConfigurationVersion]:
         """Look up one immutable configuration version by its integer ordinal."""
         return self._records.lookup_configuration_version(config_id, registry_version)
+
+    def list_configurations(self) -> tuple[ConfigurationSummary, ...]:
+        """Return every registered configuration's identity, ordered by creation time then ID."""
+        return self._records.list_configurations()
 
     def list_configuration_versions(self, config_id: str) -> tuple[ConfigurationVersion, ...]:
         """Return every registered version of one configuration, oldest first."""

--- a/tests/configuration/test_adapter_setting_conformance.py
+++ b/tests/configuration/test_adapter_setting_conformance.py
@@ -129,6 +129,28 @@ def test_bundled_literal_setting_accesses_are_declared_or_deliberately_refused(a
     assert _settings_forwarding_targets(adapter_name) == {expected_target}
 
 
+# Implementing incremental extraction means overriding both of these; the base class raises
+# unless cursor_tier_for stays NONE.
+_INCREMENTAL_OVERRIDES = frozenset({"cursor_tier_for", "list_changed_since"})
+
+
+def _defined_function_names(module_name: str) -> frozenset[str]:
+    tree = ast.parse((_ADAPTERS_DIRECTORY / f"{module_name}.py").read_text(encoding="utf-8"))
+    return frozenset(node.name for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)))
+
+
+@pytest.mark.parametrize("adapter_name", BUILTIN_ADAPTER_CAPABILITIES)
+def test_incremental_qualification_matches_the_runtime_overrides(adapter_name: str) -> None:
+    # `incremental_extraction=True` must co-occur with the incremental-extraction overrides,
+    # so a new incremental adapter cannot keep the unqualified-optional-feature warning
+    # firing forever, and a declaration cannot qualify a feature its runtime never reads.
+    capability = BUILTIN_ADAPTER_CAPABILITIES[adapter_name]
+    runtime_modules = _RUNTIME_MODULES[adapter_name]
+    defined = frozenset().union(*(_defined_function_names(name) for name in runtime_modules))
+
+    assert capability.incremental_extraction == (_INCREMENTAL_OVERRIDES <= defined)
+
+
 @pytest.mark.parametrize("adapter_name", BUILTIN_ADAPTER_CAPABILITIES)
 def test_dynamic_settings_forwarding_is_explicit(adapter_name: str) -> None:
     boundary = _DYNAMIC_FORWARDING_BOUNDARIES.get(adapter_name)

--- a/tests/configuration/test_adapter_setting_conformance.py
+++ b/tests/configuration/test_adapter_setting_conformance.py
@@ -148,7 +148,7 @@ def test_incremental_qualification_matches_the_runtime_overrides(adapter_name: s
     runtime_modules = _RUNTIME_MODULES[adapter_name]
     defined = frozenset().union(*(_defined_function_names(name) for name in runtime_modules))
 
-    assert capability.incremental_extraction == (_INCREMENTAL_OVERRIDES <= defined)
+    assert capability.incremental_extraction == (defined >= _INCREMENTAL_OVERRIDES)
 
 
 @pytest.mark.parametrize("adapter_name", BUILTIN_ADAPTER_CAPABILITIES)

--- a/tests/configuration/test_contracts.py
+++ b/tests/configuration/test_contracts.py
@@ -307,6 +307,71 @@ def test_checksum_changes_with_declared_credential_identifier() -> None:
     assert ConfigurationPackage.model_validate(changed).checksum() != baseline.checksum()
 
 
+def test_omissions_are_declared_content_inside_package_identity() -> None:
+    # OPT-A, always-serialize: `omissions` is a top-level sibling of `configuration` and
+    # `credentials`, and the empty declaration serializes too, so absent and empty cannot
+    # be two different byte streams. Omissions change the validation report a version
+    # produces, so two packages differing only in omissions are two identities.
+    baseline = _package()
+    data = baseline.model_dump(mode="json")
+    data["omissions"] = [
+        {"kind": "InfraDevice", "fields": ["serial_number", "asset_tag"], "reason": "serials tracked in the CMDB"}
+    ]
+    declared = ConfigurationPackage.model_validate(data)
+
+    assert baseline.declared_content()["omissions"] == []
+    assert declared.declared_content()["omissions"] == [
+        {"kind": "InfraDevice", "fields": ["serial_number", "asset_tag"], "reason": "serials tracked in the CMDB"}
+    ]
+    assert declared.checksum() != baseline.checksum()
+    reparsed = ConfigurationPackage.model_validate(declared.declared_content())
+    assert reparsed.declared_content() == declared.declared_content()
+    assert reparsed.checksum() == declared.checksum()
+
+
+def test_a_whole_kind_omission_omits_the_field_list() -> None:
+    data = _package().model_dump(mode="json")
+    data["omissions"] = [{"kind": "InfraDevice"}]
+
+    declared = ConfigurationPackage.model_validate(data)
+
+    assert declared.declared_content()["omissions"] == [{"kind": "InfraDevice", "fields": None, "reason": None}]
+
+
+def test_an_omission_reason_at_the_bound_is_accepted_and_the_declaration_is_strict() -> None:
+    data = _package().model_dump(mode="json")
+    data["omissions"] = [{"kind": "InfraDevice", "reason": "r" * 160}]
+
+    declared = ConfigurationPackage.model_validate(data)
+
+    assert declared.omissions[0].reason == "r" * 160
+    with pytest.raises(ConfigurationPackageParseError) as caught:
+        parse_configuration_package({**data, "omissions": [{"kind": "InfraDevice", "note": "x"}]})
+    assert str(caught.value) == "configuration package is invalid at /omissions/0/note: unsupported declared field"
+
+
+def test_an_over_long_omission_reason_is_a_clean_registration_time_refusal() -> None:
+    # The 160-character bound plus the fixed message template stays under the 256 finding
+    # text bound, so an over-long reason is refused here and can never crash a finding.
+    data = _package().model_dump(mode="json")
+    data["omissions"] = [{"kind": "InfraDevice", "reason": "r" * 161}]
+
+    with pytest.raises(ConfigurationPackageParseError) as caught:
+        parse_configuration_package(data)
+
+    assert str(caught.value) == "configuration package is invalid at /omissions/0/reason: value is too long"
+    assert "r" * 161 not in str(caught.value)
+
+
+def test_an_empty_omission_field_list_is_refused() -> None:
+    # Omitting the list omits the whole kind; an empty list would declare nothing.
+    data = _package().model_dump(mode="json")
+    data["omissions"] = [{"kind": "InfraDevice", "fields": []}]
+
+    with pytest.raises(ConfigurationPackageParseError):
+        parse_configuration_package(data)
+
+
 @pytest.mark.parametrize("flag_name", ["SKIP_UNMATCHED_DST", "SKIP_UNMATCHED_BOTH", "NONE"])
 def test_diffsync_flags_are_declared_and_hashed_by_stable_name(flag_name: str) -> None:
     data = _package().model_dump(mode="json")

--- a/tests/configuration/test_contracts.py
+++ b/tests/configuration/test_contracts.py
@@ -2194,15 +2194,59 @@ def test_findings_use_deterministic_interface_order() -> None:
     ]
 
 
-def test_finding_severity_has_no_channel_beyond_error() -> None:
-    # A severity nothing reports would let a capability author write into silence.
+def test_finding_severity_carries_exactly_the_two_contract_severities() -> None:
+    # OES-8 candidate A: "warning" exists now that the two contract section 4 families
+    # report into it. A third severity still has nothing that reports it, so it would let
+    # a capability author write into silence and is refused at the model.
+    warning = ValidationFinding(code="optional-field", severity="warning", location="/a", message="optional")
+
+    assert warning.severity == "warning"
     with pytest.raises(ValidationError):
         ValidationFinding(
             code="optional-field",
-            severity=cast("Any", "warning"),
+            severity=cast("Any", "info"),
             location="/a",
             message="optional",
         )
+
+
+def test_error_findings_sort_before_warnings_at_the_same_location() -> None:
+    # (location, severity, code): severity separates two findings at one location with one
+    # code, and error comes first because errors prevent execution and warnings do not.
+    findings = [
+        ValidationFinding(code="same-code", severity="warning", location="/a", message="warning"),
+        ValidationFinding(code="same-code", severity="error", location="/a", message="error"),
+    ]
+
+    assert [item.severity for item in sort_findings(findings)] == ["error", "warning"]
+
+
+def test_mixed_severity_ordering_is_deterministic_across_invocations() -> None:
+    findings = [
+        ValidationFinding(code="zulu-code", severity="warning", location="/a", message="w"),
+        ValidationFinding(code="alpha-code", severity="warning", location="/a", message="w"),
+        ValidationFinding(code="mid-code", severity="error", location="/b", message="e"),
+        ValidationFinding(code="alpha-code", severity="error", location="/a", message="e"),
+    ]
+
+    ordered = sort_findings(findings)
+
+    assert ordered == sort_findings(list(reversed(findings)))
+    assert [(item.location, item.severity, item.code) for item in ordered] == [
+        ("/a", "error", "alpha-code"),
+        ("/a", "warning", "alpha-code"),
+        ("/a", "warning", "zulu-code"),
+        ("/b", "error", "mid-code"),
+    ]
+
+
+def test_sort_findings_still_refuses_a_third_severity() -> None:
+    # The severity dict raises KeyError on a severity outside the declared vocabulary
+    # rather than sorting it somewhere silently; only the model widening was sanctioned.
+    smuggled = ValidationFinding.model_construct(code="smuggled-code", severity="info", location="/a", message="m")
+
+    with pytest.raises(KeyError):
+        sort_findings([cast("ValidationFinding", smuggled)])
 
 
 @pytest.mark.parametrize(

--- a/tests/configuration/test_contracts.py
+++ b/tests/configuration/test_contracts.py
@@ -2102,7 +2102,9 @@ def test_case_variant_adapter_name_cannot_split_package_identity() -> None:
     package = ConfigurationPackage.model_validate(data)
 
     assert package.checksum() != _package().checksum()
-    with pytest.raises(UnknownAdapterCapabilitiesError, match="no configuration capability declaration"):
+    # OES-15: every validation refusal is one exception type now. The narrow type still exists
+    # where it belongs, pinned by test_capability_lookup_is_exact_and_unknown_is_refused.
+    with pytest.raises(CredentialConfigurationError, match="no configuration capability declaration"):
         validate_package_credentials(package)
 
 

--- a/tests/configuration/test_contracts.py
+++ b/tests/configuration/test_contracts.py
@@ -2311,7 +2311,7 @@ def test_sort_findings_still_refuses_a_third_severity() -> None:
     smuggled = ValidationFinding.model_construct(code="smuggled-code", severity="info", location="/a", message="m")
 
     with pytest.raises(KeyError):
-        sort_findings([cast("ValidationFinding", smuggled)])
+        sort_findings([smuggled])
 
 
 @pytest.mark.parametrize(

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -630,3 +630,58 @@ def test_a_missing_declared_url_lands_as_a_typed_finding(monkeypatch: pytest.Mon
     ]
     assert "unconfigured" in result.findings[0].message
     assert result.schema_fingerprint is None
+
+
+# --- Pre-PR correction F3: a malformed schema response is a typed read failure ----------
+
+
+class _ReturningSchemaEndpoint:
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def all(self, branch: str) -> object:
+        del branch
+        return self._response
+
+
+class _ReturningClient:
+    def __init__(self, response: object) -> None:
+        self.schema = _ReturningSchemaEndpoint(response)
+
+
+def _mock_schema_read_response(monkeypatch: pytest.MonkeyPatch, response: object) -> None:
+    _inject(monkeypatch, _live_read_table())
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "test-token")
+
+    def _fake_client(address: str, config: object) -> _ReturningClient:
+        del address, config
+        return _ReturningClient(response)
+
+    monkeypatch.setattr("infrahub_sdk.InfrahubClientSync", _fake_client)
+
+
+class _MalformedNode:
+    """A node whose attributes are plain dicts rather than SDK attribute objects."""
+
+    attributes = ({"name": "hostname", "kind": "Text"},)
+    relationships = ()
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        # A read the client call accepted but that cannot be normalized into a snapshot.
+        # Before normalization moved inside the typed boundary, each escaped the accessor
+        # as an untyped AttributeError/TypeError the service boundary could only report
+        # as ConfigsInternalError.
+        pytest.param(None, id="none-root"),
+        pytest.param(["InfraDevice"], id="wrong-type-root"),
+        pytest.param({"InfraDevice": _MalformedNode()}, id="malformed-member"),
+    ],
+)
+def test_a_malformed_schema_response_lands_as_a_typed_finding(
+    monkeypatch: pytest.MonkeyPatch, response: object
+) -> None:
+    _mock_schema_read_response(monkeypatch, response)
+
+    _read_failure_and_write_findings("rejected")

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -767,12 +767,14 @@ def test_every_normalization_failure_lands_as_a_typed_finding(
     _read_failure_and_write_findings("rejected")
 
 
-def test_a_normalization_refusal_carries_the_exception_type_name_only() -> None:
+def test_a_normalization_refusal_carries_the_fixed_message_only() -> None:
+    # The rejection reads nothing from the exception — not even its type name, whose
+    # read a hostile metaclass executes on — so the message is one fixed sentence.
     with pytest.raises(DestinationSchemaReadError) as caught:
         capabilities_module._normalized_schema_snapshot(_RaisingItemsSchema())
 
     message = str(caught.value)
-    assert "RuntimeError" in message
+    assert message == "destination returned an unusable schema response"
     assert "third-party secret text" not in message
     assert caught.value.reason == "rejected"
 

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import re
+from collections.abc import ItemsView, Iterator, Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -39,7 +40,7 @@ from infrahub_sync.configuration.validation import collect_findings, validate_pa
 from tests.configuration.validation_packages import package, package_data
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
     from infrahub_sync.configuration import ConfigurationPackage
 
@@ -686,6 +687,94 @@ def test_a_malformed_schema_response_lands_as_a_typed_finding(
     _mock_schema_read_response(monkeypatch, response)
 
     _read_failure_and_write_findings("rejected")
+
+
+# --- Property closure P3: schema normalization is one total typed boundary --------------
+
+
+class _RaisingItemsSchema(Mapping):
+    """A real ``Mapping`` whose ``items()`` raises an arbitrary ordinary exception."""
+
+    def __getitem__(self, key: str) -> object:
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+    def items(self) -> ItemsView[str, object]:  # noqa: PLR6301 - protocol hook, self unused by design
+        msg = "items() exploded: third-party secret text"
+        raise RuntimeError(msg)
+
+
+class _RaisingIterationSchema(Mapping):
+    """A real ``Mapping`` whose iteration raises once ``items()`` is consumed."""
+
+    def __getitem__(self, key: str) -> object:
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[str]:
+        msg = "iteration exploded"
+        raise RuntimeError(msg)
+
+    def __len__(self) -> int:
+        return 0
+
+
+class _RaisingAttributesNode:
+    """A member node whose ``attributes`` property raises a non-AttributeError."""
+
+    relationships: tuple[object, ...] = ()
+
+    @property
+    def attributes(self) -> tuple[object, ...]:
+        msg = "attributes exploded"
+        raise RuntimeError(msg)
+
+
+class _NonStringShapeNode:
+    """A member node the SDK contract does not promise: a non-string attribute kind."""
+
+    class _Attribute:
+        name = "hostname"
+        kind = 123
+
+    attributes = (_Attribute(),)
+    relationships: tuple[object, ...] = ()
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        # Every schema-read normalization failure is the same typed finding. Before the
+        # whole normalization ran inside one boundary, only enumerated exception types
+        # were classified: a RuntimeError from items(), from member iteration, or from a
+        # raising attribute property escaped validate() as ConfigsInternalError.
+        pytest.param(_RaisingItemsSchema(), id="raising-items"),
+        pytest.param(_RaisingIterationSchema(), id="raising-iteration"),
+        pytest.param({"InfraDevice": _RaisingAttributesNode()}, id="raising-attribute-property"),
+        pytest.param({"InfraDevice": _NonStringShapeNode()}, id="non-string-member-shape"),
+        pytest.param({1: _MalformedNode()}, id="non-string-kind"),
+    ],
+)
+def test_every_normalization_failure_lands_as_a_typed_finding(
+    monkeypatch: pytest.MonkeyPatch, response: object
+) -> None:
+    _mock_schema_read_response(monkeypatch, response)
+
+    _read_failure_and_write_findings("rejected")
+
+
+def test_a_normalization_refusal_carries_the_exception_type_name_only() -> None:
+    with pytest.raises(DestinationSchemaReadError) as caught:
+        capabilities_module._normalized_schema_snapshot(_RaisingItemsSchema())
+
+    message = str(caught.value)
+    assert "RuntimeError" in message
+    assert "third-party secret text" not in message
+    assert caught.value.reason == "rejected"
 
 
 # --- Pre-PR correction F5: the schema-module enumeration is documented ------------------

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -1,0 +1,474 @@
+"""Destination schema validation — the explicit opt-in checks outside the declared-content core.
+
+Everything here exercises :mod:`infrahub_sync.configuration.schema_validation` and the
+accessor seam on :mod:`infrahub_sync.configuration.capabilities`. Schema snapshots are
+injected through the seam; no test contacts a live server (the live-read exercise is the
+opt-in integration test). The declared-content core and its frozen tests stay untouched —
+this module carries the schema-path mirror of the core's exact-set and reachability tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub_sync.cache import compute_schema_subhash
+from infrahub_sync.configuration import schema_validation
+from infrahub_sync.configuration import validation as validation_module
+from infrahub_sync.configuration.capabilities import (
+    BUILTIN_ADAPTER_CAPABILITIES,
+    AdapterConfigurationCapabilities,
+    DestinationSchemaReadError,
+    _read_infrahub_destination_schema,
+)
+from infrahub_sync.configuration.schema_validation import (
+    collect_destination_schema_findings,
+    resolve_declared_destination_branch,
+)
+from infrahub_sync.configuration.credentials import CredentialConfigurationError
+from infrahub_sync.configuration.validation import collect_findings, validate_package_credentials
+from tests.configuration.validation_packages import package, package_data
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from infrahub_sync.configuration import ConfigurationPackage
+
+
+# A real destination schema snapshot shape: kind -> attributes (name -> kind) and
+# relationships (name -> peer + cardinality), exactly what the accessor contract returns.
+_SNAPSHOT: dict[str, Any] = {
+    "InfraDevice": {
+        "attributes": {"name": "Text", "description": "Text"},
+        "relationships": {
+            "site": {"peer": "LocationSite", "cardinality": "one"},
+            "tags": {"peer": "BuiltinTag", "cardinality": "many"},
+        },
+    },
+    "LocationSite": {"attributes": {"name": "Text"}, "relationships": {}},
+}
+
+
+class _SpiedAccessor:
+    """An injected accessor that records every read and returns a fixed snapshot."""
+
+    def __init__(self, snapshot: Mapping[str, Any] | None = None) -> None:
+        self.snapshot = _SNAPSHOT if snapshot is None else snapshot
+        self.calls: list[str] = []
+
+    def __call__(self, package_: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+        del package_
+        self.calls.append(branch)
+        return self.snapshot
+
+
+def _raising_accessor(reason: str) -> Callable[[ConfigurationPackage, str], Mapping[str, Any]]:
+    def read(package_: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+        del package_
+        msg = f"schema read failed for branch {branch!r}"
+        raise DestinationSchemaReadError(msg, reason=reason)
+
+    return read
+
+
+def _table_with_accessor(
+    accessor: Callable[[ConfigurationPackage, str], Mapping[str, Any]],
+) -> dict[str, AdapterConfigurationCapabilities]:
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["infrahub"] = replace(table["infrahub"], destination_schema_accessor=accessor)
+    return table
+
+
+def _inject(
+    monkeypatch: pytest.MonkeyPatch,
+    table: dict[str, AdapterConfigurationCapabilities],
+) -> None:
+    monkeypatch.setattr(schema_validation, "BUILTIN_ADAPTER_CAPABILITIES", table)
+
+
+def _mapping_package_data(
+    fields: list[dict[str, Any]] | None = None,
+    *,
+    kind: str = "InfraDevice",
+) -> dict[str, Any]:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [
+        {"name": kind, "mapping": "dcim.devices", "fields": [] if fields is None else fields}
+    ]
+    return data
+
+
+def _codes_and_locations(findings: tuple[Any, ...]) -> list[tuple[str, str]]:
+    return [(finding.code, finding.location) for finding in findings]
+
+
+# --- The accessor seam (registration-time invariant) ---------------------------------
+
+
+def test_declaring_schema_validation_without_an_accessor_is_a_registration_time_error() -> None:
+    with pytest.raises(ValueError, match="schema"):
+        AdapterConfigurationCapabilities(
+            adapter_name="declared-without-accessor",
+            roles=frozenset({"destination"}),
+            destination_schema_validation=True,
+        )
+
+
+def test_an_accessor_without_the_declaration_is_a_registration_time_error() -> None:
+    with pytest.raises(ValueError, match="schema"):
+        AdapterConfigurationCapabilities(
+            adapter_name="accessor-without-declaration",
+            roles=frozenset({"destination"}),
+            destination_schema_accessor=_SpiedAccessor(),
+        )
+
+
+def test_the_bundled_infrahub_declaration_binds_the_live_accessor() -> None:
+    capabilities = BUILTIN_ADAPTER_CAPABILITIES["infrahub"]
+    assert capabilities.destination_schema_validation is True
+    assert capabilities.destination_schema_accessor is _read_infrahub_destination_schema
+
+
+def test_a_read_error_requires_a_short_lowercase_reason() -> None:
+    error = DestinationSchemaReadError("boom", reason="timeout")
+    assert error.reason == "timeout"
+    with pytest.raises(ValueError, match="reason"):
+        DestinationSchemaReadError("boom", reason="Not A Word!")
+
+
+# --- The interim branch-resolution helper (SYNC-79 direction) -------------------------
+
+
+def test_the_declared_branch_setting_is_resolved() -> None:
+    data = package_data()
+    data["configuration"]["destination"]["settings"]["branch"] = "staging"
+    assert resolve_declared_destination_branch(package(data)) == "staging"
+
+
+def test_an_absent_branch_setting_resolves_to_main() -> None:
+    assert resolve_declared_destination_branch(package(package_data())) == "main"
+
+
+def test_a_non_string_branch_setting_resolves_to_main() -> None:
+    data = package_data()
+    data["configuration"]["destination"]["settings"]["branch"] = 5
+    assert resolve_declared_destination_branch(package(data)) == "main"
+
+
+def test_the_ambient_environment_is_never_read_for_the_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The helper reads the declared setting only — never the environment (SYNC-79).
+    monkeypatch.setenv("INFRAHUB_BRANCH", "ambient-branch")
+    monkeypatch.setenv("INFRAHUB_DEFAULT_BRANCH", "ambient-branch")
+    assert resolve_declared_destination_branch(package(package_data())) == "main"
+
+
+def test_the_schema_read_consumes_the_resolved_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    accessor = _SpiedAccessor()
+    _inject(monkeypatch, _table_with_accessor(accessor))
+    data = package_data()
+    data["configuration"]["destination"]["settings"]["branch"] = "staging"
+
+    collect_destination_schema_findings(package(data))
+
+    assert accessor.calls == ["staging"]
+
+
+# --- AR3: the four error fixtures against an injected snapshot ------------------------
+
+
+def test_an_unknown_kind_is_an_error_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    # The bogus field under the unknown kind is judged nowhere deeper: the kind made the
+    # subtree unevaluable, so exactly one finding names the defect (the OES-15 rule).
+    data = _mapping_package_data([{"name": "bogus"}], kind="NopeKind")
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-mismatch", "/configuration/schema_mapping/0/name")
+    ]
+
+
+def test_an_unknown_field_is_an_error_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    data = _mapping_package_data([{"name": "serial_number", "mapping": "serial"}])
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-mismatch", "/configuration/schema_mapping/0/fields/0/name")
+    ]
+
+
+def test_a_reference_on_an_attribute_is_a_wrong_type_error_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    # `name` is an attribute of InfraDevice; a reference can only bind a relationship.
+    data = _mapping_package_data([{"name": "name", "mapping": "name", "reference": "LocationSite"}])
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-mismatch", "/configuration/schema_mapping/0/fields/0/reference")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "location"),
+    [
+        pytest.param(
+            {"name": "site", "static": ["a", "b"]},
+            "/configuration/schema_mapping/0/fields/0/static",
+            id="list-static-on-cardinality-one",
+        ),
+        pytest.param(
+            {"name": "tags", "static": "a"},
+            "/configuration/schema_mapping/0/fields/0/static",
+            id="scalar-static-on-cardinality-many",
+        ),
+    ],
+)
+def test_a_wrong_relationship_cardinality_is_an_error_finding(
+    monkeypatch: pytest.MonkeyPatch, field: dict[str, Any], location: str
+) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+
+    result = collect_destination_schema_findings(package(_mapping_package_data([field])))
+
+    assert _codes_and_locations(result.findings) == [("destination-schema-mismatch", location)]
+
+
+def test_a_conforming_mapping_yields_no_findings_and_a_fingerprint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    data = _mapping_package_data(
+        [
+            {"name": "name", "mapping": "name"},
+            {"name": "site", "mapping": "site.name", "reference": "LocationSite"},
+            {"name": "tags", "static": ["managed"]},
+        ]
+    )
+    parsed = package(data)
+
+    result = collect_destination_schema_findings(parsed)
+
+    assert result.findings == ()
+    assert result.schema_fingerprint == compute_schema_subhash(parsed.configuration, _SNAPSHOT)
+
+
+# --- AR2: capability gating -----------------------------------------------------------
+
+
+def test_an_explicit_request_against_a_non_declaring_destination_is_an_error_finding() -> None:
+    # peeringmanager is a real destination that does not declare schema validation, and it
+    # declares update as its only write operation, so the shipped infrahub_to_peering-manager
+    # shape — creates requested, update-only declared — reports both defects (AR5 fixture).
+    data = package_data()
+    data["configuration"]["destination"]["name"] = "peeringmanager"
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-validation-unsupported", "/configuration/destination"),
+        ("unsupported-destination-write", "/configuration/destination"),
+    ]
+    assert result.schema_fingerprint is None
+
+
+def test_an_update_only_request_against_an_update_only_destination_is_clean() -> None:
+    # SKIP_UNMATCHED_SRC removes create, and delete is never requested under the supported
+    # live-sync profile even though SKIP_UNMATCHED_DST is not configured (SYNC-78).
+    data = package_data()
+    data["configuration"]["destination"]["name"] = "peeringmanager"
+    data["configuration"]["diffsync_flags"] = ["SKIP_UNMATCHED_SRC"]
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert [finding.code for finding in result.findings] == ["destination-schema-validation-unsupported"]
+
+
+def test_an_unknown_destination_adapter_adds_no_schema_findings() -> None:
+    # The core already reports missing-adapter for the destination and keeps judging
+    # everything independent of it; the schema checks add nothing on the unevaluable subtree.
+    data = package_data()
+    data["configuration"]["destination"]["name"] = "doesnotexist"
+    data["configuration"]["source"]["settings"]["bogus_source"] = "x"
+    parsed = package(data)
+
+    result = collect_destination_schema_findings(parsed)
+    core = collect_findings(parsed)
+
+    assert result.findings == ()
+    assert result.schema_fingerprint is None
+    assert ("missing-adapter", "/configuration/destination") in _codes_and_locations(core)
+    assert ("undeclared-setting", "/configuration/source/settings/bogus_source") in _codes_and_locations(core)
+
+
+# --- AR9: a failed schema read is a typed error finding -------------------------------
+
+
+@pytest.mark.parametrize("reason", ["timeout", "unauthorized", "unreachable"])
+def test_a_failed_schema_read_is_an_error_finding_not_a_raise(
+    monkeypatch: pytest.MonkeyPatch, reason: str
+) -> None:
+    _inject(monkeypatch, _table_with_accessor(_raising_accessor(reason)))
+
+    result = collect_destination_schema_findings(package(package_data()))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-read-failed", "/configuration/destination")
+    ]
+    assert reason in result.findings[0].message
+    assert result.schema_fingerprint is None
+
+
+def test_a_failed_schema_read_does_not_suppress_the_write_operations_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An update-only destination that also declares schema validation, whose read fails:
+    # the two checks are independent, so both report (the accumulating contract).
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["peeringmanager"] = replace(
+        table["peeringmanager"],
+        destination_schema_validation=True,
+        destination_schema_accessor=_raising_accessor("timeout"),
+    )
+    _inject(monkeypatch, table)
+    data = package_data()
+    data["configuration"]["destination"]["name"] = "peeringmanager"
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-read-failed", "/configuration/destination"),
+        ("unsupported-destination-write", "/configuration/destination"),
+    ]
+
+
+# --- AR6: determinism and ordering -----------------------------------------------------
+
+
+def test_the_same_package_and_snapshot_produce_byte_identical_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    data = _mapping_package_data([{"name": "bogus"}, {"name": "also_bogus"}])
+
+    first = collect_destination_schema_findings(package(data))
+    second = collect_destination_schema_findings(package(data))
+
+    assert first.findings == second.findings
+    assert first.schema_fingerprint == second.schema_fingerprint
+
+
+def test_schema_findings_arrive_in_the_stable_sort_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [
+        {"name": "InfraDevice", "mapping": "dcim.devices", "fields": [{"name": "bogus"}]},
+        {"name": "NopeKind", "mapping": "dcim.nope"},
+    ]
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-mismatch", "/configuration/schema_mapping/0/fields/0/name"),
+        ("destination-schema-mismatch", "/configuration/schema_mapping/1/name"),
+    ]
+
+
+# --- AR4 (retained): the wrapper path never performs a schema read ---------------------
+
+
+def test_the_wrapper_and_the_core_never_call_a_schema_accessor(monkeypatch: pytest.MonkeyPatch) -> None:
+    accessor = _SpiedAccessor()
+    table = _table_with_accessor(accessor)
+    monkeypatch.setattr(validation_module, "BUILTIN_ADAPTER_CAPABILITIES", table)
+    _inject(monkeypatch, table)
+    defective = package_data()
+    defective["configuration"]["destination"]["settings"]["bogus_dest"] = "x"
+
+    assert validate_package_credentials(package(package_data())) is None
+    with pytest.raises(CredentialConfigurationError, match="bogus_dest"):
+        validate_package_credentials(package(defective))
+    collect_findings(package(defective))
+
+    assert accessor.calls == []
+
+
+# --- AR8: the schema module's own exact-set and reachability tests ---------------------
+
+
+FROZEN_SCHEMA_CODES = frozenset(
+    {
+        # The destination-schema-mismatch family: declared mappings judged against the
+        # snapshot, and the capability gate for a destination that cannot be judged at all.
+        "destination-schema-mismatch",
+        "destination-schema-validation-unsupported",
+        # The unsupported-destination-write family.
+        "unsupported-destination-write",
+        # AR9's schema-read-failure family.
+        "destination-schema-read-failed",
+    }
+)
+
+
+def _declared_codes(tree: ast.AST) -> set[str]:
+    declared: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        if any(name.startswith("_CODE_") for name in names) and isinstance(node.value, ast.Constant):
+            declared.add(str(node.value.value))
+    return declared
+
+
+_KEBAB_LITERAL = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)+$")
+
+
+def _kebab_literals(tree: ast.AST) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _KEBAB_LITERAL.fullmatch(node.value) is not None
+    }
+
+
+def test_the_schema_module_can_emit_exactly_the_frozen_schema_code_enumeration() -> None:
+    # The schema-path mirror of the core's exact-set test: collected from the implementation,
+    # not restated, and extended only by new enumerated surface — never by loosening this.
+    tree = ast.parse(Path(schema_validation.__file__).read_text(encoding="utf-8"))
+
+    assert _declared_codes(tree) == FROZEN_SCHEMA_CODES
+    assert _kebab_literals(tree) == FROZEN_SCHEMA_CODES
+
+
+def test_every_frozen_schema_code_is_reachable_and_nothing_else_is_emitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reached: set[str] = set()
+    severities: set[str] = set()
+
+    _inject(monkeypatch, _table_with_accessor(_SpiedAccessor()))
+    for finding in collect_destination_schema_findings(package(_mapping_package_data(kind="NopeKind"))).findings:
+        reached.add(finding.code)
+        severities.add(finding.severity)
+    _inject(monkeypatch, _table_with_accessor(_raising_accessor("timeout")))
+    for finding in collect_destination_schema_findings(package(package_data())).findings:
+        reached.add(finding.code)
+        severities.add(finding.severity)
+    _inject(monkeypatch, dict(BUILTIN_ADAPTER_CAPABILITIES))
+    non_declaring = package_data()
+    non_declaring["configuration"]["destination"]["name"] = "peeringmanager"
+    for finding in collect_destination_schema_findings(package(non_declaring)).findings:
+        reached.add(finding.code)
+        severities.add(finding.severity)
+
+    assert reached == FROZEN_SCHEMA_CODES
+    assert severities == {"error"}

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -18,19 +18,19 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from infrahub_sync.cache import compute_schema_subhash
+from infrahub_sync.configuration import capabilities as capabilities_module
 from infrahub_sync.configuration import schema_validation
 from infrahub_sync.configuration import validation as validation_module
 from infrahub_sync.configuration.capabilities import (
     BUILTIN_ADAPTER_CAPABILITIES,
     AdapterConfigurationCapabilities,
     DestinationSchemaReadError,
-    _read_infrahub_destination_schema,
 )
+from infrahub_sync.configuration.credentials import CredentialConfigurationError
 from infrahub_sync.configuration.schema_validation import (
     collect_destination_schema_findings,
     resolve_declared_destination_branch,
 )
-from infrahub_sync.configuration.credentials import CredentialConfigurationError
 from infrahub_sync.configuration.validation import collect_findings, validate_package_credentials
 from tests.configuration.validation_packages import package, package_data
 
@@ -131,7 +131,7 @@ def test_an_accessor_without_the_declaration_is_a_registration_time_error() -> N
 def test_the_bundled_infrahub_declaration_binds_the_live_accessor() -> None:
     capabilities = BUILTIN_ADAPTER_CAPABILITIES["infrahub"]
     assert capabilities.destination_schema_validation is True
-    assert capabilities.destination_schema_accessor is _read_infrahub_destination_schema
+    assert capabilities.destination_schema_accessor is capabilities_module._read_infrahub_destination_schema
 
 
 def test_a_read_error_requires_a_short_lowercase_reason() -> None:
@@ -311,16 +311,12 @@ def test_an_unknown_destination_adapter_adds_no_schema_findings() -> None:
 
 
 @pytest.mark.parametrize("reason", ["timeout", "unauthorized", "unreachable"])
-def test_a_failed_schema_read_is_an_error_finding_not_a_raise(
-    monkeypatch: pytest.MonkeyPatch, reason: str
-) -> None:
+def test_a_failed_schema_read_is_an_error_finding_not_a_raise(monkeypatch: pytest.MonkeyPatch, reason: str) -> None:
     _inject(monkeypatch, _table_with_accessor(_raising_accessor(reason)))
 
     result = collect_destination_schema_findings(package(package_data()))
 
-    assert _codes_and_locations(result.findings) == [
-        ("destination-schema-read-failed", "/configuration/destination")
-    ]
+    assert _codes_and_locations(result.findings) == [("destination-schema-read-failed", "/configuration/destination")]
     assert reason in result.findings[0].message
     assert result.schema_fingerprint is None
 

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -20,6 +20,7 @@ import pydantic
 import pytest
 from infrahub_sdk import exceptions as sdk_exceptions
 
+import infrahub_sync
 from infrahub_sync.cache import compute_schema_subhash
 from infrahub_sync.configuration import capabilities as capabilities_module
 from infrahub_sync.configuration import schema_validation
@@ -685,3 +686,16 @@ def test_a_malformed_schema_response_lands_as_a_typed_finding(
     _mock_schema_read_response(monkeypatch, response)
 
     _read_failure_and_write_findings("rejected")
+
+
+# --- Pre-PR correction F5: the schema-module enumeration is documented ------------------
+
+
+def test_every_frozen_schema_code_is_documented_for_an_operator() -> None:
+    # The schema-path mirror of the core's documentation guard: a stable identifier an
+    # operator can meet - opt-in emission included - must be one they can look up.
+    reference = Path(infrahub_sync.__file__).parents[1] / "docs" / "docs" / "reference" / "durable-product-records.mdx"
+    documented = reference.read_text(encoding="utf-8")
+
+    assert "### Finding codes" in documented
+    assert {code for code in FROZEN_SCHEMA_CODES if f"`{code}`" not in documented} == set()

--- a/tests/configuration/test_schema_validation.py
+++ b/tests/configuration/test_schema_validation.py
@@ -15,7 +15,10 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import httpx
+import pydantic
 import pytest
+from infrahub_sdk import exceptions as sdk_exceptions
 
 from infrahub_sync.cache import compute_schema_subhash
 from infrahub_sync.configuration import capabilities as capabilities_module
@@ -468,3 +471,162 @@ def test_every_frozen_schema_code_is_reachable_and_nothing_else_is_emitted(
 
     assert reached == FROZEN_SCHEMA_CODES
     assert severities == {"error"}
+
+
+# --- Correction round 1 (F1): the live accessor's classification arms, mocked client ----
+
+
+def _live_read_table() -> dict[str, AdapterConfigurationCapabilities]:
+    """The real live accessor, with an update-only write declaration.
+
+    Update-only makes the write-operations check report (creates are requested by
+    default), so every read-failure test also witnesses that an independent check
+    still reports alongside the typed finding.
+    """
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["infrahub"] = replace(table["infrahub"], supported_destination_write_operations=frozenset({"update"}))
+    return table
+
+
+class _FakeSchemaEndpoint:
+    def __init__(self, exception: Exception) -> None:
+        self._exception = exception
+
+    def all(self, branch: str) -> None:
+        del branch
+        raise self._exception
+
+
+class _FakeClient:
+    def __init__(self, exception: Exception) -> None:
+        self.schema = _FakeSchemaEndpoint(exception)
+
+
+def _mock_schema_read_failure(monkeypatch: pytest.MonkeyPatch, exception: Exception) -> None:
+    _inject(monkeypatch, _live_read_table())
+    # The declared token reference must resolve, or the credentials arm reports before
+    # the mocked client is ever constructed.
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "test-token")
+
+    def _fake_client(address: str, config: object) -> _FakeClient:
+        del address, config
+        return _FakeClient(exception)
+
+    monkeypatch.setattr("infrahub_sdk.InfrahubClientSync", _fake_client)
+
+
+def _read_failure_and_write_findings(reason: str) -> None:
+    result = collect_destination_schema_findings(package(package_data()))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-read-failed", "/configuration/destination"),
+        ("unsupported-destination-write", "/configuration/destination"),
+    ]
+    assert reason in result.findings[0].message
+    assert result.schema_fingerprint is None
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "http://localhost:8000")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("refused", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("exception", "reason"),
+    [
+        pytest.param(httpx.TimeoutException("timed out"), "timeout", id="httpx-timeout"),
+        pytest.param(
+            sdk_exceptions.ServerNotResponsiveError(url="http://localhost:8000"),
+            "timeout",
+            id="sdk-not-responsive",
+        ),
+        pytest.param(sdk_exceptions.AuthenticationError("denied"), "unauthorized", id="sdk-authentication"),
+        pytest.param(_http_status_error(401), "unauthorized", id="http-status-401"),
+        pytest.param(_http_status_error(403), "unauthorized", id="http-status-403"),
+        pytest.param(_http_status_error(500), "unreachable", id="http-status-500"),
+        pytest.param(httpx.ConnectError("refused"), "unreachable", id="httpx-transport"),
+        pytest.param(
+            sdk_exceptions.ServerNotReachableError(address="http://localhost:8000"),
+            "unreachable",
+            id="sdk-not-reachable",
+        ),
+        pytest.param(
+            sdk_exceptions.GraphQLError(errors=[{"message": "boom"}]),
+            "rejected",
+            id="sdk-error-graphql",
+        ),
+    ],
+)
+def test_every_live_accessor_classification_arm_lands_as_a_typed_finding(
+    monkeypatch: pytest.MonkeyPatch, exception: Exception, reason: str
+) -> None:
+    _mock_schema_read_failure(monkeypatch, exception)
+
+    _read_failure_and_write_findings(reason)
+
+
+def test_a_missing_branch_lands_as_a_typed_finding_not_a_boundary_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The review F1 reproduction: a typo'd declared branch makes the SDK raise
+    # BranchNotFoundError, which escaped the accessor untyped and surfaced as the
+    # generic service-boundary refusal.
+    _mock_schema_read_failure(monkeypatch, sdk_exceptions.BranchNotFoundError("no-such-branch"))
+
+    _read_failure_and_write_findings("rejected")
+
+
+def _pydantic_validation_error() -> pydantic.ValidationError:
+    try:
+        pydantic.TypeAdapter(int).validate_python("not-a-number")
+    except pydantic.ValidationError as exc:
+        return exc
+    raise AssertionError
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(ValueError("bad declared value"), id="value-error"),
+        pytest.param(_pydantic_validation_error(), id="pydantic-validation-error"),
+    ],
+)
+def test_an_unusable_declared_client_configuration_lands_as_a_typed_finding(
+    monkeypatch: pytest.MonkeyPatch, exception: Exception
+) -> None:
+    _inject(monkeypatch, _live_read_table())
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "test-token")
+
+    def _refusing_config(**kwargs: object) -> object:
+        del kwargs
+        raise exception
+
+    monkeypatch.setattr("infrahub_sdk.Config", _refusing_config)
+
+    _read_failure_and_write_findings("unconfigured")
+
+
+def test_an_unresolvable_declared_token_lands_as_a_typed_finding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _inject(monkeypatch, _live_read_table())
+    monkeypatch.delenv("INFRAHUB_API_TOKEN", raising=False)
+
+    _read_failure_and_write_findings("credentials")
+
+
+def test_a_missing_declared_url_lands_as_a_typed_finding(monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject(monkeypatch, _live_read_table())
+    data = package_data()
+    del data["configuration"]["destination"]["settings"]["url"]
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "test-token")
+
+    result = collect_destination_schema_findings(package(data))
+
+    assert _codes_and_locations(result.findings) == [
+        ("destination-schema-read-failed", "/configuration/destination"),
+        ("unsupported-destination-write", "/configuration/destination"),
+    ]
+    assert "unconfigured" in result.findings[0].message
+    assert result.schema_fingerprint is None

--- a/tests/configuration/test_validation_compatibility.py
+++ b/tests/configuration/test_validation_compatibility.py
@@ -277,6 +277,42 @@ def test_every_validation_refusal_raises_one_exception_type(
         validate_package_credentials(package(data))
 
 
+def test_a_warning_only_package_does_not_raise() -> None:
+    # Errors prevent execution; warnings do not. A package whose only findings are
+    # warnings validates with no wrapper raise, so registration cannot refuse it.
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "fields": ["serial_number"]}]
+
+    validate_package_credentials(package(data))
+
+
+def test_the_wrapper_raises_the_first_error_even_when_warnings_precede_it() -> None:
+    # The element-zero pin's one sanctioned re-reading: "the first finding" becomes "the
+    # first *error* in execution order". A warning accumulates ahead of this error, and
+    # the raised message is still the error's own.
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": "InfraDevice", "mapping": "dcim.devices"}]
+    data["omissions"] = [{"kind": "InfraCircuit"}, {"kind": "InfraDevice"}]
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    assert str(caught.value) == "omission names content a schema mapping also maps"
+
+
+def test_a_legacy_defect_keeps_its_shipped_message_when_warnings_are_also_declared() -> None:
+    # The warning families run after the shipped execution order, so a package carrying a
+    # legacy defect raises the same message it raised before omissions existed.
+    data = package_data()
+    data["credentials"]["netbox-token"]["provider"] = "vault"
+    data["omissions"] = [{"kind": "InfraDevice"}]
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    assert str(caught.value) == "credential reference 'netbox-token' uses provider 'vault', which is not installed"
+
+
 def _two_defective_declarations(first_name: str, second_name: str) -> dict[str, Any]:
     data = package_data()
     declarations = {

--- a/tests/configuration/test_validation_compatibility.py
+++ b/tests/configuration/test_validation_compatibility.py
@@ -1,0 +1,321 @@
+"""The shipped refusal contract of ``validate_package_credentials``, pinned site by site.
+
+Every message below was observed by executing ``c767067``. The accumulating core replaces the
+raise-first checks with finding producers, and the wrapper reproduces the message belonging to
+the finding the shipped code would have raised first — the **execution-order** element, not the
+sort-order one. A drift in either the messages or the check order moves an assertion here.
+
+Each of the eighteen shipped pins carries one defect, so none of them can see the order two
+*different* checks run in. ``CROSS_CHECK_REFUSALS`` covers that separately: each of its packages
+carries two defects that different checks report, so reordering those checks changes which
+message the wrapper raises and the pin moves.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub_sync.configuration import CredentialConfigurationError, validate_package_credentials
+from tests.configuration.validation_packages import package, package_data
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _unknown_provider(data: dict[str, Any]) -> None:
+    data["credentials"]["netbox-token"]["provider"] = "vault"
+
+
+def _invalid_identifier(data: dict[str, Any]) -> None:
+    data["credentials"]["netbox-token"]["identifier"] = "INVALID-NAME"
+
+
+def _undeclared_store_type(data: dict[str, Any]) -> None:
+    data["configuration"]["store"] = {"type": "mystery", "settings": {"url": "redis://localhost"}}
+
+
+def _undeclared_store_setting(data: dict[str, Any]) -> None:
+    data["configuration"]["store"] = {"type": "redis", "settings": {"host": "localhost", "bogus": 1}}
+
+
+def _store_names_unknown_reference(data: dict[str, Any]) -> None:
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": {"$credential": "nope"}}}
+
+
+def _store_carries_inline_value(data: dict[str, Any]) -> None:
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": "declared-in-line"}}
+
+
+def _store_carries_malformed_reference(data: dict[str, Any]) -> None:
+    node = {"$credential": "netbox-token", "fallback": "declared-in-line"}
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": node}}
+
+
+def _unknown_adapter(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["name"] = "NetBox"
+
+
+def _role_mismatch(data: dict[str, Any]) -> None:
+    data["configuration"]["destination"] = {"name": "netbox", "settings": {}}
+
+
+def _undeclared_adapter_setting(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["bogus"] = 1
+
+
+def _adapter_names_unknown_reference(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["token"] = {"$credential": "nope"}
+
+
+def _adapter_carries_inline_value(data: dict[str, Any]) -> None:
+    inline_value = "declared-in-line"
+    data["configuration"]["source"]["settings"]["token"] = inline_value
+
+
+def _url_is_not_a_string(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["url"] = {"nested": "value"}
+
+
+def _url_carries_request_material(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["url"] = "https://demo.netbox.dev/?page=1"
+
+
+def _url_is_not_absolute(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["url"] = "demo.netbox.dev"
+
+
+def _endpoint_is_not_relative(data: dict[str, Any]) -> None:
+    data["configuration"]["source"] = {
+        "name": "genericrestapi",
+        "settings": {"url": "https://api.example", "api_endpoint": "https://evil.example/api"},
+    }
+
+
+def _reference_outside_declared_paths(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["verify_ssl"] = {"$credential": "netbox-token"}
+
+
+def _adapter_validator_refuses(data: dict[str, Any]) -> None:
+    data["configuration"]["source"] = {"name": "genericrestapi", "settings": {"url": "https://api.example"}}
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "https://evil.example/devices"}]
+
+
+SHIPPED_REFUSALS: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+    (
+        "unknown-credential-provider",
+        _unknown_provider,
+        "credential reference 'netbox-token' uses provider 'vault', which is not installed",
+    ),
+    (
+        "malformed-credential-reference-declaration",
+        _invalid_identifier,
+        "credential reference 'netbox-token' has an invalid environment identifier",
+    ),
+    (
+        "missing-store-capabilities",
+        _undeclared_store_type,
+        "store type 'mystery' has no configuration capability declaration",
+    ),
+    (
+        "undeclared-setting-store",
+        _undeclared_store_setting,
+        "store type 'redis' contains unsupported declared settings: [\"bogus\"]",
+    ),
+    (
+        "unknown-credential-reference-store",
+        _store_names_unknown_reference,
+        "/configuration/store/settings/password names unknown credential reference 'nope'",
+    ),
+    (
+        "inline-credential-value-store",
+        _store_carries_inline_value,
+        "/configuration/store/settings/password contains an inline credential value",
+    ),
+    (
+        "malformed-credential-reference-store",
+        _store_carries_malformed_reference,
+        "/configuration/store/settings/password contains a malformed credential reference",
+    ),
+    (
+        "missing-adapter",
+        _unknown_adapter,
+        "adapter 'NetBox' has no configuration capability declaration",
+    ),
+    (
+        "adapter-role-mismatch",
+        _role_mismatch,
+        "adapter 'netbox' does not support the destination role",
+    ),
+    (
+        "undeclared-setting-adapter",
+        _undeclared_adapter_setting,
+        "adapter 'netbox' contains unsupported declared settings for the source role: [\"bogus\"]",
+    ),
+    (
+        "unknown-credential-reference-adapter",
+        _adapter_names_unknown_reference,
+        "/configuration/source/settings/token names unknown credential reference 'nope'",
+    ),
+    (
+        "inline-credential-value-adapter",
+        _adapter_carries_inline_value,
+        "/configuration/source/settings/token contains an inline credential value",
+    ),
+    (
+        "setting-not-a-string",
+        _url_is_not_a_string,
+        "/configuration/source/settings/url must be declared as a string",
+    ),
+    (
+        "setting-contains-credential-material",
+        _url_carries_request_material,
+        "/configuration/source/settings/url cannot contain user information, query parameters, or fragments",
+    ),
+    (
+        "endpoint-not-absolute",
+        _url_is_not_absolute,
+        "/configuration/source/settings/url must be an absolute http or https URL",
+    ),
+    (
+        "endpoint-not-relative",
+        _endpoint_is_not_relative,
+        "/configuration/source/settings/api_endpoint must be a relative request path without a scheme or authority",
+    ),
+    (
+        "credential-path-not-declared",
+        _reference_outside_declared_paths,
+        "/configuration/source/settings/verify_ssl is not a credential-bearing setting",
+    ),
+    (
+        "adapter-validator-finding",
+        _adapter_validator_refuses,
+        "/configuration/schema_mapping/0/mapping: genericrestapi schema mapping endpoints must be "
+        "a relative request path without authority, user information, query parameters, or fragments",
+    ),
+)
+
+
+def _unknown_provider_and_undeclared_store_type(data: dict[str, Any]) -> None:
+    _unknown_provider(data)
+    _undeclared_store_type(data)
+
+
+def _validator_refusal_and_inline_adapter_token(data: dict[str, Any]) -> None:
+    data["configuration"]["source"] = {
+        "name": "genericrestapi",
+        "settings": {"url": "https://api.example", "token": "declared-in-line"},
+    }
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "https://evil.example/devices"}]
+
+
+# Two defects, reported by two different checks, in one package. Both messages were re-observed
+# by executing c767067; each pin names the check that has to keep running first.
+CROSS_CHECK_REFUSALS: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+    (
+        # The credential declarations run before the store surface.
+        "credential-declarations-before-store",
+        _unknown_provider_and_undeclared_store_type,
+        "credential reference 'netbox-token' uses provider 'vault', which is not installed",
+    ),
+    (
+        # Inside one adapter role, the adapter-owned validator runs before the credential paths.
+        "adapter-validator-before-credential-paths",
+        _validator_refusal_and_inline_adapter_token,
+        "/configuration/schema_mapping/0/mapping: genericrestapi schema mapping endpoints must be "
+        "a relative request path without authority, user information, query parameters, or fragments",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [pytest.param(mutate, message, id=name) for name, mutate, message in CROSS_CHECK_REFUSALS],
+)
+def test_the_order_two_checks_run_in_decides_the_shipped_message(
+    mutate: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    data = package_data()
+    mutate(data)
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    assert str(caught.value) == expected
+
+
+_REFUSAL_CASES = [pytest.param(mutate, message, id=name) for name, mutate, message in SHIPPED_REFUSALS]
+
+
+@pytest.mark.parametrize(("mutate", "expected"), _REFUSAL_CASES)
+def test_wrapper_reproduces_the_shipped_first_error_message(
+    mutate: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    data = package_data()
+    mutate(data)
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    assert str(caught.value) == expected
+
+
+@pytest.mark.parametrize(("mutate", "expected"), _REFUSAL_CASES)
+def test_every_validation_refusal_raises_one_exception_type(
+    mutate: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    # OES-15: the unknown adapter used to escape as UnknownAdapterCapabilitiesError.
+    del expected
+    data = package_data()
+    mutate(data)
+
+    with pytest.raises(CredentialConfigurationError):
+        validate_package_credentials(package(data))
+
+
+def _two_defective_declarations(first_name: str, second_name: str) -> dict[str, Any]:
+    data = package_data()
+    declarations = {
+        "zeta": {"provider": "vault", "identifier": "ZETA_TOKEN"},
+        "alpha": {"provider": "env", "identifier": "ALPHA-TOKEN"},
+    }
+    data["credentials"] = {
+        **data["credentials"],
+        first_name: declarations[first_name],
+        second_name: declarations[second_name],
+    }
+    return data
+
+
+@pytest.mark.parametrize(
+    ("first_name", "second_name", "expected"),
+    [
+        pytest.param(
+            "zeta",
+            "alpha",
+            "credential reference 'zeta' uses provider 'vault', which is not installed",
+            id="zeta-declared-first",
+        ),
+        pytest.param(
+            "alpha",
+            "zeta",
+            "credential reference 'alpha' has an invalid environment identifier",
+            id="alpha-declared-first",
+        ),
+    ],
+)
+def test_declaration_order_decides_which_defect_is_reported_first(
+    first_name: str,
+    second_name: str,
+    expected: str,
+) -> None:
+    # Two defects inside one check: the eighteen single-defect pins cannot see iteration order,
+    # and sorting the declarations would silently change the message for one of these packages.
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(_two_defective_declarations(first_name, second_name)))
+
+    assert str(caught.value) == expected

--- a/tests/configuration/test_validation_core.py
+++ b/tests/configuration/test_validation_core.py
@@ -1,0 +1,1110 @@
+"""The accumulating validation core: one declared defect, one finding.
+
+``validate_package_credentials`` reports the first defect and stops. The core behind it keeps
+going, so a package carrying N independent defects yields N findings. These tests fix the two
+orderings that separates — execution order, which the wrapper's message comes from, and the
+stable cross-interface order ``collect_findings`` returns.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import infrahub_sync
+from infrahub_sync.configuration import (
+    BUILTIN_ADAPTER_CAPABILITIES,
+    AdapterConfigurationCapabilities,
+    AdapterRole,
+    ConfigurationPackage,
+    CredentialConfigurationError,
+    ValidationFinding,
+    sort_findings,
+    validate_package_credentials,
+    validation,
+)
+from infrahub_sync.configuration.validation import collect_findings
+from tests.configuration.test_validation_compatibility import SHIPPED_REFUSALS
+from tests.configuration.validation_packages import package, package_data
+
+_NARROW_TYPE = "UnknownAdapterCapabilitiesError"
+_FINDING_TEXT_BOUND = 256
+
+
+def _triples(package_content: dict[str, Any]) -> list[tuple[str, str]]:
+    return [(finding.code, finding.location) for finding in collect_findings(package(package_content))]
+
+
+def test_a_valid_package_produces_no_findings() -> None:
+    assert collect_findings(package()) == ()
+
+
+def test_independent_defects_each_become_one_finding() -> None:
+    data = package_data()
+    data["credentials"]["netbox-token"]["provider"] = "vault"
+    data["configuration"]["source"]["settings"]["url"] = "demo.netbox.dev"
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = 1
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": {"$credential": "nope"}}}
+
+    assert _triples(data) == [
+        ("undeclared-setting", "/configuration/destination/settings/bogus_dest"),
+        ("endpoint-not-absolute", "/configuration/source/settings/url"),
+        ("unknown-credential-reference", "/configuration/store/settings/password"),
+        ("unknown-credential-provider", "/credentials/netbox-token"),
+    ]
+
+
+def test_findings_are_returned_in_the_stable_cross_interface_order() -> None:
+    data = package_data()
+    data["credentials"]["netbox-token"]["provider"] = "vault"
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = 1
+    findings = collect_findings(package(data))
+
+    assert findings == sort_findings(findings)
+
+
+def test_execution_first_error_and_sort_first_finding_are_different_findings() -> None:
+    # OES-16. The pinned pair: the credential declaration executes first and sorts last, while
+    # the destination setting executes fourth and sorts first. A fixture whose two orders agree
+    # would prove nothing.
+    data = package_data()
+    data["credentials"]["netbox-token"]["provider"] = "vault"
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = 1
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    findings = collect_findings(package(data))
+    assert str(caught.value) == "credential reference 'netbox-token' uses provider 'vault', which is not installed"
+    assert findings[0].location == "/configuration/destination/settings/bogus_dest"
+    assert findings[0].code == "undeclared-setting"
+    assert findings[-1].location == "/credentials/netbox-token"
+
+
+@pytest.mark.parametrize(
+    ("node", "expected_code"),
+    [
+        pytest.param({"$credential": "nope"}, "unknown-credential-reference", id="unknown-reference"),
+        pytest.param(
+            {"$credential": "netbox-token", "fallback": "declared-in-line"},
+            "malformed-credential-reference",
+            id="malformed-reference",
+        ),
+    ],
+)
+def test_the_owning_check_is_authoritative_at_a_declared_credential_path(
+    node: dict[str, Any],
+    expected_code: str,
+) -> None:
+    # The whole-package walk revisits the same node the adapter check already judged. Reporting
+    # both would give one defect two byte-identical findings.
+    data = package_data()
+    data["configuration"]["source"]["settings"]["token"] = node
+
+    assert _triples(data) == [(expected_code, "/configuration/source/settings/token")]
+
+
+def test_a_reference_at_an_undeclared_setting_name_yields_one_finding() -> None:
+    # One typo. The surface check owns the location and gives the precise reason; the walk
+    # would add "not a credential-bearing setting" at the same pointer, which is the vaguer
+    # reason the check order already exists to make unreachable.
+    data = package_data()
+    data["configuration"]["source"]["settings"]["api_key"] = {"$credential": "netbox-token"}
+
+    assert _triples(data) == [("undeclared-setting", "/configuration/source/settings/api_key")]
+
+
+def _nested_under_an_undeclared_setting(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["api_key"] = {"deep": {"$credential": "netbox-token"}}
+
+
+def _nested_under_a_refused_url(data: dict[str, Any]) -> None:
+    data["configuration"]["source"]["settings"]["url"] = {"deep": {"$credential": "netbox-token"}}
+
+
+def _nested_under_a_refused_store_setting(data: dict[str, Any]) -> None:
+    node = {"deep": {"$credential": "netbox-token"}}
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": node}}
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        pytest.param(
+            _nested_under_an_undeclared_setting,
+            ("undeclared-setting", "/configuration/source/settings/api_key"),
+            id="undeclared-setting",
+        ),
+        pytest.param(
+            _nested_under_a_refused_url,
+            ("setting-not-a-string", "/configuration/source/settings/url"),
+            id="setting-not-a-string",
+        ),
+        pytest.param(
+            _nested_under_a_refused_store_setting,
+            ("inline-credential-value", "/configuration/store/settings/password"),
+            id="inline-credential-value",
+        ),
+    ],
+)
+def test_a_surface_check_owns_the_setting_it_judged_and_everything_beneath_it(
+    mutate: Callable[[dict[str, Any]], None],
+    expected: tuple[str, str],
+) -> None:
+    # The flat form of each of these is one finding. Nesting the reference one level deeper
+    # must not turn one defect into two, and the second would be the vaguer reason at the
+    # deeper pointer — exactly what the surface checks run first to make unreachable.
+    data = package_data()
+    mutate(data)
+
+    assert _triples(data) == [expected]
+
+
+def test_a_role_mismatch_and_a_misplaced_reference_stay_two_findings() -> None:
+    # Not the same defect twice. netbox declares verify_ssl under a role-independent settings
+    # surface, so the reference is misplaced on its own merits whether or not the adapter can
+    # serve the destination role. Suppressing either would under-report.
+    data = package_data()
+    data["configuration"]["destination"] = {
+        "name": "netbox",
+        "settings": {"verify_ssl": {"$credential": "netbox-token"}},
+    }
+
+    assert _triples(data) == [
+        ("adapter-role-mismatch", "/configuration/destination"),
+        ("credential-path-not-declared", "/configuration/destination/settings/verify_ssl"),
+    ]
+
+
+def test_the_walk_still_reports_where_no_surface_check_has_authority() -> None:
+    # The counter-test to the ownership rule: suppressing the walk wholesale would pass every
+    # test above and silence its real job. "order" is declared as strings and cannot carry a
+    # node, so the reachable uncovered surfaces are a declared setting that is not
+    # credential-bearing, the package-level schema mapping, and structures nested inside it.
+    data = package_data()
+    data["configuration"]["source"]["settings"]["verify_ssl"] = {"$credential": "netbox-token"}
+    data["configuration"]["schema_mapping"] = [
+        {
+            "name": "Device",
+            "fields": [
+                {"name": "token", "static": {"$credential": "netbox-token"}},
+                {"name": "nested", "static": {"outer": [{"inner": {"$credential": "netbox-token"}}]}},
+            ],
+        }
+    ]
+
+    assert _triples(data) == [
+        ("credential-path-not-declared", "/configuration/schema_mapping/0/fields/0/static"),
+        ("credential-path-not-declared", "/configuration/schema_mapping/0/fields/1/static/outer/0/inner"),
+        ("credential-path-not-declared", "/configuration/source/settings/verify_ssl"),
+    ]
+
+
+def _shared_validator_package_data() -> dict[str, Any]:
+    """One package-level mapping defect judged by two adapters sharing one validator."""
+    data = package_data()
+    data["configuration"]["source"] = {"name": "genericrestapi", "settings": {"url": "https://api.example"}}
+    data["configuration"]["destination"] = {"name": "peeringmanager", "settings": {"url": "https://pm.example"}}
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "https://evil.example/devices"}]
+    return data
+
+
+def test_one_mapping_defect_judged_by_two_adapters_yields_one_finding() -> None:
+    # _validate_relative_rest_mapping_endpoints is one function object serving both adapters and
+    # it interpolates the adapter name, so the two findings differ only in message. The defect is
+    # a package-level schema_mapping entry and is role-independent; first in execution order wins.
+    findings = collect_findings(package(_shared_validator_package_data()))
+
+    assert [(finding.code, finding.location) for finding in findings] == [
+        ("unsafe-rest-request-endpoint", "/configuration/schema_mapping/0/mapping"),
+    ]
+    assert findings[0].message.startswith("genericrestapi ")
+
+
+def test_two_defects_in_one_declaration_still_yield_two_findings() -> None:
+    # The precedence rule is per check, not per finding: one check reporting two different
+    # problems at one pointer is two defects, and collapsing them would under-report.
+    data = package_data()
+    data["credentials"]["both-bad"] = {"provider": "vault", "identifier": "NOT-VALID"}
+
+    assert _triples(data) == [
+        ("malformed-credential-reference", "/credentials/both-bad"),
+        ("unknown-credential-provider", "/credentials/both-bad"),
+    ]
+
+
+def test_a_reference_outside_the_declared_paths_is_still_reported_by_the_walk() -> None:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [
+        {"name": "Device", "fields": [{"name": "token", "static": {"$credential": "netbox-token"}}]}
+    ]
+
+    assert _triples(data) == [
+        ("credential-path-not-declared", "/configuration/schema_mapping/0/fields/0/static"),
+    ]
+
+
+def test_a_missing_adapter_is_expressible_as_a_finding() -> None:
+    data = package_data()
+    data["configuration"]["source"]["name"] = "NetBox"
+
+    assert _triples(data) == [("missing-adapter", "/configuration/source")]
+
+
+def test_a_missing_adapter_suppresses_only_its_own_role() -> None:
+    # Its settings cannot be judged against a surface that does not exist, so claiming a finding
+    # about them would be inventing one. Everything else still runs.
+    data = package_data()
+    data["configuration"]["source"]["name"] = "NetBox"
+    data["configuration"]["source"]["settings"]["bogus_source"] = 1
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = 1
+    data["configuration"]["store"] = {"type": "redis", "settings": {"password": "declared-in-line"}}
+
+    assert _triples(data) == [
+        ("undeclared-setting", "/configuration/destination/settings/bogus_dest"),
+        ("missing-adapter", "/configuration/source"),
+        ("inline-credential-value", "/configuration/store/settings/password"),
+    ]
+
+
+def test_an_undeclared_store_type_suppresses_only_its_own_settings() -> None:
+    # The same rule the missing adapter above obeys, at the other unevaluable surface. Whether
+    # a store setting is credential-bearing is exactly what an undeclared store type makes
+    # unknowable, so the walk has no surface to judge "url" against and must not claim one.
+    data = package_data()
+    data["configuration"]["store"] = {"type": "mystery", "settings": {"url": {"$credential": "netbox-token"}}}
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = 1
+    data["configuration"]["source"]["settings"]["verify_ssl"] = {"$credential": "netbox-token"}
+
+    assert _triples(data) == [
+        ("undeclared-setting", "/configuration/destination/settings/bogus_dest"),
+        ("credential-path-not-declared", "/configuration/source/settings/verify_ssl"),
+        ("missing-store-capabilities", "/configuration/store"),
+    ]
+
+
+def test_an_undeclared_store_type_carrying_nothing_is_still_silent() -> None:
+    # Measured shipped behaviour: an undeclared store type declaring no settings declares
+    # nothing unsafe, so it is not a defect and suppresses nothing.
+    data = package_data()
+    data["configuration"]["store"] = {"type": "mystery", "settings": {}}
+
+    assert _triples(data) == []
+
+
+def _narrow_type_uses(tree: ast.AST) -> list[str]:
+    uses: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Raise):
+            uses.extend("raise" for name in ast.walk(node) if isinstance(name, ast.Name) and name.id == _NARROW_TYPE)
+        if isinstance(node, ast.ExceptHandler) and node.type is not None:
+            uses.extend(
+                "except" for name in ast.walk(node.type) if isinstance(name, ast.Name) and name.id == _NARROW_TYPE
+            )
+    return uses
+
+
+def test_the_narrow_unknown_adapter_type_is_raised_and_caught_in_one_module_only() -> None:
+    # OES-15 narrowed the blast radius of the type; this keeps that a fact rather than a claim.
+    root = Path(infrahub_sync.__file__).parent
+    owner = root / "configuration" / "capabilities.py"
+    offenders = {
+        str(path.relative_to(root)): _narrow_type_uses(ast.parse(path.read_text(encoding="utf-8")))
+        for path in sorted(root.rglob("*.py"))
+        if path != owner
+    }
+
+    assert _narrow_type_uses(ast.parse(owner.read_text(encoding="utf-8"))) == ["raise"]
+    assert {path: uses for path, uses in offenders.items() if uses} == {}
+
+
+def _capabilities_with(
+    validator: Callable[..., object],
+    adapter_name: str = "peeringmanager",
+) -> dict[str, AdapterConfigurationCapabilities]:
+    declared = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    declared[adapter_name] = replace(declared[adapter_name], validator=validator)
+    return declared
+
+
+def _both_roles_package_data(mapping: str = "https://evil.example/devices") -> dict[str, Any]:
+    data = package_data()
+    settings = {"url": "https://pm.example", "token": {"$credential": "netbox-token"}}
+    data["configuration"]["source"] = {"name": "peeringmanager", "settings": settings}
+    data["configuration"]["destination"] = {"name": "peeringmanager", "settings": dict(settings)}
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": mapping}]
+    return data
+
+
+def test_one_adapter_serving_both_roles_reports_its_validator_finding_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OES-17. The same validator serves both roles and cannot tell them apart here, so it
+    # returns the same finding twice; two identical findings would break the sort's totality.
+    roles: list[str] = []
+
+    def _validator(package_argument: ConfigurationPackage, role: AdapterRole) -> tuple[ValidationFinding, ...]:
+        del package_argument
+        roles.append(role)
+        return (
+            ValidationFinding(
+                code="unsafe-rest-request-endpoint",
+                severity="error",
+                location="/configuration/schema_mapping/0/mapping",
+                message="peeringmanager schema mapping endpoints must be a relative request path",
+            ),
+        )
+
+    monkeypatch.setattr(validation, "BUILTIN_ADAPTER_CAPABILITIES", _capabilities_with(_validator))
+    findings = collect_findings(package(_both_roles_package_data()))
+
+    assert roles == ["source", "destination"]
+    assert [(finding.code, finding.location) for finding in findings] == [
+        ("unsafe-rest-request-endpoint", "/configuration/schema_mapping/0/mapping"),
+    ]
+
+
+def test_an_adapter_validator_keeps_its_own_code_and_location() -> None:
+    data = package_data()
+    data["configuration"]["source"] = {"name": "genericrestapi", "settings": {"url": "https://api.example"}}
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "https://evil.example/devices"}]
+
+    assert _triples(data) == [("unsafe-rest-request-endpoint", "/configuration/schema_mapping/0/mapping")]
+
+
+def _validator_reporting_at(location: str) -> Callable[..., tuple[ValidationFinding, ...]]:
+    """Return a validator that reports one finding at `location`, whatever role it is given."""
+
+    def _validator(package_argument: ConfigurationPackage, role: AdapterRole) -> tuple[ValidationFinding, ...]:
+        del package_argument, role
+        return (ValidationFinding(code="adapter-note", severity="error", location=location, message="Zq7"),)
+
+    return _validator
+
+
+def test_a_source_validator_cannot_silence_a_finding_in_the_destination_subtree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Location precedence is the acceptance rule and stays intact; what an adapter may not do
+    # is place a finding where it has no standing. A source validator reporting at a
+    # destination pointer used to win precedence there and delete the core's credential-safety
+    # finding for a real inline value, silently.
+    monkeypatch.setattr(
+        validation,
+        "BUILTIN_ADAPTER_CAPABILITIES",
+        _capabilities_with(_validator_reporting_at("/configuration/destination/settings/token"), "netbox"),
+    )
+    data = package_data()
+    inline_value = "declared-in-line"
+    data["configuration"]["destination"]["settings"]["token"] = inline_value
+
+    findings = collect_findings(package(data))
+
+    assert [(finding.code, finding.location) for finding in findings] == [
+        ("inline-credential-value", "/configuration/destination/settings/token"),
+        ("adapter-validator-finding", "/configuration/source"),
+    ]
+    assert all("Zq7" not in finding.message for finding in findings)
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        pytest.param("/configuration/destination/settings/token", id="the-other-role"),
+        pytest.param("/configuration/destination", id="the-other-role-root"),
+        pytest.param("/configuration/store/settings/password", id="the-store"),
+        pytest.param("/credentials/netbox-token", id="the-credential-declarations"),
+        pytest.param("", id="the-whole-package"),
+        pytest.param("/configuration/schema_mapping_other", id="a-prefix-lookalike"),
+    ],
+)
+def test_a_finding_outside_the_validator_role_subtree_is_contained(
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+) -> None:
+    monkeypatch.setattr(
+        validation,
+        "BUILTIN_ADAPTER_CAPABILITIES",
+        _capabilities_with(_validator_reporting_at(location), "netbox"),
+    )
+
+    assert _triples(package_data()) == [("adapter-validator-finding", "/configuration/source")]
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        pytest.param("/configuration/source", id="its-own-role-root"),
+        pytest.param("/configuration/source/settings/url", id="its-own-role-subtree"),
+        pytest.param("/configuration/schema_mapping", id="package-level-mapping-root"),
+        pytest.param("/configuration/schema_mapping/0/mapping", id="package-level-mapping-entry"),
+    ],
+)
+def test_a_finding_inside_the_validator_role_subtree_is_kept(
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+) -> None:
+    # The permitted set is the validator's own role subtree plus the role-independent package
+    # content the shipped genericrestapi validator legitimately reports at.
+    monkeypatch.setattr(
+        validation,
+        "BUILTIN_ADAPTER_CAPABILITIES",
+        _capabilities_with(_validator_reporting_at(location), "netbox"),
+    )
+
+    assert _triples(package_data()) == [("adapter-note", location)]
+
+
+_ROLE_INDEPENDENT_POINTER = "/configuration/schema_mapping/0/mapping"
+
+
+def _validator_reporting(code: str) -> Callable[..., tuple[ValidationFinding, ...]]:
+    """Return a validator reporting one distinctly coded finding at the shared mapping pointer."""
+
+    def _validator(package_argument: ConfigurationPackage, role: AdapterRole) -> tuple[ValidationFinding, ...]:
+        del package_argument, role
+        return (
+            ValidationFinding(
+                code=code,
+                severity="error",
+                location=_ROLE_INDEPENDENT_POINTER,
+                message=f"{code} reports here",
+            ),
+        )
+
+    return _validator
+
+
+def test_the_first_check_to_report_at_a_pointer_silences_a_different_check_there(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The precedence rule has two halves and only one of them is reachable with the shipped
+    # adapters. The (code, location) half drops a repeat of the same code; this half drops a
+    # *different* check's finding at a pointer some earlier check already owns, and it needs
+    # two adapters that both have standing at one pointer. A schema mapping is declared once
+    # for the package, so each role's own validator may report at it, and the two roles are
+    # two different checks. Source runs first, so the destination adapter's distinct finding
+    # is dropped - not deduplicated, dropped, and nothing tells the operator it existed.
+    declared = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    declared["netbox"] = replace(declared["netbox"], validator=_validator_reporting("source-note"))
+    declared["infrahub"] = replace(declared["infrahub"], validator=_validator_reporting("destination-note"))
+    monkeypatch.setattr(validation, "BUILTIN_ADAPTER_CAPABILITIES", declared)
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "/devices"}]
+
+    assert _triples(data) == [("source-note", _ROLE_INDEPENDENT_POINTER)]
+
+
+def _raising_validator(package_argument: ConfigurationPackage, role: AdapterRole) -> tuple[ValidationFinding, ...]:
+    del package_argument, role
+    msg = "Zq7"
+    raise RuntimeError(msg)
+
+
+def _string_returning_validator(package_argument: ConfigurationPackage, role: AdapterRole) -> str:
+    del package_argument, role
+    return "Zq7"
+
+
+def _non_finding_returning_validator(
+    package_argument: ConfigurationPackage,
+    role: AdapterRole,
+) -> list[dict[str, str]]:
+    del package_argument, role
+    return [{"code": "Zq7", "severity": "error", "location": "/a", "message": "Zq7"}]
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [
+        pytest.param(_raising_validator, id="raises"),
+        pytest.param(_string_returning_validator, id="returns-a-string"),
+        pytest.param(_non_finding_returning_validator, id="returns-a-non-finding"),
+    ],
+)
+def test_a_failing_adapter_validator_is_contained_as_one_finding(
+    monkeypatch: pytest.MonkeyPatch,
+    validator: Callable[..., object],
+) -> None:
+    # A str is a Sequence, so "returned a sequence" is not the test; "returned findings" is.
+    monkeypatch.setattr(validation, "BUILTIN_ADAPTER_CAPABILITIES", _capabilities_with(validator))
+    data = _both_roles_package_data(mapping="/devices")
+
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+
+    assert _triples(data) == [
+        ("adapter-validator-finding", "/configuration/destination"),
+        ("adapter-validator-finding", "/configuration/source"),
+    ]
+    # The contained failure is reported, not re-raised, and it carries none of its own text.
+    assert caught.value.__context__ is None
+    assert "Zq7" not in str(caught.value)
+
+
+def _constructed_finding_validator(fields: dict[str, Any]) -> Callable[..., list[ValidationFinding]]:
+    """Return a validator handing back a finding built with ``model_construct``.
+
+    ``model_construct`` runs no field validator, so an adapter can return an object that
+    passes ``isinstance(item, ValidationFinding)`` while carrying fields the contract refuses.
+    """
+
+    def _validator(package_argument: ConfigurationPackage, role: AdapterRole) -> list[ValidationFinding]:
+        del package_argument, role
+        return [ValidationFinding.model_construct(**fields)]
+
+    return _validator
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        pytest.param(
+            {"code": "x", "severity": "warning", "location": "/a", "message": "Zq7"},
+            id="undeclared-severity",
+        ),
+        pytest.param(
+            {"code": "x", "severity": "error", "location": 7, "message": "Zq7"},
+            id="location-not-a-string",
+        ),
+        pytest.param(
+            {"code": "x", "severity": "error", "location": "/a", "message": "Zq7" + "m" * 5000},
+            id="over-long-message",
+        ),
+        pytest.param(
+            {"code": "x", "severity": "error", "location": "/Zq7\nb\x00", "message": "m"},
+            id="unprintable-location",
+        ),
+    ],
+)
+@pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning")
+def test_a_returned_finding_the_contract_refuses_is_contained(
+    monkeypatch: pytest.MonkeyPatch,
+    fields: dict[str, Any],
+) -> None:
+    # Sorting the returned findings and joining their text sat outside the contained block, so
+    # the first two of these escaped collect_findings as a KeyError and a TypeError. The last two
+    # reached the public tuple unbounded and unescaped, because an adapter finding was used as
+    # given rather than put through the bounds the core applies to its own.
+    monkeypatch.setattr(
+        validation,
+        "BUILTIN_ADAPTER_CAPABILITIES",
+        _capabilities_with(_constructed_finding_validator(fields)),
+    )
+
+    findings = collect_findings(package(_both_roles_package_data(mapping="/devices")))
+
+    assert [(finding.code, finding.location) for finding in findings] == [
+        ("adapter-validator-finding", "/configuration/destination"),
+        ("adapter-validator-finding", "/configuration/source"),
+    ]
+    # Nothing the validator supplied is carried, and what is published is displayable and bounded.
+    assert all("Zq7" not in finding.location + finding.message for finding in findings)
+    assert all(character.isprintable() for finding in findings for character in finding.location + finding.message)
+    assert all(len(finding.message) <= _FINDING_TEXT_BOUND for finding in findings)
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        pytest.param(
+            {
+                "code": "adapter-note",
+                "severity": "error",
+                "location": "/configuration/schema_mapping",
+                "message": "Zq7" + "m" * 5000,
+            },
+            id="over-long-message",
+        ),
+        pytest.param(
+            {
+                "code": "adapter-note",
+                "severity": "error",
+                "location": "/configuration/schema_mapping",
+                "message": "Zq7\x07",
+            },
+            id="unprintable-message",
+        ),
+    ],
+)
+def test_a_returned_finding_the_contract_refuses_is_contained_inside_the_role_subtree(
+    monkeypatch: pytest.MonkeyPatch,
+    fields: dict[str, Any],
+) -> None:
+    # The confinement rule refuses a finding placed outside the validator's own subtree before
+    # anything is read off it, so a fixture reporting out of subtree proves confinement and
+    # says nothing about revalidation. These two report where the validator does have standing,
+    # which is the only place the revalidation and printability guards decide anything: without
+    # them the adapter's own text is published, bounded to 256 characters or carrying a control
+    # character an operator's terminal interprets.
+    monkeypatch.setattr(
+        validation,
+        "BUILTIN_ADAPTER_CAPABILITIES",
+        _capabilities_with(_constructed_finding_validator(fields), "netbox"),
+    )
+
+    findings = collect_findings(package(package_data()))
+
+    assert [(finding.code, finding.location) for finding in findings] == [
+        ("adapter-validator-finding", "/configuration/source"),
+    ]
+    assert all("Zq7" not in finding.location + finding.message for finding in findings)
+    assert all(character.isprintable() for finding in findings for character in finding.location + finding.message)
+
+
+def _pointer_cut_on_an_escape() -> dict[str, Any]:
+    """A declared package whose pointer cut lands on the "~" of a "~1" escape.
+
+    The 256-character cut is taken over the escaped pointer, so it can separate a "~" from the
+    "0" or "1" that completes it, and the finding grammar refuses a lone "~". The offsets are
+    chosen so the cut falls exactly there: the escape comes from a "/" in a declared key, and
+    the key below it pushes the pointer past the bound without moving the escape.
+    """
+    data = package_data()
+    node: Any = {"$credential": "netbox-token"}
+    node = {"z" * 20: node}
+    node = {("x" * 16) + "/y": node}
+    for _ in range(3):
+        node = {"n" * 60: node}
+    data["configuration"]["source"]["settings"]["verify_ssl"] = node
+    return data
+
+
+def test_a_pointer_cut_on_an_escape_still_yields_a_well_formed_finding() -> None:
+    # Without the trailing-"~" drop this raises pydantic.ValidationError out of collect_findings,
+    # uncontained: a declared package makes the validator itself crash rather than report.
+    findings = collect_findings(package(_pointer_cut_on_an_escape()))
+
+    assert [finding.code for finding in findings] == ["credential-path-not-declared"]
+    assert not findings[0].location.rstrip("~").endswith("~")
+    assert _TRUNCATED_POINTER.search(findings[0].location) is not None
+    assert len(findings[0].location) <= _FINDING_TEXT_BOUND
+
+
+_OVER_CAP_DEFECTS = 300
+_FINDING_CAP = 256
+# The empty pointer, which every real pointer sorts after because they all begin with "/".
+_LIMIT_POINTER = ""
+
+
+def _over_cap_package_data(*, reversed_declaration: bool) -> dict[str, Any]:
+    # Credential declarations are walked in insertion order, so reversing them reverses the
+    # execution order too. Undeclared settings would not work here: that check already emits
+    # sorted, so a truncation taken in execution order would survive the reordering unnoticed.
+    data = package_data()
+    names = [f"ref{index:03}" for index in range(_OVER_CAP_DEFECTS)]
+    if reversed_declaration:
+        names.reverse()
+    for name in names:
+        data["credentials"][name] = {"provider": "vault", "identifier": "DECLARED_TOKEN"}
+    return data
+
+
+def test_the_finding_count_is_bounded_and_the_bound_reports_itself_first() -> None:
+    findings = collect_findings(package(_over_cap_package_data(reversed_declaration=False)))
+
+    assert len(findings) == _FINDING_CAP + 1
+    assert findings[0].code == "finding-limit-reached"
+    assert findings[0].location == _LIMIT_POINTER
+    assert {finding.code for finding in findings[1:]} == {"unknown-credential-provider"}
+    assert findings[1].location == "/credentials/ref000"
+
+
+def test_a_reordered_equivalent_package_yields_an_identical_finding_set() -> None:
+    # Truncating in execution order would make the surviving 256 depend on the order the
+    # defects were declared in, which is why the cut happens after the sort and not before it.
+    declared = package(_over_cap_package_data(reversed_declaration=False))
+    reordered = package(_over_cap_package_data(reversed_declaration=True))
+
+    assert collect_findings(declared) == collect_findings(reordered)
+
+
+@pytest.mark.parametrize("declaration", ["declared", "reordered"])
+def test_no_two_findings_share_a_location_severity_and_code_over_the_cap(declaration: str) -> None:
+    data = _over_cap_package_data(reversed_declaration=declaration == "reordered")
+    findings = collect_findings(package(data))
+
+    keys = [(finding.location, finding.severity, finding.code) for finding in findings]
+    assert len(set(keys)) == len(keys)
+
+
+# Frozen by CF-004a's envelope. Two contract families are deliberately absent — destination
+# schema mismatch and unsupported destination write behaviour — so neither can be claimed
+# vacuously by a set comparison that only grows.
+FROZEN_CODES = frozenset(
+    {
+        "adapter-role-mismatch",
+        "adapter-validator-finding",
+        "credential-path-not-declared",
+        "endpoint-not-absolute",
+        "endpoint-not-relative",
+        "finding-limit-reached",
+        "inline-credential-value",
+        "malformed-credential-reference",
+        "missing-adapter",
+        "missing-store-capabilities",
+        "setting-contains-credential-material",
+        "setting-not-a-string",
+        "undeclared-setting",
+        "unknown-credential-provider",
+        "unknown-credential-reference",
+    }
+)
+
+
+def _declared_codes(tree: ast.AST) -> set[str]:
+    declared: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        if any(name.startswith("_CODE_") for name in names) and isinstance(node.value, ast.Constant):
+            declared.add(str(node.value.value))
+    return declared
+
+
+_KEBAB_LITERAL = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)+$")
+
+
+def _kebab_literals(tree: ast.AST) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _KEBAB_LITERAL.fullmatch(node.value) is not None
+    }
+
+
+def test_the_core_can_emit_exactly_the_frozen_code_enumeration() -> None:
+    # Collected from the implementation, not restated: a new check introduces a code here and
+    # this test is what asks whether the envelope agreed to it.
+    tree = ast.parse(Path(validation.__file__).read_text(encoding="utf-8"))
+
+    assert _declared_codes(tree) == FROZEN_CODES
+    # A code written as a bare literal rather than as a _CODE_ constant would slip past the
+    # scan above; every finding code is kebab-case and nothing else in the module is.
+    assert _kebab_literals(tree) == FROZEN_CODES
+
+
+def _totality_package_data() -> dict[str, Any]:
+    # A missing adapter makes its role unevaluable, so it goes on one role and every other
+    # family is spread across the other role, the store, and the credential declarations.
+    data = package_data()
+    data["credentials"]["bad-provider"] = {"provider": "vault", "identifier": "DECLARED_TOKEN"}
+    data["credentials"]["bad-identifier"] = {"provider": "env", "identifier": "NOT-VALID"}
+    data["configuration"]["source"] = {
+        "name": "genericrestapi",
+        "settings": {
+            "url": "api.example",
+            "api_endpoint": "https://evil.example/api",
+            "token": {"$credential": "nope"},
+            "username": "declared-in-line",
+            "password": {"$credential": "netbox-token", "fallback": "declared-in-line"},
+            "response_key_pattern": {"$credential": "netbox-token"},
+            "bogus_source": 1,
+        },
+    }
+    data["configuration"]["destination"] = {"name": "NetBox", "settings": {"url": "http://localhost:8000"}}
+    data["configuration"]["store"] = {
+        "type": "redis",
+        "settings": {
+            "url": {"$credential": "nope"},
+            "password": "declared-in-line",
+            "host": {"$credential": "netbox-token"},
+            "bogus_store": 1,
+        },
+    }
+    data["configuration"]["schema_mapping"] = [{"name": "Device", "mapping": "https://evil.example/devices"}]
+    return data
+
+
+def test_one_package_carrying_every_reachable_family_keeps_the_sort_total() -> None:
+    # Nine of these codes appear more than once and are separated only by location, which is
+    # the collision a per-family test cannot see.
+    findings = collect_findings(package(_totality_package_data()))
+
+    keys = [(finding.location, finding.severity, finding.code) for finding in findings]
+    assert len(set(keys)) == len(keys)
+    assert len(keys) == 15
+    assert {finding.code for finding in findings} == {
+        "credential-path-not-declared",
+        "endpoint-not-absolute",
+        "endpoint-not-relative",
+        "inline-credential-value",
+        "malformed-credential-reference",
+        "missing-adapter",
+        "undeclared-setting",
+        "unknown-credential-provider",
+        "unknown-credential-reference",
+        # The adapter's own code, passed through rather than replaced.
+        "unsafe-rest-request-endpoint",
+    }
+
+
+def _collision_prone_package_data() -> dict[str, Any]:
+    """The two collisions a per-family fixture cannot see, in one package.
+
+    A shared adapter validator judging one package-level mapping under both roles, and a
+    credential reference at a setting name the adapter does not declare.
+    """
+    data = _shared_validator_package_data()
+    data["configuration"]["source"]["settings"]["api_key"] = {"$credential": "netbox-token"}
+    return data
+
+
+def test_the_collision_prone_package_reports_each_defect_once() -> None:
+    assert _triples(_collision_prone_package_data()) == [
+        ("unsafe-rest-request-endpoint", "/configuration/schema_mapping/0/mapping"),
+        ("undeclared-setting", "/configuration/source/settings/api_key"),
+    ]
+
+
+def _reachable_codes(monkeypatch: pytest.MonkeyPatch) -> set[str]:
+    reached: set[str] = set()
+    for _name, mutate, _message in SHIPPED_REFUSALS:
+        data = package_data()
+        mutate(data)
+        reached.update(finding.code for finding in collect_findings(package(data)))
+    reached.update(
+        finding.code
+        for finding in collect_findings(
+            package(
+                _over_cap_package_data(
+                    reversed_declaration=False,
+                )
+            )
+        )
+    )
+    monkeypatch.setattr(validation, "BUILTIN_ADAPTER_CAPABILITIES", _capabilities_with(_raising_validator))
+    reached.update(finding.code for finding in collect_findings(package(_both_roles_package_data(mapping="/x"))))
+    return reached
+
+
+def test_every_frozen_code_is_reachable_and_nothing_else_is_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    reached = _reachable_codes(monkeypatch)
+
+    # The adapter-owned code is emitted by an adapter, not by the core, so it is not frozen here.
+    assert reached - {"unsafe-rest-request-endpoint"} == FROZEN_CODES
+
+
+# Resolution, network access, and destination schema reads all belong to later slices. The core
+# judges declared content only, so none of these may appear in it.
+FORBIDDEN_IN_THE_CORE = (
+    "EnvironmentCredentialProvider",
+    "environ",
+    "httpx",
+    "provider_for",
+    "requests",
+    "resolve",
+    "resolve_reference",
+)
+
+
+def test_the_core_reads_declared_content_only() -> None:
+    tree = ast.parse(Path(validation.__file__).read_text(encoding="utf-8"))
+    called = {
+        node.func.id if isinstance(node.func, ast.Name) else node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    severities = {
+        keyword.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "severity" and isinstance(keyword.value, ast.Constant)
+    }
+
+    assert severities == {"error"}
+    assert called & set(FORBIDDEN_IN_THE_CORE) == set()
+
+
+_FINDING_TEXT_BOUND = 256
+
+
+# A truncated pointer ends with the marker and the digest that keeps it distinguishable.
+_TRUNCATED_POINTER = re.compile(r"\\u2026[0-9a-f]{8}$")
+
+
+def test_a_hostile_declaration_still_yields_a_well_formed_finding() -> None:
+    # A finding pointer is bounded and refuses a lone "~", while the diagnostic truncation
+    # marker is "~2". So the marker changes form here, to one escaping can never produce.
+    over_length_key = package_data()
+    over_length_key["configuration"]["source"]["settings"]["k" * 5000] = 1
+    deep_node: Any = {"$credential": "netbox-token"}
+    for _ in range(8):
+        deep_node = {"n" * 60: deep_node}
+    deep_nesting = package_data()
+    deep_nesting["configuration"]["source"]["settings"]["verify_ssl"] = deep_node
+
+    truncated_component = collect_findings(package(over_length_key))
+    truncated_pointer = collect_findings(package(deep_nesting))
+
+    assert [finding.code for finding in truncated_component] == ["undeclared-setting"]
+    assert _TRUNCATED_POINTER.search(truncated_component[0].location) is not None
+    assert [finding.code for finding in truncated_pointer] == ["credential-path-not-declared"]
+    assert _TRUNCATED_POINTER.search(truncated_pointer[0].location) is not None
+    assert len(truncated_pointer[0].location) == _FINDING_TEXT_BOUND
+    assert len(truncated_pointer[0].message) == _FINDING_TEXT_BOUND
+
+
+def _pointer_bound_collision() -> dict[str, Any]:
+    """Two distinct ``$credential`` nodes whose pointers share a >256-character prefix."""
+    data = package_data()
+    node: Any = {"a": {"$credential": "netbox-token"}, "b": {"$credential": "netbox-token"}}
+    for _ in range(8):
+        node = {"n" * 60: node}
+    data["configuration"]["source"]["settings"]["verify_ssl"] = node
+    return data
+
+
+def _component_bound_collision() -> dict[str, Any]:
+    """Two undeclared settings whose names differ only past the component bound."""
+    data = package_data()
+    shared = "k" * 70
+    data["configuration"]["source"]["settings"][f"{shared}a"] = 1
+    data["configuration"]["source"]["settings"][f"{shared}b"] = 1
+    return data
+
+
+@pytest.mark.parametrize(
+    ("build", "expected_code"),
+    [
+        pytest.param(_pointer_bound_collision, "credential-path-not-declared", id="pointer-bound"),
+        pytest.param(_component_bound_collision, "undeclared-setting", id="component-bound"),
+    ],
+)
+def test_two_defects_under_one_truncated_pointer_stay_distinguishable(
+    build: Callable[[], dict[str, Any]],
+    expected_code: str,
+) -> None:
+    # Truncation is lossy at both bounds, so without a digest of the untruncated pointer two
+    # separate defects arrive as one byte-identical finding twice and the operator cannot tell
+    # them apart. The module's global "no two findings share (location, severity, code)" claim
+    # is what that falsifies.
+    findings = collect_findings(package(build()))
+
+    assert [finding.code for finding in findings] == [expected_code, expected_code]
+    assert findings[0].location != findings[1].location
+    assert findings[0] != findings[1]
+    assert all(len(finding.location) <= _FINDING_TEXT_BOUND for finding in findings)
+    assert all(_TRUNCATED_POINTER.search(finding.location) is not None for finding in findings)
+
+
+def _normalized_walk_collision() -> dict[str, Any]:
+    """Two undeclared ``$credential`` nodes whose keys differ only by a trailing space."""
+    data = package_data()
+    data["configuration"]["source"]["settings"]["verify_ssl"] = {
+        "leaked": {"$credential": "netbox-token"},
+        "leaked ": {"$credential": "netbox-token"},
+    }
+    return data
+
+
+def _normalized_setting_collision() -> dict[str, Any]:
+    """Two undeclared adapter settings whose names differ only by a trailing space."""
+    data = package_data()
+    data["configuration"]["source"]["settings"]["zz"] = 1
+    data["configuration"]["source"]["settings"]["zz "] = 1
+    return data
+
+
+def _normalized_store_collision() -> dict[str, Any]:
+    """Two undeclared store settings whose names differ only by a trailing space."""
+    data = package_data()
+    data["configuration"]["store"] = {"type": "redis", "settings": {"zz": 1, "zz ": 1}}
+    return data
+
+
+def _normalized_empty_component_collision() -> dict[str, Any]:
+    """An empty declared key and a whitespace-only one, which normalize onto each other."""
+    data = package_data()
+    data["configuration"]["source"]["settings"]["verify_ssl"] = {
+        "": {"$credential": "netbox-token"},
+        " ": {"$credential": "netbox-token"},
+    }
+    return data
+
+
+@pytest.mark.parametrize(
+    ("build", "expected_code"),
+    [
+        pytest.param(_normalized_walk_collision, "credential-path-not-declared", id="walk"),
+        pytest.param(_normalized_setting_collision, "undeclared-setting", id="adapter-setting"),
+        pytest.param(_normalized_store_collision, "undeclared-setting", id="store-setting"),
+        pytest.param(_normalized_empty_component_collision, "credential-path-not-declared", id="empty-component"),
+    ],
+)
+def test_two_defects_the_finding_model_normalizes_together_stay_distinguishable(
+    build: Callable[[], dict[str, Any]],
+    expected_code: str,
+) -> None:
+    # ValidationFinding normalizes what it stores, so the pointer the core builds is not always
+    # the pointer the finding carries. That is a third lossy transform beside the two length
+    # bounds and it breaks the same way: two declared keys differing only in what the model
+    # strips arrive at one pointer, and (code, location) deduplication then deletes one of the
+    # two defects outright. Under-reporting a credential-safety defect is the failure this pins.
+    findings = collect_findings(package(build()))
+
+    assert [finding.code for finding in findings] == [expected_code, expected_code]
+    assert findings[0].location != findings[1].location
+    assert all(len(finding.location) <= _FINDING_TEXT_BOUND for finding in findings)
+    # Exactly one of the pair was rewritten by the model, so exactly one carries the marker.
+    marked = [finding for finding in findings if _TRUNCATED_POINTER.search(finding.location) is not None]
+    assert len(marked) == 1
+
+
+def test_two_defects_at_one_normalized_pointer_keep_their_own_codes() -> None:
+    # Distinguishability is not only about deduplication deleting a finding. Two independent
+    # defects whose keys differ only by what the model strips must not be rendered at one
+    # pointer either, or the operator is told to look in one place for two different keys.
+    data = package_data()
+    data["configuration"]["source"]["settings"]["url "] = "demo.netbox.dev"
+    data["configuration"]["source"]["settings"]["url"] = "demo.netbox.dev"
+
+    findings = collect_findings(package(data))
+    locations = [finding.location for finding in findings]
+
+    assert len(findings) == 2
+    assert len(set(locations)) == 2
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(_totality_package_data, id="every-family"),
+        pytest.param(_collision_prone_package_data, id="collision-prone"),
+        pytest.param(_pointer_bound_collision, id="pointer-bound"),
+        pytest.param(_component_bound_collision, id="component-bound"),
+        pytest.param(_normalized_walk_collision, id="normalized-walk"),
+        pytest.param(_normalized_setting_collision, id="normalized-adapter-setting"),
+        pytest.param(_normalized_store_collision, id="normalized-store-setting"),
+        pytest.param(_normalized_empty_component_collision, id="normalized-empty-component"),
+    ],
+)
+def test_no_two_findings_share_a_location_severity_and_code(build: Callable[[], dict[str, Any]]) -> None:
+    # The global invariant, not a property of one fixture. Every family that has been shown to
+    # break it gets a fixture here.
+    findings = collect_findings(package(build()))
+
+    keys = [(finding.location, finding.severity, finding.code) for finding in findings]
+    assert len(keys) >= 2
+    assert len(set(keys)) == len(keys)
+
+
+def test_every_frozen_code_is_documented_for_an_operator() -> None:
+    # The codes are the part of the contract AD030 says is stable, so an undocumented one is a
+    # stable identifier nobody can look up. Anchored at the repository root, not the working
+    # directory, so it cannot pass by reading nothing.
+    reference = Path(infrahub_sync.__file__).parents[1] / "docs" / "docs" / "reference" / "durable-product-records.mdx"
+    documented = reference.read_text(encoding="utf-8")
+
+    assert "### Finding codes" in documented
+    assert {code for code in FROZEN_CODES if f"`{code}`" not in documented} == set()

--- a/tests/configuration/test_validation_core.py
+++ b/tests/configuration/test_validation_core.py
@@ -461,6 +461,32 @@ def test_a_finding_inside_the_validator_role_subtree_is_kept(
     assert _triples(package_data()) == [("adapter-note", location)]
 
 
+def test_an_adapter_validator_cannot_mint_a_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The emission rule is closed: only the two contract section 4 families in the warnings
+    # module report warnings. A warning is advice the wrapper never raises on, so a validator
+    # allowed to return one could write a defect into the non-blocking channel. It is contained
+    # to the existing contained-validator-failure error, exactly like any other unusable result.
+    def _validator(package_argument: ConfigurationPackage, role: AdapterRole) -> tuple[ValidationFinding, ...]:
+        del package_argument, role
+        return (
+            ValidationFinding(
+                code="adapter-note",
+                severity="warning",
+                location="/configuration/source",
+                message="Zq7",
+            ),
+        )
+
+    monkeypatch.setattr(validation, "BUILTIN_ADAPTER_CAPABILITIES", _capabilities_with(_validator, "netbox"))
+
+    findings = collect_findings(package(package_data()))
+
+    assert [(finding.code, finding.severity, finding.location) for finding in findings] == [
+        ("adapter-validator-finding", "error", "/configuration/source"),
+    ]
+    assert all("Zq7" not in finding.message for finding in findings)
+
+
 _ROLE_INDEPENDENT_POINTER = "/configuration/schema_mapping/0/mapping"
 
 

--- a/tests/configuration/test_validation_core.py
+++ b/tests/configuration/test_validation_core.py
@@ -760,6 +760,44 @@ def test_no_two_findings_share_a_location_severity_and_code_over_the_cap(declara
     assert len(set(keys)) == len(keys)
 
 
+def _many_omissions_package_data(*, contradiction_at: int | None = None) -> dict[str, Any]:
+    data = package_data()
+    if contradiction_at is not None:
+        data["configuration"]["schema_mapping"] = [{"name": f"Kind{contradiction_at:03}", "mapping": "x"}]
+    data["omissions"] = [{"kind": f"Kind{index:03}"} for index in range(_FINDING_CAP + 1)]
+    return data
+
+
+def test_a_warnings_only_suppression_yields_a_warning_sentinel_and_no_refusal() -> None:
+    # The sentinel's severity is the maximum severity among the *suppressed* findings.
+    # 257 warnings: the one cut is a warning, so the report stays error-free and the
+    # package still validates with no wrapper raise.
+    data = _many_omissions_package_data()
+
+    findings = collect_findings(package(data))
+
+    assert len(findings) == _FINDING_CAP + 1
+    assert findings[0].code == "finding-limit-reached"
+    assert findings[0].location == _LIMIT_POINTER
+    assert {finding.severity for finding in findings} == {"warning"}
+    validate_package_credentials(package(data))
+
+
+def test_one_suppressed_error_yields_an_error_sentinel() -> None:
+    # The contradiction error's pointer "/omissions/99" sorts lexicographically last among
+    # the 257 omission pointers, so warnings fill the cap and the one suppressed finding
+    # is the error: the sentinel says error even though every presented real finding is a
+    # warning — an error-free presentation would misreport a package that cannot register.
+    data = _many_omissions_package_data(contradiction_at=99)
+
+    findings = collect_findings(package(data))
+
+    assert len(findings) == _FINDING_CAP + 1
+    assert findings[0].code == "finding-limit-reached"
+    assert findings[0].severity == "error"
+    assert {finding.severity for finding in findings[1:]} == {"warning"}
+
+
 # Frozen by CF-004a's envelope. Two contract families are deliberately absent — destination
 # schema mismatch and unsupported destination write behaviour — so neither can be claimed
 # vacuously by a set comparison that only grows.

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -103,6 +103,43 @@ def test_omitting_an_unmapped_kind_stays_a_warning() -> None:
     assert _triples(data) == [("intentional-omission", "warning", "/omissions/0")]
 
 
+# --- The unqualified-optional-feature family ---------------------------------------------
+
+
+def test_declaring_incremental_against_an_unqualified_source_yields_one_warning() -> None:
+    # `incremental:` is an optional feature only some sources implement; a source whose
+    # capability declaration does not qualify it silently runs full extraction today.
+    data = package_data()
+    data["configuration"]["source"] = {"name": "prometheus", "settings": {"url": "https://prom.example"}}
+    data["configuration"]["incremental"] = {"full_resync_every": 5}
+
+    assert _triples(data) == [("optional-feature-unqualified", "warning", "/configuration/incremental")]
+
+
+def test_declaring_incremental_against_a_qualified_source_yields_no_warning() -> None:
+    data = package_data()
+    data["configuration"]["incremental"] = {"full_resync_every": 5}
+
+    assert _triples(data) == []
+
+
+def test_an_undeclared_incremental_feature_yields_no_warning() -> None:
+    data = package_data()
+    data["configuration"]["source"] = {"name": "prometheus", "settings": {"url": "https://prom.example"}}
+
+    assert _triples(data) == []
+
+
+def test_an_unknown_source_adapter_reports_no_feature_warning() -> None:
+    # A missing capability needed to determine safety is an error, not a warning: the
+    # core's missing-adapter finding owns the role and its subtree is unevaluable.
+    data = package_data()
+    data["configuration"]["source"]["name"] = "mystery"
+    data["configuration"]["incremental"] = {"full_resync_every": 5}
+
+    assert _triples(data) == [("missing-adapter", "error", "/configuration/source")]
+
+
 # --- The warnings module's own exact-set and reachability guards ------------------------
 
 
@@ -110,10 +147,11 @@ FROZEN_WARNING_MODULE_CODES = frozenset(
     {
         "intentional-omission",
         "omission-contradicts-mapping",
+        "optional-feature-unqualified",
     }
 )
 # The closed emission rule: only the two contract section 4 families carry a warning.
-FROZEN_WARNING_SEVERITY_CODES = frozenset({"intentional-omission"})
+FROZEN_WARNING_SEVERITY_CODES = frozenset({"intentional-omission", "optional-feature-unqualified"})
 
 
 def _declared_codes(tree: ast.AST) -> set[str]:
@@ -151,6 +189,8 @@ def test_the_warnings_module_can_emit_exactly_the_frozen_code_enumeration() -> N
 
 def test_every_frozen_warning_module_code_is_reachable_and_nothing_else_is_emitted() -> None:
     data = package_data()
+    data["configuration"]["source"] = {"name": "prometheus", "settings": {"url": "https://prom.example"}}
+    data["configuration"]["incremental"] = {"full_resync_every": 5}
     data["configuration"]["schema_mapping"] = [{"name": "InfraDevice", "mapping": "dcim.devices"}]
     data["omissions"] = [
         {"kind": "InfraCircuit", "fields": ["provider"]},

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
 import infrahub_sync
 from infrahub_sync.configuration import (
@@ -23,6 +24,7 @@ from infrahub_sync.configuration import (
     parse_configuration_package,
     validate_package_credentials,
 )
+from infrahub_sync.configuration import models as configuration_models
 from infrahub_sync.configuration import warnings as configuration_warnings
 from tests.configuration.validation_packages import package, package_data
 
@@ -150,22 +152,26 @@ def test_an_unknown_source_adapter_reports_no_feature_warning() -> None:
     assert _triples(data) == [("missing-adapter", "error", "/configuration/source")]
 
 
-# --- Pre-PR correction F2: an omission reason must be printable -------------------------
+# --- Pre-PR correction F2, closed as property P2: acceptance is str.isprintable() -------
 
 
 @pytest.mark.parametrize(
     "reason",
     [
-        # One probe per refused category class: a line break (Cc) splits an operator-facing
+        # Probes across the refused categories: a line break (Cc) splits an operator-facing
         # line, an ANSI escape (Cc) rewrites the terminal it is printed to, a bidi override
-        # (U+202E, Cf) reorders what the operator reads, and the Unicode line and paragraph
-        # separators (Zl, Zp) split a line the way a newline does. Each reached the finding
+        # (U+202E, Cf) reorders what the operator reads, the Unicode line and paragraph
+        # separators (Zl, Zp) split a line the way a newline does, a no-break space
+        # (U+00A0, Zs but not the space character) and an unassigned code point (U+0378,
+        # Cn) are what the former category denylist let through. Each reached the finding
         # message verbatim before the model refused them.
         pytest.param("tracked\nelsewhere", id="newline"),
         pytest.param("tracked\x1b[31melsewhere", id="ansi-escape"),
         pytest.param("tracked \u202eelsewhere", id="bidi-override"),
         pytest.param("tracked\u2028elsewhere", id="line-separator"),
         pytest.param("tracked\u2029elsewhere", id="paragraph-separator"),
+        pytest.param("tracked\u00a0elsewhere", id="no-break-space"),
+        pytest.param("tracked\u0378elsewhere", id="unassigned"),
     ],
 )
 def test_an_unprintable_omission_reason_is_refused_without_being_echoed(reason: str) -> None:
@@ -188,6 +194,45 @@ def test_a_reason_with_ordinary_spaces_stays_accepted() -> None:
     data["omissions"] = [{"kind": "InfraDevice", "reason": "serials tracked in the CMDB"}]
 
     assert [finding.code for finding in collect_findings(package(data))] == ["intentional-omission"]
+
+
+def _omission_reason_accepted(reason: str) -> bool:
+    try:
+        configuration_models._OmissionDeclaration(kind="InfraDevice", reason=reason)
+    except PydanticValidationError:
+        return False
+    return True
+
+
+# One probe per category the property must decide: printable letters, the plain space
+# (Zs, and the one separator ``isprintable`` accepts), an emoji (So), punctuation, a
+# control character (Cc), a format character (Cf), a lone surrogate (Cs), a private-use
+# character (Co), line/paragraph separators (Zl, Zp), a no-break space (Zs, not
+# printable), and an unassigned code point (Cn).
+_CATEGORY_PROBES = (
+    "a",
+    "serials tracked in the CMDB",
+    " ",
+    "\U0001f642",
+    "!",
+    "\x07",
+    "\u202e",
+    "\ud800",
+    "\ue000",
+    "\u2028",
+    "\u2029",
+    "\u00a0",
+    "\u0378",
+)
+
+
+def test_omission_reason_acceptance_is_exactly_isprintable() -> None:
+    # The closed property: the validator's verdict equals str.isprintable(), for every
+    # category probe and for a generated sample of code points across the BMP and SMP.
+    sample = [chr(code_point) for code_point in range(0x20, 0x2FA20, 0x10F)]
+
+    for probe in (*_CATEGORY_PROBES, *sample):
+        assert _omission_reason_accepted(probe) == probe.isprintable(), hex(ord(probe[0]))
 
 
 # --- Determinism across invocations and presentations -----------------------------------

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 
+import infrahub_sync
 from infrahub_sync.configuration import (
     ConfigurationPackageParseError,
     CredentialConfigurationError,
@@ -297,3 +298,17 @@ def test_warning_severity_is_written_only_in_the_warnings_module() -> None:
         }
         if module_path.name != "warnings.py":
             assert "warning" not in severities, f"{module_path.name} writes a warning severity"
+
+
+# --- Pre-PR correction F5: the warnings-module enumeration is documented ----------------
+
+
+def test_every_frozen_warning_module_code_is_documented_for_an_operator() -> None:
+    # The warnings-module mirror of the core's documentation guard: the warning channel's
+    # codes are stable identifiers an operator can meet, so each must be one they can
+    # look up.
+    reference = Path(infrahub_sync.__file__).parents[1] / "docs" / "docs" / "reference" / "durable-product-records.mdx"
+    documented = reference.read_text(encoding="utf-8")
+
+    assert "### Finding codes" in documented
+    assert {code for code in FROZEN_WARNING_MODULE_CODES if f"`{code}`" not in documented} == set()

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 import ast
 import re
+import unicodedata
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from infrahub_sync.configuration import (
+    ConfigurationPackageParseError,
     CredentialConfigurationError,
     collect_findings,
+    parse_configuration_package,
     validate_package_credentials,
 )
 from infrahub_sync.configuration import warnings as configuration_warnings
@@ -144,6 +147,46 @@ def test_an_unknown_source_adapter_reports_no_feature_warning() -> None:
     data["configuration"]["incremental"] = {"full_resync_every": 5}
 
     assert _triples(data) == [("missing-adapter", "error", "/configuration/source")]
+
+
+# --- Pre-PR correction F2: an omission reason must be printable -------------------------
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # One probe per refused category class: a line break (Cc) splits an operator-facing
+        # line, an ANSI escape (Cc) rewrites the terminal it is printed to, a bidi override
+        # (U+202E, Cf) reorders what the operator reads, and the Unicode line and paragraph
+        # separators (Zl, Zp) split a line the way a newline does. Each reached the finding
+        # message verbatim before the model refused them.
+        pytest.param("tracked\nelsewhere", id="newline"),
+        pytest.param("tracked\x1b[31melsewhere", id="ansi-escape"),
+        pytest.param("tracked \u202eelsewhere", id="bidi-override"),
+        pytest.param("tracked\u2028elsewhere", id="line-separator"),
+        pytest.param("tracked\u2029elsewhere", id="paragraph-separator"),
+    ],
+)
+def test_an_unprintable_omission_reason_is_refused_without_being_echoed(reason: str) -> None:
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "reason": reason}]
+
+    with pytest.raises(ConfigurationPackageParseError) as caught:
+        parse_configuration_package(data)
+
+    message = str(caught.value)
+    assert "/omissions/0/reason" in message
+    # The refusal never echoes the raw value: no character of the probe class survives
+    # into the operator-facing parse error.
+    assert reason not in message
+    assert not any(unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"} for character in message)
+
+
+def test_a_reason_with_ordinary_spaces_stays_accepted() -> None:
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "reason": "serials tracked in the CMDB"}]
+
+    assert [finding.code for finding in collect_findings(package(data))] == ["intentional-omission"]
 
 
 # --- Determinism across invocations and presentations -----------------------------------

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -1,0 +1,181 @@
+"""Contract section 4 warning families: the emission surface in ``configuration/warnings.py``.
+
+The core's own code enumeration (``test_validation_core.FROZEN_CODES``) and the schema
+module's stay byte-untouched; this module carries the warnings module's mirror of the same
+exact-set and reachability guards, plus the behavior of the two warning families.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+from infrahub_sync.configuration import collect_findings
+from infrahub_sync.configuration import warnings as configuration_warnings
+from tests.configuration.validation_packages import package, package_data
+
+_MAX_FINDING_TEXT_LENGTH = 256
+
+
+def _triples(data: dict[str, Any]) -> list[tuple[str, str, str]]:
+    return [(finding.code, finding.severity, finding.location) for finding in collect_findings(package(data))]
+
+
+# --- The intentional-omission family ----------------------------------------------------
+
+
+def test_each_declared_omission_yields_one_warning_at_its_declaration() -> None:
+    data = package_data()
+    data["omissions"] = [
+        {"kind": "InfraDevice", "fields": ["serial_number"]},
+        {"kind": "InfraCircuit"},
+    ]
+
+    assert _triples(data) == [
+        ("intentional-omission", "warning", "/omissions/0"),
+        ("intentional-omission", "warning", "/omissions/1"),
+    ]
+
+
+def test_an_omission_reason_reaches_the_warning_message_verbatim() -> None:
+    reason = "serials tracked in the CMDB"
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "reason": reason}]
+
+    findings = collect_findings(package(data))
+
+    assert [finding.code for finding in findings] == ["intentional-omission"]
+    assert findings[0].message.endswith(f": {reason}")
+
+
+def test_a_reason_at_the_model_bound_yields_a_well_formed_finding() -> None:
+    # AR10 at the bound: the 160-character model bound plus the fixed template stays under
+    # the 256-character finding-text limit, verbatim and untruncated.
+    reason = "r" * 160
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "reason": reason}]
+
+    findings = collect_findings(package(data))
+
+    assert [finding.code for finding in findings] == ["intentional-omission"]
+    assert findings[0].message.endswith(f": {reason}")
+    assert len(findings[0].message) <= _MAX_FINDING_TEXT_LENGTH
+
+
+def test_an_omission_naming_a_mapped_field_is_an_error_replacing_the_warning() -> None:
+    # A contradictory declaration is a package defect, not a preference: exactly one
+    # finding at the declaration, and it is the error.
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [
+        {"name": "InfraDevice", "mapping": "dcim.devices", "fields": [{"name": "serial_number", "mapping": "serial"}]}
+    ]
+    data["omissions"] = [{"kind": "InfraDevice", "fields": ["serial_number"]}]
+
+    assert _triples(data) == [("omission-contradicts-mapping", "error", "/omissions/0")]
+
+
+def test_a_whole_kind_omission_contradicts_any_mapping_of_that_kind() -> None:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": "InfraDevice", "mapping": "dcim.devices"}]
+    data["omissions"] = [{"kind": "InfraDevice"}]
+
+    assert _triples(data) == [("omission-contradicts-mapping", "error", "/omissions/0")]
+
+
+def test_omitting_an_unmapped_field_of_a_mapped_kind_stays_a_warning() -> None:
+    # The mapping maps other fields; omitting a field it does not map is consistent intent.
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [
+        {"name": "InfraDevice", "mapping": "dcim.devices", "fields": [{"name": "hostname", "mapping": "name"}]}
+    ]
+    data["omissions"] = [{"kind": "InfraDevice", "fields": ["serial_number"]}]
+
+    assert _triples(data) == [("intentional-omission", "warning", "/omissions/0")]
+
+
+def test_omitting_an_unmapped_kind_stays_a_warning() -> None:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": "InfraCircuit", "mapping": "circuits.circuits"}]
+    data["omissions"] = [{"kind": "InfraDevice"}]
+
+    assert _triples(data) == [("intentional-omission", "warning", "/omissions/0")]
+
+
+# --- The warnings module's own exact-set and reachability guards ------------------------
+
+
+FROZEN_WARNING_MODULE_CODES = frozenset(
+    {
+        "intentional-omission",
+        "omission-contradicts-mapping",
+    }
+)
+# The closed emission rule: only the two contract section 4 families carry a warning.
+FROZEN_WARNING_SEVERITY_CODES = frozenset({"intentional-omission"})
+
+
+def _declared_codes(tree: ast.AST) -> set[str]:
+    declared: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        if any(name.startswith("_CODE_") for name in names) and isinstance(node.value, ast.Constant):
+            declared.add(str(node.value.value))
+    return declared
+
+
+_KEBAB_LITERAL = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)+$")
+
+
+def _kebab_literals(tree: ast.AST) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _KEBAB_LITERAL.fullmatch(node.value) is not None
+    }
+
+
+def test_the_warnings_module_can_emit_exactly_the_frozen_code_enumeration() -> None:
+    # The warnings-module mirror of the core's exact-set test: collected from the
+    # implementation, not restated, and every code is a kebab-case literal nothing else is.
+    tree = ast.parse(Path(configuration_warnings.__file__).read_text(encoding="utf-8"))
+
+    assert _declared_codes(tree) == FROZEN_WARNING_MODULE_CODES
+    assert _kebab_literals(tree) == FROZEN_WARNING_MODULE_CODES
+
+
+def test_every_frozen_warning_module_code_is_reachable_and_nothing_else_is_emitted() -> None:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": "InfraDevice", "mapping": "dcim.devices"}]
+    data["omissions"] = [
+        {"kind": "InfraCircuit", "fields": ["provider"]},
+        {"kind": "InfraDevice"},
+    ]
+
+    findings = collect_findings(package(data))
+
+    assert {finding.code for finding in findings} == FROZEN_WARNING_MODULE_CODES
+    assert {finding.code for finding in findings if finding.severity == "warning"} == FROZEN_WARNING_SEVERITY_CODES
+
+
+def test_warning_severity_is_written_only_in_the_warnings_module() -> None:
+    # The closed emission rule, structurally: across the configuration package, only the
+    # warnings module hands "warning" to a finding constructor. The core's own AST test
+    # already proves validation.py writes severity="error" and nothing else.
+    package_directory = Path(configuration_warnings.__file__).parent
+    for module_path in sorted(package_directory.glob("*.py")):
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        severities = {
+            keyword.value.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            for keyword in node.keywords
+            if keyword.arg == "severity" and isinstance(keyword.value, ast.Constant)
+        }
+        if module_path.name != "warnings.py":
+            assert "warning" not in severities, f"{module_path.name} writes a warning severity"

--- a/tests/configuration/test_warnings.py
+++ b/tests/configuration/test_warnings.py
@@ -12,7 +12,13 @@ import re
 from pathlib import Path
 from typing import Any
 
-from infrahub_sync.configuration import collect_findings
+import pytest
+
+from infrahub_sync.configuration import (
+    CredentialConfigurationError,
+    collect_findings,
+    validate_package_credentials,
+)
 from infrahub_sync.configuration import warnings as configuration_warnings
 from tests.configuration.validation_packages import package, package_data
 
@@ -138,6 +144,35 @@ def test_an_unknown_source_adapter_reports_no_feature_warning() -> None:
     data["configuration"]["incremental"] = {"full_resync_every": 5}
 
     assert _triples(data) == [("missing-adapter", "error", "/configuration/source")]
+
+
+# --- Determinism across invocations and presentations -----------------------------------
+
+
+def test_mixed_severity_findings_are_deterministic_across_invocations_and_presentations() -> None:
+    # Same package bytes, same installed adapter set: byte-identical ordered findings,
+    # warnings included, on every invocation — and the wrapper still raises the shipped
+    # message of the first error in execution order, which the warning families follow.
+    data = package_data()
+    data["configuration"]["source"] = {"name": "prometheus", "settings": {"url": "https://prom.example", "bogus": 1}}
+    data["configuration"]["incremental"] = {"full_resync_every": 5}
+    data["configuration"]["schema_mapping"] = [{"name": "InfraDevice", "mapping": "dcim.devices"}]
+    data["omissions"] = [{"kind": "InfraCircuit"}, {"kind": "InfraDevice"}]
+
+    first = collect_findings(package(data))
+
+    assert first == collect_findings(package(data))
+    assert [(finding.code, finding.severity, finding.location) for finding in first] == [
+        ("optional-feature-unqualified", "warning", "/configuration/incremental"),
+        ("undeclared-setting", "error", "/configuration/source/settings/bogus"),
+        ("intentional-omission", "warning", "/omissions/0"),
+        ("omission-contradicts-mapping", "error", "/omissions/1"),
+    ]
+    with pytest.raises(CredentialConfigurationError) as caught:
+        validate_package_credentials(package(data))
+    assert str(caught.value) == (
+        "adapter 'prometheus' contains unsupported declared settings for the source role: [\"bogus\"]"
+    )
 
 
 # --- The warnings module's own exact-set and reachability guards ------------------------

--- a/tests/configuration/validation_packages.py
+++ b/tests/configuration/validation_packages.py
@@ -1,0 +1,37 @@
+"""Declared-package builders shared by the accumulating-validation tests."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from infrahub_sync.configuration import ConfigurationPackage
+
+_VALID_CONTENT: dict[str, Any] = {
+    "format_version": 1,
+    "configuration": {
+        "name": "from-netbox",
+        "source": {
+            "name": "netbox",
+            "settings": {"url": "https://demo.netbox.dev", "token": {"$credential": "netbox-token"}},
+        },
+        "destination": {
+            "name": "infrahub",
+            "settings": {"url": "http://localhost:8000", "token": {"$credential": "infrahub-token"}},
+        },
+    },
+    "credentials": {
+        "netbox-token": {"provider": "env", "identifier": "NETBOX_TOKEN"},
+        "infrahub-token": {"provider": "env", "identifier": "INFRAHUB_API_TOKEN"},
+    },
+}
+
+
+def package_data() -> dict[str, Any]:
+    """Return one valid declared package as mutable JSON-native content."""
+    return copy.deepcopy(_VALID_CONTENT)
+
+
+def package(data: dict[str, Any] | None = None) -> ConfigurationPackage:
+    """Parse declared content into a package, defaulting to the valid one."""
+    return ConfigurationPackage.model_validate(package_data() if data is None else data)

--- a/tests/conformance/test_product_cache_location.py
+++ b/tests/conformance/test_product_cache_location.py
@@ -1,0 +1,59 @@
+"""One product-cache-location rule, reached by every entry point that accepts the option.
+
+Envelope OES-21. The absoluteness rule was stated three times before this slice — once in
+the version 1 request models, once implicitly by the local projection's constructor, and
+nowhere in the shared layer — so two entry points refused the same input with two different
+sentences. What is asserted here is that one function now produces the refusal and that the
+shared service renders it verbatim.
+
+The asymmetry is deliberate and is asserted too: a *missing* location is a legacy cache-only
+fallback for a run and a refusal for the registry, which has nowhere to live without a store.
+Only absoluteness is shared.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub_sync.product_store import configs as configs_service
+from infrahub_sync.product_store.standalone import ProductCacheLocationError, resolve_product_cache_location
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+RELATIVE = "relative/product-cache"
+UNRESOLVABLE = "~db006-user-that-cannot-exist/product-cache"
+
+
+def test_the_relative_path_refusal_is_one_sentence_at_every_entry_point() -> None:
+    with pytest.raises(ProductCacheLocationError) as rule:
+        resolve_product_cache_location(RELATIVE)
+    expected = str(rule.value)
+
+    with pytest.raises(configs_service.ConfigsRequestError) as service:
+        configs_service.validate(config_id="c", registry_version=1, product_cache_location=RELATIVE)
+    assert str(service.value) == expected
+
+
+def test_the_unresolvable_home_refusal_is_one_sentence_at_every_entry_point() -> None:
+    with pytest.raises(ProductCacheLocationError, match="unresolvable user home"):
+        resolve_product_cache_location(UNRESOLVABLE)
+
+
+def test_user_home_expansion_is_still_accepted_at_every_entry_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The repair narrows the accepted set to non-absolute paths only, not to `~` as well."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    tilde = "~/product-cache"
+
+    assert resolve_product_cache_location(tilde) == home / "product-cache"
+
+
+def test_a_missing_location_falls_back_for_runs_and_refuses_for_the_registry() -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="product_cache_location is required"):
+        configs_service.validate(config_id="c", registry_version=1, product_cache_location=None)

--- a/tests/integration/test_destination_schema_live_read.py
+++ b/tests/integration/test_destination_schema_live_read.py
@@ -17,8 +17,8 @@ from typing import Any
 
 import pytest
 
+from infrahub_sync.configuration import capabilities as capabilities_module
 from infrahub_sync.configuration import parse_configuration_package
-from infrahub_sync.configuration.capabilities import _read_infrahub_destination_schema
 
 INFRAHUB_ADDRESS = os.environ.get("INFRAHUB_ADDRESS")
 INFRAHUB_API_TOKEN = os.environ.get("INFRAHUB_API_TOKEN")
@@ -50,7 +50,7 @@ def _live_package_data() -> dict[str, Any]:
 def test_the_live_accessor_returns_a_judgeable_snapshot() -> None:
     package = parse_configuration_package(_live_package_data())
 
-    snapshot = _read_infrahub_destination_schema(package, "main")
+    snapshot = capabilities_module._read_infrahub_destination_schema(package, "main")
 
     assert snapshot
     for entry in snapshot.values():

--- a/tests/integration/test_destination_schema_live_read.py
+++ b/tests/integration/test_destination_schema_live_read.py
@@ -1,0 +1,60 @@
+"""Live-read exercise for the bundled Infrahub destination-schema accessor.
+
+The unit tests inject snapshots through the capability seam; this is the one opt-in
+exercise against a real server, proving the live accessor returns the snapshot shape the
+schema checks judge. Skipped automatically when ``INFRAHUB_ADDRESS`` +
+``INFRAHUB_API_TOKEN`` are not set. Run locally with::
+
+    INFRAHUB_ADDRESS=http://localhost:8000 \\
+    INFRAHUB_API_TOKEN=<token> \\
+    pytest tests/integration/test_destination_schema_live_read.py -m integration
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from infrahub_sync.configuration import parse_configuration_package
+from infrahub_sync.configuration.capabilities import _read_infrahub_destination_schema
+
+INFRAHUB_ADDRESS = os.environ.get("INFRAHUB_ADDRESS")
+INFRAHUB_API_TOKEN = os.environ.get("INFRAHUB_API_TOKEN")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (INFRAHUB_ADDRESS and INFRAHUB_API_TOKEN),
+        reason="INFRAHUB_ADDRESS and INFRAHUB_API_TOKEN are required for live schema reads",
+    ),
+]
+
+
+def _live_package_data() -> dict[str, Any]:
+    return {
+        "format_version": 1,
+        "configuration": {
+            "name": "live-schema-read",
+            "source": {"name": "netbox", "settings": {"url": "https://demo.netbox.dev"}},
+            "destination": {
+                "name": "infrahub",
+                "settings": {"url": INFRAHUB_ADDRESS, "token": {"$credential": "infrahub-token"}},
+            },
+        },
+        "credentials": {"infrahub-token": {"provider": "env", "identifier": "INFRAHUB_API_TOKEN"}},
+    }
+
+
+def test_the_live_accessor_returns_a_judgeable_snapshot() -> None:
+    package = parse_configuration_package(_live_package_data())
+
+    snapshot = _read_infrahub_destination_schema(package, "main")
+
+    assert snapshot
+    for entry in snapshot.values():
+        assert set(entry) == {"attributes", "relationships"}
+        assert all(isinstance(kind, str) for kind in entry["attributes"].values())
+        for relationship in entry["relationships"].values():
+            assert set(relationship) == {"peer", "cardinality"}

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -13,7 +13,7 @@ import sqlite3
 import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from pydantic import ValidationError
@@ -1347,34 +1347,31 @@ def _prebuilt_instances() -> tuple[tuple[str, ConfigurationPackage], ...]:
     )
 
 
-@pytest.mark.parametrize(
-    "instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()]
-)
+@pytest.mark.parametrize("instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()])
 def test_register_refuses_a_prebuilt_package_instance(tmp_path: Path, instance: ConfigurationPackage) -> None:
     # Any instance — the exact class included — can carry behavior validation never judged:
     # a subclass overriding ``declared_content()``, or ``model_construct`` skipping
     # validation entirely. The boundary accepts declared JSON-native content only.
     location = _store(tmp_path)
+    # Typed away deliberately: the whole point is a call the signature no longer admits.
+    prebuilt = cast("Any", instance)
 
     with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
-        configs_service.register(package=instance, product_cache_location=location)  # type: ignore[arg-type]
+        configs_service.register(package=prebuilt, product_cache_location=location)
 
     assert _registered_configuration_count(tmp_path / "product-cache") == 0
 
 
-@pytest.mark.parametrize(
-    "instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()]
-)
-def test_create_version_refuses_a_prebuilt_package_instance(
-    tmp_path: Path, instance: ConfigurationPackage
-) -> None:
+@pytest.mark.parametrize("instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()])
+def test_create_version_refuses_a_prebuilt_package_instance(tmp_path: Path, instance: ConfigurationPackage) -> None:
     location = _store(tmp_path)
     registered = configs_service.register(package=package_data(), product_cache_location=location)
+    prebuilt = cast("Any", instance)
 
     with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
         configs_service.create_version(
             config_id=registered.configuration.config_id,
-            package=instance,  # type: ignore[arg-type]
+            package=prebuilt,
             product_cache_location=location,
         )
 
@@ -1392,10 +1389,10 @@ def test_a_hostile_declared_content_override_cannot_reach_the_store(tmp_path: Pa
     the caller's own input, and nothing is written.
     """
     location = _store(tmp_path)
-    hostile = _HostileDeclaredContent.model_validate(package_data())
+    hostile = cast("Any", _HostileDeclaredContent.model_validate(package_data()))
 
     with pytest.raises(configs_service.ConfigsRequestError):
-        configs_service.register(package=hostile, product_cache_location=location)  # type: ignore[arg-type]
+        configs_service.register(package=hostile, product_cache_location=location)
 
     root = tmp_path / "product-cache"
     assert _registered_configuration_count(root) == 0
@@ -1416,7 +1413,7 @@ class _IntSubclass(int):
     """An int subclass: well-behaved arithmetically, still not the declared domain."""
 
 
-_OUT_OF_DOMAIN_REGISTRY_VERSIONS: tuple[tuple[str, Any], ...] = (
+_OUT_OF_DOMAIN_REGISTRY_VERSIONS: tuple[tuple[str, object], ...] = (
     # bool is an int subclass, so an isinstance guard let True reach SQLite, compare
     # equal to 1, and silently resolve version 1 - a caller defect answered as data.
     ("true", True),
@@ -1434,7 +1431,7 @@ _OUT_OF_DOMAIN_REGISTRY_VERSIONS: tuple[tuple[str, Any], ...] = (
 )
 @pytest.mark.parametrize("operation", ["get_version", "validate"])
 def test_an_out_of_domain_registry_version_is_the_callers_input(
-    tmp_path: Path, operation: str, registry_version: Any
+    tmp_path: Path, operation: str, registry_version: object
 ) -> None:
     location = _store(tmp_path)
     registered = configs_service.register(package=package_data(), product_cache_location=location)

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1541,6 +1541,11 @@ _OUT_OF_DOMAIN_REGISTRY_VERSIONS: tuple[tuple[str, object], ...] = (
     ("zero", 0),
     ("negative", -1),
     ("int-subclass", _IntSubclass(1)),
+    # The storage domain has an upper edge too: SQLite INTEGER is signed 64-bit, so the
+    # registry can never allocate above 2**63 - 1. 2**63 passed the positive-int guard
+    # and surfaced as SQLite's own OverflowError - an internal error for caller input.
+    ("max-plus-one", 2**63),
+    ("far-beyond-the-domain", 2**200),
 )
 
 
@@ -1563,6 +1568,22 @@ def test_an_out_of_domain_registry_version_is_the_callers_input(
         )
 
     assert raised.value.family == "request"
+
+
+def test_the_domain_maximum_is_still_the_stores_own_answer(tmp_path: Path) -> None:
+    # The property's upper edge from the inside: 2**63 - 1 is the last version the
+    # registry could ever allocate, so it reaches the store and is its own not-found.
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.get_version(
+            config_id=registered.configuration.config_id,
+            registry_version=2**63 - 1,
+            product_cache_location=location,
+        )
+
+    assert raised.value.reason == configs_service.CONFIGURATION_VERSION_NOT_FOUND_REASON
 
 
 def test_a_large_valid_registry_version_is_still_the_stores_own_answer(tmp_path: Path) -> None:

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1407,3 +1407,60 @@ def test_a_hostile_declared_content_override_cannot_reach_the_store(tmp_path: Pa
 def test_a_non_mapping_package_is_the_callers_input_not_an_internal_error(tmp_path: Path) -> None:
     with pytest.raises(configs_service.ConfigsRequestError, match="package must be Mapping"):
         configs_service.register(package=_WRONG_TYPED_VALUE, product_cache_location=_store(tmp_path))
+
+
+# --- Pre-PR correction F4: the registry_version domain is exactly positive int ----------
+
+
+class _IntSubclass(int):
+    """An int subclass: well-behaved arithmetically, still not the declared domain."""
+
+
+_OUT_OF_DOMAIN_REGISTRY_VERSIONS: tuple[tuple[str, Any], ...] = (
+    # bool is an int subclass, so an isinstance guard let True reach SQLite, compare
+    # equal to 1, and silently resolve version 1 - a caller defect answered as data.
+    ("true", True),
+    ("false", False),
+    # The registry allocates from 1: 0 and -1 are not versions that happen to be absent,
+    # so reporting them not-found claimed the store answered an unaskable question.
+    ("zero", 0),
+    ("negative", -1),
+    ("int-subclass", _IntSubclass(1)),
+)
+
+
+@pytest.mark.parametrize(
+    "registry_version", [pytest.param(value, id=name) for name, value in _OUT_OF_DOMAIN_REGISTRY_VERSIONS]
+)
+@pytest.mark.parametrize("operation", ["get_version", "validate"])
+def test_an_out_of_domain_registry_version_is_the_callers_input(
+    tmp_path: Path, operation: str, registry_version: Any
+) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+    call = getattr(configs_service, operation)
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        call(
+            config_id=registered.configuration.config_id,
+            registry_version=registry_version,
+            product_cache_location=location,
+        )
+
+    assert raised.value.family == "request"
+
+
+def test_a_large_valid_registry_version_is_still_the_stores_own_answer(tmp_path: Path) -> None:
+    # The guard checks the domain and nothing else: a well-formed version the registry has
+    # not allocated is still absence, reported by the store's own not-found.
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.get_version(
+            config_id=registered.configuration.config_id,
+            registry_version=10**12,
+            product_cache_location=location,
+        )
+
+    assert raised.value.reason == configs_service.CONFIGURATION_VERSION_NOT_FOUND_REASON

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -265,10 +265,143 @@ def test_list_configs_returns_every_configuration_in_created_at_then_config_id_o
     assert configs_service.list_configs(product_cache_location=location) == listed
 
 
+def test_get_config_and_list_versions_return_one_configurations_own_records(tmp_path: Path) -> None:
+    """The summary and the full ascending version lineage, scoped to the requested ID.
+
+    A second, unrelated configuration is registered into the same store so an unscoped read
+    would be caught leaking its rows.
+    """
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+    changed = package_data()
+    changed["configuration"]["source"]["settings"]["url"] = "https://second.netbox.test"
+    added = configs_service.create_version(
+        config_id=registered.version.config_id,
+        package=changed,
+        product_cache_location=location,
+    )
+    unrelated = configs_service.register(package=package_data(), product_cache_location=location)
+
+    summary = configs_service.get_config(
+        config_id=registered.version.config_id,
+        product_cache_location=location,
+    )
+    versions = configs_service.list_versions(
+        config_id=registered.version.config_id,
+        product_cache_location=location,
+    )
+
+    assert summary == registered.configuration
+    assert versions == (registered.version, added.version)
+    assert [version.registry_version for version in versions] == [1, 2]
+    assert unrelated.version.config_id not in {version.config_id for version in versions}
+
+
+def test_get_version_on_a_missing_configuration_names_the_configuration_as_absent(tmp_path: Path) -> None:
+    """The first half of the AR3 distinction: no such configuration at all."""
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.get_version(
+            config_id="missing-configuration",
+            registry_version=1,
+            product_cache_location=_store(tmp_path),
+        )
+
+    assert raised.value.family == "not-found"
+    assert raised.value.reason == "configuration-not-found"
+
+
+def test_get_version_on_a_missing_version_is_distinct_from_a_missing_configuration(tmp_path: Path) -> None:
+    """The second half: the configuration exists and the version does not.
+
+    The store's own lookup blends both cases into one "configuration-version-not-found"
+    reason, so the service looks the configuration up first (deletion does not exist, so the
+    two-step read is race-safe) and the two absences surface as distinct machine-readable
+    values -- what service-boundary later maps to two different status codes.
+    """
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    with pytest.raises(configs_service.ConfigsNotFoundError) as missing_version:
+        configs_service.get_version(
+            config_id=registered.version.config_id,
+            registry_version=7,
+            product_cache_location=location,
+        )
+    with pytest.raises(configs_service.ConfigsNotFoundError) as missing_configuration:
+        configs_service.get_version(
+            config_id="missing-configuration",
+            registry_version=7,
+            product_cache_location=location,
+        )
+
+    assert missing_version.value.family == "not-found"
+    assert missing_version.value.reason == "configuration-version-not-found"
+    assert missing_version.value.reason != missing_configuration.value.reason
+
+
+# The two reads whose store queries return a tuple, so a missing configuration's natural
+# defect is a silent empty result -- indistinguishable from a real answer about a registered
+# configuration with no rows to show.
+_MISSING_CONFIGURATION_READS: tuple[tuple[str, Callable[[str], object]], ...] = (
+    (
+        "get_config",
+        lambda location: configs_service.get_config(
+            config_id="missing-configuration",
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "list_versions",
+        lambda location: configs_service.list_versions(
+            config_id="missing-configuration",
+            product_cache_location=location,
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _MISSING_CONFIGURATION_READS])
+def test_a_read_of_a_missing_configuration_refuses_rather_than_answering_empty(
+    tmp_path: Path,
+    call: Callable[[str], object],
+) -> None:
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        call(_store(tmp_path))
+
+    assert raised.value.family == "not-found"
+    assert raised.value.reason == "configuration-not-found"
+
+
+def test_get_version_round_trips_the_registered_content_and_checksum(tmp_path: Path) -> None:
+    """A read returns exactly what registration reported -- field equality, not "no error"."""
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    stored = configs_service.get_version(
+        config_id=registered.version.config_id,
+        registry_version=1,
+        product_cache_location=location,
+    )
+
+    assert stored.declared_content == registered.version.declared_content
+    assert stored.package_checksum == registered.version.package_checksum
+    assert stored == registered.version
+
+
 # The read entry points, each reached with a syntactically fine request, so the only thing a
 # raised refusal can be about is the store location (envelope OES-21's evidence pattern).
 _READ_ENTRY_POINTS: tuple[tuple[str, Callable[[str | None], object]], ...] = (
     ("list_configs", lambda location: configs_service.list_configs(product_cache_location=location)),
+    ("get_config", lambda location: configs_service.get_config(config_id="c", product_cache_location=location)),
+    ("list_versions", lambda location: configs_service.list_versions(config_id="c", product_cache_location=location)),
+    (
+        "get_version",
+        lambda location: configs_service.get_version(
+            config_id="c",
+            registry_version=1,
+            product_cache_location=location,
+        ),
+    ),
 )
 
 
@@ -312,6 +445,36 @@ _WRONG_TYPED_CALLS: tuple[tuple[str, Callable[[str], object]], ...] = (
         lambda location: configs_service.create_version(
             config_id=_WRONG_TYPED_VALUE,
             package=package_data(),
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "get-config-config-id",
+        lambda location: configs_service.get_config(
+            config_id=_WRONG_TYPED_VALUE,
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "list-versions-config-id",
+        lambda location: configs_service.list_versions(
+            config_id=_WRONG_TYPED_VALUE,
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "get-version-config-id",
+        lambda location: configs_service.get_version(
+            config_id=_WRONG_TYPED_VALUE,
+            registry_version=1,
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "get-version-registry-version",
+        lambda location: configs_service.get_version(
+            config_id="c",
+            registry_version=_WRONG_TYPED_VALUE,
             product_cache_location=location,
         ),
     ),
@@ -359,6 +522,16 @@ _ENTRY_POINTS: tuple[tuple[str, Callable[[str], object]], ...] = (
         lambda location: configs_service.validate(config_id="c", registry_version=1, product_cache_location=location),
     ),
     ("list_configs", lambda location: configs_service.list_configs(product_cache_location=location)),
+    ("get_config", lambda location: configs_service.get_config(config_id="c", product_cache_location=location)),
+    ("list_versions", lambda location: configs_service.list_versions(config_id="c", product_cache_location=location)),
+    (
+        "get_version",
+        lambda location: configs_service.get_version(
+            config_id="c",
+            registry_version=1,
+            product_cache_location=location,
+        ),
+    ),
 )
 
 
@@ -554,6 +727,25 @@ _PUBLIC_OPERATIONS: tuple[tuple[str, Callable[[pytest.MonkeyPatch], None], Calla
         lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
         lambda tmp_path: configs_service.list_configs(product_cache_location=_store(tmp_path)),
     ),
+    (
+        "get_config",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.get_config(config_id="c", product_cache_location=_store(tmp_path)),
+    ),
+    (
+        "list_versions",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.list_versions(config_id="c", product_cache_location=_store(tmp_path)),
+    ),
+    (
+        "get_version",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.get_version(
+            config_id="c",
+            registry_version=1,
+            product_cache_location=_store(tmp_path),
+        ),
+    ),
 )
 
 
@@ -618,7 +810,16 @@ def test_every_public_service_operation_carries_the_error_boundary() -> None:
 
     assert guarded <= set(public)
     assert set(public) - guarded == _TEXT_HELPERS
-    assert guarded == {"create_version", "list_configs", "load_package_content", "register", "validate"}
+    assert guarded == {
+        "create_version",
+        "get_config",
+        "get_version",
+        "list_configs",
+        "list_versions",
+        "load_package_content",
+        "register",
+        "validate",
+    }
 
 
 def _refusal_types(root: type[configs_service.ConfigsError]) -> set[type[configs_service.ConfigsError]]:

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1612,6 +1612,55 @@ def test_a_wrong_typed_argument_never_has_its_class_metadata_read(
     assert reads == []
 
 
+def test_a_wrong_typed_argument_with_a_raising_class_property_is_the_callers_input(tmp_path: Path) -> None:
+    # isinstance() is itself inspection: it consults the instance's __class__, which a
+    # hostile property executes on, so this probe escaped get_config() as
+    # ConfigsInternalError. The guard matches type(value) identity alone and reads
+    # nothing off the instance.
+    reads: list[str] = []
+
+    class _RaisingClassProbe:
+        @property
+        def __class__(self) -> type:
+            reads.append("__class__")
+            msg = "__class__ was consulted"
+            raise RuntimeError(msg)
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.get_config(config_id=cast("Any", _RaisingClassProbe()), product_cache_location=_store(tmp_path))
+
+    assert raised.value.family == "request"
+    assert reads == []
+
+
+def test_the_boundary_classifies_without_consulting_an_exceptions_class_property(tmp_path: Path) -> None:
+    # The boundary's isinstance classification consulted exc.__class__ — an instance
+    # read a hostile property executes on — so an exception a hostile caller argument
+    # constructs escaped list_configs() as a raw RuntimeError, outside the declared
+    # vocabulary. Except clauses match the actual type without touching the instance.
+    del tmp_path
+    reads: list[str] = []
+
+    class _HostileError(Exception):
+        @property
+        def __class__(self) -> type:
+            reads.append("__class__")
+            msg = "__class__ was consulted"
+            raise RuntimeError(msg)
+
+    class _RaisingLocation:
+        def __str__(self) -> str:
+            msg = "str() exploded: third-party secret text"
+            raise _HostileError(msg)
+
+    with pytest.raises(configs_service.ConfigsInternalError) as raised:
+        configs_service.list_configs(product_cache_location=cast("Any", _RaisingLocation()))
+
+    assert raised.value.family == "internal"
+    assert str(raised.value) == "configs list_configs failed"
+    assert reads == []
+
+
 def test_the_boundary_reads_nothing_from_an_exception_it_did_not_name(tmp_path: Path) -> None:
     # The boundary's own refusal formatted type(exc).__name__ — but an exception a
     # hostile caller argument constructs (here: a product_cache_location whose

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1358,7 +1358,7 @@ def test_register_refuses_a_prebuilt_package_instance(tmp_path: Path, instance: 
     # Typed away deliberately: the whole point is a call the signature no longer admits.
     prebuilt = cast("Any", instance)
 
-    with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
+    with pytest.raises(configs_service.ConfigsRequestError, match="must be a JSON-native dict"):
         configs_service.register(package=prebuilt, product_cache_location=location)
 
     assert _registered_configuration_count(tmp_path / "product-cache") == 0
@@ -1370,7 +1370,7 @@ def test_create_version_refuses_a_prebuilt_package_instance(tmp_path: Path, inst
     registered = configs_service.register(package=package_data(), product_cache_location=location)
     prebuilt = cast("Any", instance)
 
-    with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
+    with pytest.raises(configs_service.ConfigsRequestError, match="must be a JSON-native dict"):
         configs_service.create_version(
             config_id=registered.configuration.config_id,
             package=prebuilt,
@@ -1522,6 +1522,38 @@ def test_a_refused_package_is_never_invoked(tmp_path: Path) -> None:
         configs_service.register(package=cast("Any", sentinel), product_cache_location=_store(tmp_path))
 
     assert sentinel.consulted == []
+
+
+def test_a_rejected_package_never_has_its_class_metadata_read(tmp_path: Path) -> None:
+    # Inspection is invocation, class metadata included: the refusal used to read
+    # ``__mro__`` and ``__name__`` off the untrusted value's class, and a metaclass
+    # executes on those reads — the probe escaped register() as ConfigsInternalError
+    # with the read recorded. The refusal reads nothing: one fixed message.
+    reads: list[str] = []
+
+    class _ExecutingMeta(type):
+        @property
+        def __mro__(cls) -> tuple[type, ...]:  # noqa: PLW3201 - shadowing type's own descriptor is the fixture
+            reads.append("__mro__")
+            msg = "metaclass executed on __mro__ read"
+            raise RuntimeError(msg)
+
+        @property
+        def __name__(cls) -> str:  # noqa: PLW3201 - shadowing type's own descriptor is the fixture
+            reads.append("__name__")
+            msg = "metaclass executed on __name__ read"
+            raise RuntimeError(msg)
+
+    class _MetadataProbe(metaclass=_ExecutingMeta):
+        """An out-of-domain value whose class metadata is executable behavior."""
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.register(package=cast("Any", _MetadataProbe()), product_cache_location=_store(tmp_path))
+
+    assert raised.value.family == "request"
+    assert "must be a JSON-native dict" in str(raised.value)
+    assert reads == []
+    assert _registered_configuration_count(tmp_path / "product-cache") == 0
 
 
 # --- Pre-PR correction F4: the registry_version domain is exactly positive int ----------

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1556,6 +1556,94 @@ def test_a_rejected_package_never_has_its_class_metadata_read(tmp_path: Path) ->
     assert _registered_configuration_count(tmp_path / "product-cache") == 0
 
 
+def _hostile_metadata_instance() -> tuple[object, list[str]]:
+    """An out-of-domain value whose class ``__name__`` read is recorded executable behavior."""
+    reads: list[str] = []
+
+    class _ExecutingMeta(type):
+        @property
+        def __name__(cls) -> str:  # noqa: PLW3201 - shadowing type's own descriptor is the fixture
+            reads.append("__name__")
+            msg = "metaclass executed on __name__ read"
+            raise RuntimeError(msg)
+
+    class _Probe(metaclass=_ExecutingMeta):
+        """A caller-supplied value whose class metadata is executable behavior."""
+
+    return _Probe(), reads
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda location, value: configs_service.get_config(config_id=value, product_cache_location=location),
+            id="config-id",
+        ),
+        pytest.param(
+            lambda location, value: configs_service.get_version(
+                config_id="c", registry_version=value, product_cache_location=location
+            ),
+            id="registry-version",
+        ),
+        pytest.param(
+            lambda location, value: configs_service.validate(
+                config_id="c",
+                registry_version=1,
+                product_cache_location=location,
+                destination_schema=value,
+            ),
+            id="destination-schema",
+        ),
+    ],
+)
+def test_a_wrong_typed_argument_never_has_its_class_metadata_read(
+    tmp_path: Path, call: Callable[[str, Any], object]
+) -> None:
+    # The package boundary's rule applied to every argument guard: the refusals
+    # formatted type(value).__name__, and a metaclass executes on that read — the
+    # probe escaped each public operation as ConfigsInternalError.
+    probe, reads = _hostile_metadata_instance()
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        call(_store(tmp_path), cast("Any", probe))
+
+    assert raised.value.family == "request"
+    assert reads == []
+
+
+def test_the_boundary_reads_nothing_from_an_exception_it_did_not_name(tmp_path: Path) -> None:
+    # The boundary's own refusal formatted type(exc).__name__ — but an exception a
+    # hostile caller argument constructs (here: a product_cache_location whose
+    # __str__ raises it) has an untrusted class, and the metaclass executing on that
+    # read escaped the module as a raw RuntimeError, outside the declared vocabulary
+    # entirely. The boundary reads nothing: family by isinstance, one fixed message.
+    del tmp_path
+    reads: list[str] = []
+
+    class _ExecutingMeta(type):
+        @property
+        def __name__(cls) -> str:  # noqa: PLW3201 - shadowing type's own descriptor is the fixture
+            reads.append("__name__")
+            msg = "metaclass executed on __name__ read"
+            raise RuntimeError(msg)
+
+    class _HostileError(Exception, metaclass=_ExecutingMeta):
+        """An exception whose class name read is executable behavior."""
+
+    class _RaisingLocation:
+        def __str__(self) -> str:
+            msg = "str() exploded: third-party secret text"
+            raise _HostileError(msg)
+
+    with pytest.raises(configs_service.ConfigsInternalError) as raised:
+        configs_service.list_configs(product_cache_location=cast("Any", _RaisingLocation()))
+
+    assert raised.value.family == "internal"
+    assert str(raised.value) == "configs list_configs failed"
+    assert reads == []
+
+
 # --- Pre-PR correction F4: the registry_version domain is exactly positive int ----------
 
 

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -90,6 +90,34 @@ def test_register_refuses_an_invalid_package_and_persists_nothing(tmp_path: Path
     assert _registered_configuration_count(tmp_path / "product-cache") == 0
 
 
+def test_a_warning_only_package_registers_and_reports_its_warnings(tmp_path: Path) -> None:
+    # Errors prevent execution; warnings do not. A package whose only findings are
+    # warnings registers, versions, and validates error-free through the whole service.
+    location = _store(tmp_path)
+    data = package_data()
+    data["omissions"] = [{"kind": "InfraDevice", "fields": ["serial_number"]}]
+    changed = package_data()
+    changed["omissions"] = [{"kind": "InfraDevice"}]
+
+    registered = configs_service.register(package=data, product_cache_location=location)
+    versioned = configs_service.create_version(
+        config_id=registered.configuration.config_id,
+        package=changed,
+        product_cache_location=location,
+    )
+    report = configs_service.validate(
+        config_id=registered.configuration.config_id,
+        registry_version=registered.version.registry_version,
+        product_cache_location=location,
+    )
+
+    assert versioned.created
+    assert versioned.version.registry_version == 2
+    assert [(finding.code, finding.severity, finding.location) for finding in report.findings] == [
+        ("intentional-omission", "warning", "/omissions/0"),
+    ]
+
+
 def test_create_version_is_idempotent_for_an_identical_package(tmp_path: Path) -> None:
     location = _store(tmp_path)
     registered = configs_service.register(package=package_data(), product_cache_location=location)

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -11,6 +11,8 @@ import inspect
 import json
 import sqlite3
 import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -22,6 +24,7 @@ from infrahub_sync.configuration.validation import collect_findings
 from infrahub_sync.execution import MIN_SECRET_LENGTH, REDACTED, collect_secret_values
 from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
+from infrahub_sync.product_store import store as product_store_store
 from tests.configuration.validation_packages import package, package_data
 
 if TYPE_CHECKING:
@@ -219,6 +222,70 @@ def test_a_relative_store_location_is_refused() -> None:
         configs_service.validate(config_id="c", registry_version=1, product_cache_location="relative/product-cache")
 
 
+# --- Registry reads ---------------------------------------------------------------------
+#
+# The rows below are chosen so raw insertion order disagrees with the declared listing order
+# on both halves of the ORDER BY. ``created_at`` is server-generated, so on an append-only
+# table insertion order always equals timestamp order and a missing ORDER BY would pass
+# trivially: the clock is therefore controlled so two rows share one ``created_at`` (only the
+# ``config_id`` tiebreak separates them) and a third row is registered last with the earliest
+# timestamp (only ordering by ``created_at`` puts it first).
+_OUT_OF_ORDER_REGISTRATIONS: tuple[tuple[str, datetime], ...] = (
+    ("config-b", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+    ("config-a", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+    ("config-z", datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)),
+)
+
+
+def _register_out_of_order(location: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register the rows above through the service, with generated IDs and clock pinned."""
+    ids = iter([config_id for config_id, _ in _OUT_OF_ORDER_REGISTRATIONS])
+    clock = iter([created_at for _, created_at in _OUT_OF_ORDER_REGISTRATIONS])
+    monkeypatch.setattr(product_store_store, "_generate_config_id", lambda: next(ids))
+    monkeypatch.setattr(product_store_store, "datetime", SimpleNamespace(now=lambda tz: next(clock)))  # noqa: ARG005
+    for _ in _OUT_OF_ORDER_REGISTRATIONS:
+        configs_service.register(package=package_data(), product_cache_location=location)
+
+
+def test_list_configs_returns_every_configuration_in_created_at_then_config_id_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every registered configuration exactly once, in the one declared deterministic order."""
+    location = _store(tmp_path)
+    _register_out_of_order(location, monkeypatch)
+
+    listed = configs_service.list_configs(product_cache_location=location)
+
+    assert [(summary.config_id, summary.created_at) for summary in listed] == [
+        ("config-z", datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)),
+        ("config-a", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+        ("config-b", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+    ]
+    # Order determinism: a re-read of the same store returns the identical sequence.
+    assert configs_service.list_configs(product_cache_location=location) == listed
+
+
+# The read entry points, each reached with a syntactically fine request, so the only thing a
+# raised refusal can be about is the store location (envelope OES-21's evidence pattern).
+_READ_ENTRY_POINTS: tuple[tuple[str, Callable[[str | None], object]], ...] = (
+    ("list_configs", lambda location: configs_service.list_configs(product_cache_location=location)),
+)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _READ_ENTRY_POINTS])
+def test_a_read_with_a_missing_store_location_is_a_refusal_rather_than_a_fallback(
+    call: Callable[[str | None], object],
+) -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="product_cache_location is required"):
+        call(None)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _READ_ENTRY_POINTS])
+def test_a_read_with_a_relative_store_location_is_refused(call: Callable[[str | None], object]) -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="must be absolute after user expansion"):
+        call("relative/product-cache")
+
+
 # A value of the wrong type entirely, annotated ``Any`` so the calls below type-check. That is
 # the only way it reaches the service: a caller's own defect that got past static checking.
 _WRONG_TYPED_VALUE: Any = object()
@@ -291,6 +358,7 @@ _ENTRY_POINTS: tuple[tuple[str, Callable[[str], object]], ...] = (
         "validate",
         lambda location: configs_service.validate(config_id="c", registry_version=1, product_cache_location=location),
     ),
+    ("list_configs", lambda location: configs_service.list_configs(product_cache_location=location)),
 )
 
 
@@ -481,6 +549,11 @@ _PUBLIC_OPERATIONS: tuple[tuple[str, Callable[[pytest.MonkeyPatch], None], Calla
             product_cache_location=_store(tmp_path),
         ),
     ),
+    (
+        "list_configs",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.list_configs(product_cache_location=_store(tmp_path)),
+    ),
 )
 
 
@@ -545,7 +618,7 @@ def test_every_public_service_operation_carries_the_error_boundary() -> None:
 
     assert guarded <= set(public)
     assert set(public) - guarded == _TEXT_HELPERS
-    assert guarded == {"create_version", "load_package_content", "register", "validate"}
+    assert guarded == {"create_version", "list_configs", "load_package_content", "register", "validate"}
 
 
 def _refusal_types(root: type[configs_service.ConfigsError]) -> set[type[configs_service.ConfigsError]]:

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from pydantic import ValidationError
 
-from infrahub_sync.configuration import BUILTIN_ADAPTER_CAPABILITIES, ValidationFinding
+from infrahub_sync.configuration import BUILTIN_ADAPTER_CAPABILITIES, ConfigurationPackage, ValidationFinding
 from infrahub_sync.configuration.models import safe_pointer_component
 from infrahub_sync.configuration.validation import collect_findings
 from infrahub_sync.execution import MIN_SECRET_LENGTH, REDACTED, collect_secret_values
@@ -1322,3 +1322,88 @@ def test_an_untouched_component_survives_redaction_of_its_neighbour_byte_for_byt
 
     assert redacted.startswith("/configuration/source/settings/a~01b~1c/***")
     assert _accepts(redacted)
+
+
+# --- Pre-PR correction F1: the write boundary refuses prebuilt package instances --------
+
+
+_INLINE_CANARY = "canary-inline-secret-0123456789"
+
+
+class _HostileDeclaredContent(ConfigurationPackage):
+    """Validated fields hold only references; the persisted dump smuggles an inline secret."""
+
+    def declared_content(self) -> dict[str, Any]:
+        content = super().declared_content()
+        content["configuration"]["source"]["settings"]["token"] = _INLINE_CANARY
+        return content
+
+
+def _prebuilt_instances() -> tuple[tuple[str, ConfigurationPackage], ...]:
+    return (
+        ("exact-class", ConfigurationPackage.model_validate(package_data())),
+        ("subclass", _HostileDeclaredContent.model_validate(package_data())),
+        ("model-construct", ConfigurationPackage.model_construct(**package_data())),
+    )
+
+
+@pytest.mark.parametrize(
+    "instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()]
+)
+def test_register_refuses_a_prebuilt_package_instance(tmp_path: Path, instance: ConfigurationPackage) -> None:
+    # Any instance — the exact class included — can carry behavior validation never judged:
+    # a subclass overriding ``declared_content()``, or ``model_construct`` skipping
+    # validation entirely. The boundary accepts declared JSON-native content only.
+    location = _store(tmp_path)
+
+    with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
+        configs_service.register(package=instance, product_cache_location=location)  # type: ignore[arg-type]
+
+    assert _registered_configuration_count(tmp_path / "product-cache") == 0
+
+
+@pytest.mark.parametrize(
+    "instance", [pytest.param(instance, id=name) for name, instance in _prebuilt_instances()]
+)
+def test_create_version_refuses_a_prebuilt_package_instance(
+    tmp_path: Path, instance: ConfigurationPackage
+) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    with pytest.raises(configs_service.ConfigsRequestError, match="prebuilt ConfigurationPackage instance"):
+        configs_service.create_version(
+            config_id=registered.configuration.config_id,
+            package=instance,  # type: ignore[arg-type]
+            product_cache_location=location,
+        )
+
+    versions = configs_service.list_versions(
+        config_id=registered.configuration.config_id, product_cache_location=location
+    )
+    assert [version.registry_version for version in versions] == [1]
+
+
+def test_a_hostile_declared_content_override_cannot_reach_the_store(tmp_path: Path) -> None:
+    """The pre-PR review reproduction, now failing safe.
+
+    Before the boundary refused instances, this subclass registered successfully and the
+    inline canary landed in the durable store row. Now the instance itself is refused as
+    the caller's own input, and nothing is written.
+    """
+    location = _store(tmp_path)
+    hostile = _HostileDeclaredContent.model_validate(package_data())
+
+    with pytest.raises(configs_service.ConfigsRequestError):
+        configs_service.register(package=hostile, product_cache_location=location)  # type: ignore[arg-type]
+
+    root = tmp_path / "product-cache"
+    assert _registered_configuration_count(root) == 0
+    database = root / "product-records.sqlite3"
+    if database.exists():
+        assert _INLINE_CANARY.encode() not in database.read_bytes()
+
+
+def test_a_non_mapping_package_is_the_callers_input_not_an_internal_error(tmp_path: Path) -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="package must be Mapping"):
+        configs_service.register(package=_WRONG_TYPED_VALUE, product_cache_location=_store(tmp_path))

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -1,0 +1,1022 @@
+"""Behavioral contract for the shared ``configs`` application service.
+
+The service is the layer both interfaces call. What is asserted here is therefore what the
+CLI and the Python API are each forbidden to re-decide: which package is persisted, which
+error family a failure belongs to, and the order findings arrive in.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sqlite3
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from pydantic import ValidationError
+
+from infrahub_sync.configuration import BUILTIN_ADAPTER_CAPABILITIES, ValidationFinding
+from infrahub_sync.configuration.models import safe_pointer_component
+from infrahub_sync.configuration.validation import collect_findings
+from infrahub_sync.execution import MIN_SECRET_LENGTH, REDACTED, collect_secret_values
+from infrahub_sync.product_store import configs as configs_service
+from infrahub_sync.product_store import local_product_projection
+from tests.configuration.validation_packages import package, package_data
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+def _store(tmp_path: Path) -> str:
+    root = tmp_path / "product-cache"
+    root.mkdir()
+    return str(root)
+
+
+def _registered_configuration_count(root: Path) -> int:
+    """Count registry rows directly, so 'persisted nothing' is read off the durable store."""
+    database = root / "product-records.sqlite3"
+    if not database.exists():
+        return 0
+    connection = sqlite3.connect(database)
+    try:
+        rows = connection.execute(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'configurations'"
+        ).fetchone()
+        if rows[0] == 0:
+            return 0
+        return int(connection.execute("SELECT count(*) FROM configurations").fetchone()[0])
+    finally:
+        connection.close()
+
+
+def _invalid_package_data() -> dict[str, Any]:
+    """Return a package with two independent, unrelated defects."""
+    data = package_data()
+    data["configuration"]["source"]["settings"]["url"] = "netbox.example.test"
+    data["configuration"]["destination"]["settings"]["bogus_dest"] = "x"
+    return data
+
+
+def test_register_returns_the_configuration_and_its_first_version(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    assert registered.version.registry_version == 1
+    assert registered.configuration.config_id == registered.version.config_id
+    stored = local_product_projection(tmp_path / "product-cache").lookup_configuration_version(
+        registered.version.config_id, 1
+    )
+    assert stored.value is not None
+    assert stored.value.package_checksum == registered.version.package_checksum
+
+
+def test_register_refuses_an_invalid_package_and_persists_nothing(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+
+    with pytest.raises(configs_service.ConfigsValidationError) as raised:
+        configs_service.register(package=_invalid_package_data(), product_cache_location=location)
+
+    assert raised.value.family == "validation"
+    codes = [finding.code for finding in raised.value.findings]
+    assert "endpoint-not-absolute" in codes
+    assert "undeclared-setting" in codes
+    assert _registered_configuration_count(tmp_path / "product-cache") == 0
+
+
+def test_create_version_is_idempotent_for_an_identical_package(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    repeated = configs_service.create_version(
+        config_id=registered.version.config_id,
+        package=package_data(),
+        product_cache_location=location,
+    )
+
+    assert repeated.created is False
+    assert repeated.version.registry_version == 1
+
+
+def test_create_version_allocates_the_next_ordinal_for_new_content(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+    changed = package_data()
+    changed["configuration"]["source"]["settings"]["url"] = "https://second.netbox.test"
+
+    added = configs_service.create_version(
+        config_id=registered.version.config_id,
+        package=changed,
+        product_cache_location=location,
+    )
+
+    assert added.created is True
+    assert added.version.registry_version == 2
+
+
+def test_create_version_refuses_an_unregistered_configuration(tmp_path: Path) -> None:
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.create_version(
+            config_id="20260808T1200-aaaaaaaa",
+            package=package_data(),
+            product_cache_location=_store(tmp_path),
+        )
+
+    assert raised.value.family == "not-found"
+
+
+def test_validate_reports_every_defect_of_a_registered_version_in_sorted_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+    # A registered package was valid when it was registered; re-validating it against a
+    # different adapter set is the whole reason this surface exists.
+    monkeypatch.setattr("infrahub_sync.configuration.validation.BUILTIN_ADAPTER_CAPABILITIES", {})
+
+    report = configs_service.validate(
+        config_id=registered.version.config_id,
+        registry_version=1,
+        product_cache_location=location,
+    )
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("missing-adapter", "/configuration/destination"),
+        ("missing-adapter", "/configuration/source"),
+    ]
+    assert report.package_checksum == registered.version.package_checksum
+
+
+def test_validate_reports_no_findings_for_a_still_valid_version(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    report = configs_service.validate(
+        config_id=registered.version.config_id,
+        registry_version=1,
+        product_cache_location=location,
+    )
+
+    assert report.findings == ()
+    assert BUILTIN_ADAPTER_CAPABILITIES  # the real capability set was in play
+
+
+def test_validate_refuses_an_unregistered_version(tmp_path: Path) -> None:
+    location = _store(tmp_path)
+    registered = configs_service.register(package=package_data(), product_cache_location=location)
+
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.validate(
+            config_id=registered.version.config_id,
+            registry_version=7,
+            product_cache_location=location,
+        )
+
+    assert raised.value.family == "not-found"
+
+
+def test_unparseable_package_content_is_a_request_refusal(tmp_path: Path) -> None:
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.register(package={"format_version": 99}, product_cache_location=_store(tmp_path))
+
+    assert raised.value.family == "request"
+
+
+def test_the_error_vocabulary_is_one_closed_family_set() -> None:
+    families = {
+        subclass.family
+        for subclass in (
+            configs_service.ConfigsRequestError,
+            configs_service.ConfigsValidationError,
+            configs_service.ConfigsNotFoundError,
+            configs_service.ConfigsStorageError,
+        )
+    }
+
+    assert families == {"request", "validation", "not-found", "storage"}
+    assert all(
+        issubclass(subclass, configs_service.ConfigsError)
+        for subclass in (
+            configs_service.ConfigsRequestError,
+            configs_service.ConfigsValidationError,
+            configs_service.ConfigsNotFoundError,
+            configs_service.ConfigsStorageError,
+        )
+    )
+    assert configs_service.describe(configs_service.ConfigsNotFoundError("gone"), ()) == "not-found: gone"
+
+
+def test_a_missing_store_location_is_a_refusal_rather_than_a_fallback() -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="product_cache_location is required"):
+        configs_service.validate(config_id="c", registry_version=1, product_cache_location="")
+
+
+def test_a_relative_store_location_is_refused() -> None:
+    with pytest.raises(configs_service.ConfigsRequestError, match="must be absolute after user expansion"):
+        configs_service.validate(config_id="c", registry_version=1, product_cache_location="relative/product-cache")
+
+
+# A value of the wrong type entirely, annotated ``Any`` so the calls below type-check. That is
+# the only way it reaches the service: a caller's own defect that got past static checking.
+_WRONG_TYPED_VALUE: Any = object()
+
+_WRONG_TYPED_CALLS: tuple[tuple[str, Callable[[str], object]], ...] = (
+    (
+        "validate-config-id",
+        lambda location: configs_service.validate(
+            config_id=_WRONG_TYPED_VALUE,
+            registry_version=1,
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "validate-registry-version",
+        lambda location: configs_service.validate(
+            config_id="c",
+            registry_version=_WRONG_TYPED_VALUE,
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "create-version-config-id",
+        lambda location: configs_service.create_version(
+            config_id=_WRONG_TYPED_VALUE,
+            package=package_data(),
+            product_cache_location=location,
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _WRONG_TYPED_CALLS])
+def test_a_wrong_typed_identifier_is_the_callers_input_and_not_the_store(
+    tmp_path: Path,
+    call: Callable[[str], object],
+) -> None:
+    """A wrong-typed identifier must not send an operator to look at their own disk.
+
+    Unguarded, the value is handed to SQLite as a query parameter and comes back as
+    ``sqlite3.ProgrammingError``, which the boundary can only read as ``storage``. The store
+    here is real, writable and healthy, so ``storage`` is a false report about it: the defect is
+    in the call.
+    """
+    with pytest.raises(configs_service.ConfigsError) as raised:
+        call(_store(tmp_path))
+
+    assert raised.value.family == "request"
+
+
+def test_a_well_typed_identifier_still_gets_the_stores_own_answer(tmp_path: Path) -> None:
+    """The type guard checks the type and nothing else, so absence is still the store's verdict."""
+    with pytest.raises(configs_service.ConfigsNotFoundError) as raised:
+        configs_service.validate(config_id="c", registry_version=1, product_cache_location=_store(tmp_path))
+
+    assert raised.value.family == "not-found"
+
+
+_ENTRY_POINTS: tuple[tuple[str, Callable[[str], object]], ...] = (
+    ("register", lambda location: configs_service.register(package=package_data(), product_cache_location=location)),
+    (
+        "create_version",
+        lambda location: configs_service.create_version(
+            config_id="c",
+            package=package_data(),
+            product_cache_location=location,
+        ),
+    ),
+    (
+        "validate",
+        lambda location: configs_service.validate(config_id="c", registry_version=1, product_cache_location=location),
+    ),
+)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _ENTRY_POINTS])
+def test_a_store_the_filesystem_refuses_is_a_storage_refusal(
+    tmp_path: Path,
+    call: Callable[[str], object],
+) -> None:
+    # A real store failure, not a monkeypatched raise. Opening the registry creates its own
+    # directories, and the filesystem is what refuses here, so this test can see which base
+    # class the service catches - which a faked raise cannot. A plain file where the registry
+    # wants a directory is the form that needs no permission change, so it behaves identically
+    # as root and under CI, where an unwritable-directory test would not fail at all.
+    occupied = tmp_path / "product-cache"
+    occupied.write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(configs_service.ConfigsStorageError) as raised:
+        call(str(occupied))
+
+    assert raised.value.family == "storage"
+
+
+def test_a_package_file_is_loaded_from_json_or_yaml(tmp_path: Path) -> None:
+    json_file = tmp_path / "package.json"
+    json_file.write_text('{"format_version": 1}', encoding="utf-8")
+    yaml_file = tmp_path / "package.yml"
+    yaml_file.write_text("format_version: 1\n", encoding="utf-8")
+
+    assert configs_service.load_package_content(json_file) == {"format_version": 1}
+    assert configs_service.load_package_content(yaml_file) == {"format_version": 1}
+
+
+def test_an_unreadable_package_file_is_a_request_refusal(tmp_path: Path) -> None:
+    with pytest.raises(configs_service.ConfigsRequestError):
+        configs_service.load_package_content(tmp_path / "absent.json")
+
+
+def test_a_package_file_too_nested_to_parse_is_a_request_refusal(tmp_path: Path) -> None:
+    # A real parse failure, not a monkeypatched raise. yaml.safe_load recurses once per nesting
+    # level, so a deeply nested file exhausts the interpreter stack and raises RecursionError -
+    # which is not a yaml.YAMLError and is not a defect in the declared package either. It is
+    # the caller's file that cannot be read, so it belongs to the request family like every
+    # other unusable input.
+    depth = sys.getrecursionlimit()
+    nested = tmp_path / "nested.yaml"
+    nested.write_text("[" * depth + "]" * depth, encoding="utf-8")
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.load_package_content(nested)
+
+    assert raised.value.family == "request"
+
+
+# --- One error boundary, so the declared vocabulary is total -----------------------------
+#
+# What is asserted below is the property, not a list of known escapes: any exception leaving
+# a public service operation is a ConfigsError from the declared vocabulary. Wherever a real
+# failure is available it is caused for real - a registry file that is not a database, a file
+# saved in the wrong encoding, a file describing an infinite structure - because this defect
+# class survived two adversarial reviews on tests that only ever faked the raise, and a faked
+# raise cannot see which base class production code actually catches. Only the unforeseen
+# arm, which by definition no real dependency reaches, is driven by a monkeypatched raise.
+
+_DECLARED_FAMILIES = frozenset({"request", "validation", "not-found", "storage", "internal"})
+
+# The text helpers on the service's public surface. Each transforms text the service itself
+# produced - or answers which rule governs one field of it - takes no store and no path, and
+# is what an interface calls to render a refusal that already exists, so a family label on one
+# would name nothing. Every other public function is an operation and must carry the boundary.
+_TEXT_HELPERS = frozenset(
+    {
+        "describe",
+        "is_closed_vocabulary_field",
+        "redact_finding",
+        "redact_message",
+        "redact_pointer",
+        "redact_public_field",
+    }
+)
+
+
+class _UnforeseenError(Exception):
+    """A dependency failure no arm in the service names, standing in for the ones nobody has met."""
+
+
+def _raise_unforeseen(*args: object, **kwargs: object) -> object:
+    del args, kwargs
+    msg = "Zq7"
+    raise _UnforeseenError(msg)
+
+
+def test_a_package_file_saved_in_another_encoding_is_a_request_refusal(tmp_path: Path) -> None:
+    # A real failure: the bytes really are CP1252. This is the likeliest of these mistakes to
+    # reach an operator - a package edited on Windows and saved as-is - and read_text raises
+    # UnicodeDecodeError, which is a ValueError and not an OSError, so the arm one line above
+    # it never saw it.
+    path = tmp_path / "cp1252.yaml"
+    path.write_bytes("format_version: 1\ndescription: café\n".encode("cp1252"))
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.load_package_content(path)
+
+    assert raised.value.family == "request"
+
+
+def test_a_recursive_package_file_is_a_request_refusal(tmp_path: Path) -> None:
+    # A real failure: an anchor that contains itself is legal YAML describing an infinite
+    # structure. safe_load returns it, and the JSON round-trip is where it breaks - json.dumps
+    # raises ValueError("Circular reference detected"), which the coercion probe swallows and
+    # the coercion itself did not guard. The caller's file is what cannot be read as a
+    # package, so it is a request refusal like every other unusable input.
+    path = tmp_path / "recursive.yaml"
+    path.write_text("&anchor\nkey: *anchor\n", encoding="utf-8")
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.load_package_content(path)
+
+    assert raised.value.family == "request"
+
+
+def test_a_package_file_whose_key_json_cannot_hold_is_a_request_refusal(tmp_path: Path) -> None:
+    # The same arm, a second real shape: an unquoted YAML date is a date, and a date used as a
+    # mapping key is a TypeError from json.dumps, because default=str stringifies values and
+    # never keys. It arrives at the same place as the recursive file and for the same reason -
+    # the coercion probe reads every dump failure as "coercion needed".
+    path = tmp_path / "dated-key.yaml"
+    path.write_text("? 2024-01-01\n: value\n", encoding="utf-8")
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.load_package_content(path)
+
+    assert raised.value.family == "request"
+
+
+def _corrupt_registry(tmp_path: Path) -> str:
+    """Return a store location whose registry file exists, is readable, and is not a database."""
+    root = tmp_path / "product-cache"
+    root.mkdir()
+    (root / "product-records.sqlite3").write_bytes(b"this file is not a database\n")
+    return str(root)
+
+
+@pytest.mark.parametrize("call", [pytest.param(call, id=name) for name, call in _ENTRY_POINTS])
+def test_a_corrupt_registry_file_is_a_storage_refusal(tmp_path: Path, call: Callable[[str], object]) -> None:
+    # A real failure, and a cheap one: SQLite does not read the file header when it opens, so
+    # the store is constructed successfully and every *query* raises sqlite3.DatabaseError
+    # afterwards. The arms around each store call name the store's own error types, so all
+    # three operations handed the caller a raw sqlite3 traceback.
+    with pytest.raises(configs_service.ConfigsStorageError) as raised:
+        call(_corrupt_registry(tmp_path))
+
+    assert raised.value.family == "storage"
+
+
+def _load_a_written_package(tmp_path: Path) -> object:
+    """Load one legal package file, so only the patched dependency can fail the call."""
+    path = tmp_path / "package.yaml"
+    path.write_text("format_version: 1\n", encoding="utf-8")
+    return configs_service.load_package_content(path)
+
+
+_PUBLIC_OPERATIONS: tuple[tuple[str, Callable[[pytest.MonkeyPatch], None], Callable[[Path], object]], ...] = (
+    (
+        "load_package_content",
+        lambda patch: patch.setattr(configs_service.yaml, "safe_load", _raise_unforeseen),
+        _load_a_written_package,
+    ),
+    (
+        "register",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.register(package=package_data(), product_cache_location=_store(tmp_path)),
+    ),
+    (
+        "create_version",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.create_version(
+            config_id="c",
+            package=package_data(),
+            product_cache_location=_store(tmp_path),
+        ),
+    ),
+    (
+        "validate",
+        lambda patch: patch.setattr(configs_service, "local_product_projection", _raise_unforeseen),
+        lambda tmp_path: configs_service.validate(
+            config_id="c",
+            registry_version=1,
+            product_cache_location=_store(tmp_path),
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("patch_dependency", "call"),
+    [pytest.param(patch, call, id=name) for name, patch, call in _PUBLIC_OPERATIONS],
+)
+def test_a_failing_dependency_leaves_a_public_operation_inside_the_declared_vocabulary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    patch_dependency: Callable[[pytest.MonkeyPatch], None],
+    call: Callable[[Path], object],
+) -> None:
+    # The one place a monkeypatched raise is the right tool: this drives the *unforeseen* arm,
+    # and an exception type the service has never met is by definition one no real dependency
+    # raises today. Every other failure in this section is caused for real.
+    patch_dependency(monkeypatch)
+
+    with pytest.raises(configs_service.ConfigsError) as raised:
+        call(tmp_path)
+
+    assert raised.value.family in _DECLARED_FAMILIES
+    # The documented default: neither the caller's input nor the store, and it says so rather
+    # than sending an operator to check a disk over a defect in this service.
+    assert raised.value.family == "internal"
+
+
+def _raise_interrupt(*args: object, **kwargs: object) -> object:
+    del args, kwargs
+    raise KeyboardInterrupt
+
+
+def test_an_interrupt_is_not_caught_by_the_error_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The boundary catches Exception, never BaseException, so an interrupt reaches the
+    # interpreter instead of being reported as a registry refusal. Widening it would swallow
+    # Ctrl-C and SystemExit, which is the decision the run boundary already made explicitly,
+    # and nothing else here would notice.
+    monkeypatch.setattr(configs_service, "local_product_projection", _raise_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        configs_service.register(package=package_data(), product_cache_location=_store(tmp_path))
+
+
+def _public_service_functions() -> dict[str, Any]:
+    """Return every function the service module itself exposes without a leading underscore."""
+    return {
+        name: value
+        for name, value in vars(configs_service).items()
+        if not name.startswith("_") and inspect.isfunction(value) and value.__module__ == configs_service.__name__
+    }
+
+
+def test_every_public_service_operation_carries_the_error_boundary() -> None:
+    # The general claim, checked structurally rather than case by case, so coverage is not four
+    # names kept in step by hand. A public operation added later without the boundary fails
+    # here, and the only way past is to call it a text helper and say why.
+    public = _public_service_functions()
+    guarded = set(configs_service._GUARDED_OPERATIONS)
+
+    assert guarded <= set(public)
+    assert set(public) - guarded == _TEXT_HELPERS
+    assert guarded == {"create_version", "load_package_content", "register", "validate"}
+
+
+def _refusal_types(root: type[configs_service.ConfigsError]) -> set[type[configs_service.ConfigsError]]:
+    """Return every refusal type the service module defines below `root`, however nested."""
+    direct = {subclass for subclass in root.__subclasses__() if subclass.__module__ == configs_service.__name__}
+    return direct | {nested for subclass in direct for nested in _refusal_types(subclass)}
+
+
+def test_every_refusal_type_the_service_defines_carries_a_documented_family() -> None:
+    # The closed-family-set test above names its four types, so it cannot notice a fifth. This
+    # one enumerates, so a family added to the module without a documented name fails here.
+    families = {subclass.family for subclass in _refusal_types(configs_service.ConfigsError)}
+
+    assert families == _DECLARED_FAMILIES
+
+
+# Two pointers whose only difference is a component that is itself a current credential value.
+# Redaction replaces exactly that component, which is the shape in which a lossy pointer
+# transformation can collapse two separate declared defects into one reported finding.
+_COLLIDING_SECRETS = ("alpha", "beta")
+
+_POINTER_BOUND = 256
+
+
+def _settings_finding(component: str) -> ValidationFinding:
+    """Build one finding whose pointer ends in `component` and whose message quotes it."""
+    return ValidationFinding(
+        code="undeclared-setting",
+        severity="error",
+        location=f"/configuration/source/settings/{component}",
+        message=f"setting {component}",
+    )
+
+
+def test_two_pointers_that_redact_alike_stay_distinguishable() -> None:
+    """Redaction is lossy, so it obeys the rule truncation obeys: no two pointers collapse into one.
+
+    The core's invariant is intact either way — dedup and precedence run in `collect_findings`,
+    before redaction — so what breaks here is the operator's ability to tell two reported
+    defects apart at the presentation boundary, which is the same failure truncation had.
+    """
+    first, second = (
+        configs_service.redact_finding(_settings_finding(name), _COLLIDING_SECRETS) for name in _COLLIDING_SECRETS
+    )
+
+    assert first.location != second.location
+    assert first != second
+    for finding, collected in zip((first, second), _COLLIDING_SECRETS):
+        assert collected not in finding.location
+        assert finding.location.startswith("/configuration/source/settings/***")
+        # Still a pointer the field's own grammar accepts, which is what redacting a component
+        # at a time buys and what appending anything to the result could otherwise cost.
+        assert ValidationFinding.model_validate(finding.model_dump()) == finding
+
+
+def test_a_redacted_pointer_is_distinguished_by_its_path_not_by_its_secret() -> None:
+    """The distinguishing tag is bound to the pointer, so it is not a fingerprint of a value.
+
+    One credential value at two declared paths must not produce one tag: a value-only tag is
+    the same wherever that value appears, in any report, and can be joined against a table of
+    hashed candidate values.
+    """
+    collected = "alpha"
+
+    source = configs_service.redact_pointer(f"/configuration/source/settings/{collected}", [collected])
+    destination = configs_service.redact_pointer(f"/configuration/destination/settings/{collected}", [collected])
+
+    assert source.removeprefix("/configuration/source") != destination.removeprefix("/configuration/destination")
+
+
+def test_a_redacted_pointer_stays_inside_the_pointer_bound() -> None:
+    """Whatever redaction appends is inside the bound the pointer field enforces."""
+    collected = "alpha"
+    location = "/" + "a" * 200 + f"/{collected}/" + "b" * 40
+
+    redacted = configs_service.redact_pointer(location, [collected])
+
+    assert len(redacted) <= _POINTER_BOUND
+    assert ValidationFinding(code="undeclared-setting", severity="error", location=redacted, message="x")
+
+
+def test_a_redacted_pointer_cut_on_an_escape_is_still_a_legal_pointer() -> None:
+    """The re-applied bound can separate a "~" from the character that completes it.
+
+    Redaction rebuilds the pointer and then re-applies the field's own 256-character bound, and
+    that second cut lands wherever the shortened text puts it. Here it falls on the "~" of a
+    "~1" escape, so without dropping the orphaned "~" the returned pointer is one the finding
+    grammar refuses — a pydantic error at both interfaces instead of a redacted result. The
+    offsets are chosen so a legal input pointer produces exactly that cut.
+    """
+    collected = "abcdef"
+    location = f"/{collected}/" + "a" * 239 + "~1" + "z" * 5
+
+    assert _accepts(location)
+
+    redacted = configs_service.redact_pointer(location, [collected])
+
+    assert collected not in redacted
+    assert len(redacted) <= _POINTER_BOUND
+    assert _accepts(redacted)
+
+
+def test_an_unredacted_pointer_is_returned_unchanged() -> None:
+    """Nothing is appended when nothing was replaced: only a lossy pass needs a tag."""
+    location = "/configuration/source/settings/url"
+
+    assert configs_service.redact_pointer(location, ["alpha"]) == location
+
+
+# A pointer component is an *escaped* declared key: "~0" stands for a literal "~" and "~1" for
+# a literal "/". The cases below are the ones that separate redacting the key from redacting
+# the escaped text of the key.
+_TILDE_KEY = "x~abcdefg"
+_SLASH_KEY = "a/babcde"
+
+
+def _escaped(key: str) -> str:
+    """Return one declared key in the escaped form a pointer component actually carries."""
+    return safe_pointer_component(key)
+
+
+def _accepts(location: str) -> bool:
+    """Return whether the pointer field's own grammar accepts `location`."""
+    try:
+        ValidationFinding(code="undeclared-setting", severity="error", location=location, message="x")
+    except ValidationError:
+        return False
+    return True
+
+
+@pytest.mark.parametrize(
+    ("key", "collected"),
+    [
+        pytest.param(_TILDE_KEY, "0abcde", id="escaped-tilde"),
+        pytest.param(_SLASH_KEY, "1babcd", id="escaped-slash"),
+    ],
+)
+def test_a_collected_value_cannot_orphan_an_escape_in_a_pointer(key: str, collected: str) -> None:
+    """A collected value that overlaps an escape must not leave a "~" the grammar refuses.
+
+    "0abcde" and "1babcd" only appear in the *escaped* text of the key, straddling the escape's
+    "~" and the character that completes it. Replacing there consumes the completing character
+    and orphans the "~", so the pointer is refused — which raises a pydantic error at both
+    interfaces instead of returning a result. The value is not in the declared key at all, so
+    the correct answer is that nothing is replaced.
+    """
+    location = f"/configuration/source/settings/{_escaped(key)}"
+
+    redacted = configs_service.redact_pointer(location, [collected])
+
+    assert _accepts(redacted)
+    assert redacted == location
+
+
+def test_a_collected_value_containing_a_separator_is_redacted_from_the_key() -> None:
+    """A value is matched against the declared key, not against the key's escaped text.
+
+    A credential value carrying "/" or "~" is invisible in the escaped form, so redacting the
+    escaped text leaves it in the report. Redacting the key catches it, and re-escaping
+    afterwards keeps the result a legal pointer.
+    """
+    collected = "w/secret1"
+    location = f"/configuration/source/settings/{_escaped('pw/secret123')}"
+
+    redacted = configs_service.redact_pointer(location, [collected])
+
+    assert collected not in redacted
+    assert _accepts(redacted)
+    assert redacted.startswith("/configuration/source/settings/p***23")
+
+
+def test_a_collected_value_spanning_a_component_boundary_is_not_replaced() -> None:
+    """The "/" between two components is structure, not declared content.
+
+    No declared key contains it, so a value that only appears across the boundary is not a
+    value the pointer discloses, and the pointer is returned untouched.
+    """
+    location = "/configuration/foo/barbaz"
+
+    assert configs_service.redact_pointer(location, ["oo/barba"]) == location
+
+
+def test_a_pointer_carrying_escaped_separators_is_returned_unchanged() -> None:
+    """A key holding both escapes and no collected value comes back byte-identical."""
+    location = f"/configuration/source/settings/{_escaped('a~1b/c')}"
+
+    assert location == "/configuration/source/settings/a~01b~1c"
+    assert configs_service.redact_pointer(location, ["nosecrethere"]) == location
+
+
+# ``_add_url_userinfo`` collects a credential in "user:password" form, so a colon is part of
+# the most common collected-secret shape there is. ``safe_pointer_component`` writes ":" as
+# "\u003a", and that escaped text — not the declared key — is what the emitted pointer carries.
+_USERINFO_SHAPED_KEY = "adm:pw"
+
+# Every declared key whose escaped form differs from the key itself, so a redaction pass that
+# matches against the escaped text misses the value the key holds.
+_ESCAPED_SECRET_KEYS = (
+    pytest.param("adm:pw", id="colon"),
+    pytest.param("adm;pw", id="semicolon"),
+    pytest.param("adm\\pw", id="backslash"),
+    pytest.param("adm\tpw", id="tab"),
+    pytest.param("adm\npw", id="newline"),
+    pytest.param("adm\rpw", id="carriage-return"),
+    pytest.param("adm/pw", id="slash"),
+    pytest.param("adm~pw", id="tilde"),
+    pytest.param("adm\x01pw", id="control-character"),
+)
+
+
+def test_a_userinfo_shaped_secret_is_redacted_from_the_key_it_escapes_into() -> None:
+    """The most common collected-secret shape is the one the escaped text hides.
+
+    ``_add_url_userinfo`` collects "user:password", ``safe_pointer_component`` writes the colon
+    as "\u003a", and matching against that text never finds the value. The declared key is
+    fully recoverable from the emitted pointer, in a mechanism whose docstring says it redacts
+    the declared keys a pointer quotes.
+    """
+    location = f"/configuration/source/settings/{_escaped(_USERINFO_SHAPED_KEY)}"
+
+    redacted = configs_service.redact_pointer(location, [_USERINFO_SHAPED_KEY])
+
+    assert redacted != location
+    assert _USERINFO_SHAPED_KEY not in redacted
+    assert _escaped(_USERINFO_SHAPED_KEY) not in redacted
+    assert redacted.startswith("/configuration/source/settings/***")
+    assert _accepts(redacted)
+
+
+@pytest.mark.parametrize("key", _ESCAPED_SECRET_KEYS)
+def test_a_secret_the_escape_table_hides_is_still_redacted(key: str) -> None:
+    """Every entry in the escape table, not only the two separators, is inverted for matching."""
+    location = f"/configuration/source/settings/{_escaped(key)}"
+
+    redacted = configs_service.redact_pointer(location, [key])
+
+    assert redacted != location
+    assert _escaped(key) not in redacted
+    assert redacted.startswith("/configuration/source/settings/***")
+    assert _accepts(redacted)
+
+
+# A finding *message* quotes the same declared key the pointer does, and quotes it escaped. Two
+# producers write it, in two different encodings, so the property below is asserted against the
+# forms spelled out here rather than against either producer's output.
+_MESSAGE_PRODUCER_CODES = frozenset({"undeclared-setting", "credential-path-not-declared"})
+
+
+def _tree_forms(key: str) -> tuple[str, ...]:
+    """Every form the core can write one declared key as, derived independently of redaction.
+
+    The declared key itself; the escaped pointer component ``_bounded_location`` embeds; and
+    that escaped text run through ``json.dumps`` the way ``_render_setting_name_list`` runs it,
+    which doubles every backslash. Built here from the core's own escaping function and the
+    standard library, so weakening the redaction side cannot weaken what is asserted.
+    """
+    escaped = safe_pointer_component(key)
+    return (key, escaped, json.dumps(escaped, ensure_ascii=True)[1:-1])
+
+
+def _findings_for_declared_key(key: str) -> tuple[ValidationFinding, ...]:
+    """Return the real findings a package declaring `key` as a setting name produces.
+
+    Two, and deliberately two, because they are the two message producers: an undeclared
+    setting, whose message renders the escaped name through ``json.dumps``; and a
+    ``$credential`` node nested under an allowed setting, whose message embeds the escaped
+    pointer directly.
+    """
+    data = package_data()
+    settings = data["configuration"]["source"]["settings"]
+    settings[key] = 1
+    settings["verify_ssl"] = {key: {"$credential": "netbox-token"}}
+    return collect_findings(package(data))
+
+
+@pytest.mark.parametrize("key", _ESCAPED_SECRET_KEYS)
+def test_a_secret_the_escape_table_hides_is_redacted_from_the_message_too(key: str) -> None:
+    """No collected value survives in a finding's message in any form the core writes it as.
+
+    The pointer is matched escape-aware and the message was not, so the same declared key the
+    pointer hardening exists for walked through the message on the same output line — and a
+    message reaches CLI stdout, the abort log, ``ConfigsError.message`` and every returned
+    finding. Asserted as the property over the whole escape table and both encodings, not as
+    the two shapes that were found.
+    """
+    findings = _findings_for_declared_key(key)
+
+    redacted = [configs_service.redact_finding(finding, [key]) for finding in findings]
+
+    # Not vacuous: both producers really ran, so neither encoding is missing from the sample.
+    assert {finding.code for finding in findings} == _MESSAGE_PRODUCER_CODES
+    for finding in redacted:
+        for form in _tree_forms(key):
+            assert form not in finding.message
+            assert form not in finding.location
+        assert ValidationFinding.model_validate(finding.model_dump()) == finding
+
+
+def test_the_two_validation_message_producers_each_write_a_different_encoding() -> None:
+    """The sample the property runs over really contains both encodings, spelled apart.
+
+    Guards the parametrised test above from passing because one producer stopped embedding the
+    key at all: the escaped form and the JSON-doubled form differ for a key holding a colon,
+    and each is present in exactly the message that produces it.
+
+    Two *validation* message producers, which is not the producer set. Nothing here bounds how
+    many renderers the core has; :func:`redact_message` records the two that are known to sit
+    outside what matching covers.
+    """
+    _, escaped, json_doubled = _tree_forms(_USERINFO_SHAPED_KEY)
+    messages = {finding.code: finding.message for finding in _findings_for_declared_key(_USERINFO_SHAPED_KEY)}
+
+    assert escaped != json_doubled
+    assert escaped in messages["credential-path-not-declared"]
+    assert json_doubled in messages["undeclared-setting"]
+
+
+def test_a_message_form_is_replaced_before_any_shorter_form_contained_in_it() -> None:
+    """The order the forms come back in is part of the mechanism, not a detail of the sort.
+
+    Two collected values can share a prefix — "user:password" and "user:passwor" both reach
+    ``_add_url_userinfo`` from two endpoint variables that differ by one character — and each
+    is written into a message in the same encodings. Replacing the shorter one first leaves the
+    tail of the longer one on the line, in every encoding at once, so the forms are returned
+    longest-first the way ``collect_secret_values`` returns the values themselves.
+    """
+    longer, shorter = "abc:def", "abc:de"
+    text = f'setting "{safe_pointer_component(longer)}" and {longer} is undeclared'
+
+    redacted = configs_service.redact_message(text, (longer, shorter))
+
+    # Not vacuous: the shorter value is a real collection target and a prefix of the longer one.
+    assert len(shorter) >= MIN_SECRET_LENGTH
+    assert longer.startswith(shorter)
+    assert redacted == f'setting "{REDACTED}" and {REDACTED} is undeclared'
+
+
+def test_the_shipped_collector_really_produces_the_value_the_property_uses() -> None:
+    """The six-character userinfo value is one the runtime collector emits, not a test fixture.
+
+    ``_add_url_userinfo`` is name-blind, so an endpoint variable carrying userinfo is where this
+    shape comes from, and it clears ``MIN_SECRET_LENGTH`` — the property is therefore about a
+    value that reaches redaction in a real run.
+    """
+    collected = collect_secret_values(environ={"NETBOX_ADDRESS": f"https://{_USERINFO_SHAPED_KEY}@netbox.test/api"})
+
+    assert _USERINFO_SHAPED_KEY in collected
+
+
+# Below the collector's floor, so ``collect_secret_values`` would never hand this to redaction.
+# It is used to show what the message text carries, which is what makes the property above a
+# real exposure rather than an artifact of a value chosen to be long enough.
+_SUB_FLOOR_KEY = "a:b"
+
+
+def test_a_finding_message_carries_the_declared_key_it_quotes() -> None:
+    """The message genuinely embeds caller content, escaped — the property is not about nothing.
+
+    A sub-floor value proves the channel: unredacted, both producers carry the declared key in
+    the encoding each writes, and redaction removes it when it is supplied. Length is the
+    collector's rule, not this mechanism's.
+    """
+    findings = _findings_for_declared_key(_SUB_FLOOR_KEY)
+    _, escaped, json_doubled = _tree_forms(_SUB_FLOOR_KEY)
+    messages = {finding.code: finding.message for finding in findings}
+
+    assert len(_SUB_FLOOR_KEY) < MIN_SECRET_LENGTH
+    assert _SUB_FLOOR_KEY not in collect_secret_values(environ={"NETBOX_ADDRESS": f"https://{_SUB_FLOOR_KEY}@h/api"})
+    assert escaped in messages["credential-path-not-declared"]
+    assert json_doubled in messages["undeclared-setting"]
+    for finding in findings:
+        redacted = configs_service.redact_finding(finding, [_SUB_FLOOR_KEY])
+        for form in _tree_forms(_SUB_FLOOR_KEY):
+            assert form not in redacted.message
+
+
+# The three keys that separate a correct inversion from a plausible one. Each is written the
+# way a declared key would be, and each escapes into text an incorrect decoder mis-reads.
+_HOSTILE_KEYS = (
+    pytest.param("a\\b", id="a-literal-backslash"),
+    pytest.param("a\\u003ab", id="a-colon-written-as-six-characters"),
+    pytest.param("a\x01b", id="a-control-character"),
+)
+
+
+@pytest.mark.parametrize("key", _HOSTILE_KEYS)
+def test_a_hostile_key_survives_reassembly_byte_for_byte(key: str) -> None:
+    """Re-encoding restores exactly what was decoded, for the keys full inversion could break.
+
+    A literal backslash escapes to "\\\\", the six characters "\\u003a" escape to "\\\\u003a", and a
+    control character escapes to "\\u0001" — three different readings of one leading backslash.
+    A decoder that inverts the table without also parsing the "\\uXXXX" form conflates them, and
+    the component comes back changed. Redacting the *neighbouring* component is what forces the
+    reassembly path; a pointer with nothing replaced is returned without being rebuilt at all.
+    """
+    location = f"/configuration/source/settings/{_escaped(key)}/nb1"
+
+    redacted = configs_service.redact_pointer(location, ["nb1"])
+
+    assert redacted.startswith(f"/configuration/source/settings/{_escaped(key)}/***")
+    assert _accepts(redacted)
+
+
+@pytest.mark.parametrize("key", _HOSTILE_KEYS)
+def test_a_hostile_key_is_matched_as_the_key_and_not_as_its_escaped_text(key: str) -> None:
+    """The decoded component is the declared key itself, so a secret equal to it is caught."""
+    location = f"/configuration/source/settings/{_escaped(key)}"
+
+    redacted = configs_service.redact_pointer(location, [key])
+
+    assert redacted.startswith("/configuration/source/settings/***")
+    assert _accepts(redacted)
+
+
+# The truncation marker as the core writes it — six characters, because U+2026 is printable
+# and ``safe_pointer_component`` therefore never produces this form from a declared key.
+_TRUNCATION_MARKER_ESCAPE = "\\u2026"
+_TRUNCATION_MARKER_CHARACTER = "\u2026"
+
+
+def _two_truncated_pointers() -> tuple[ValidationFinding, ValidationFinding]:
+    """Two findings whose declared keys differ only past the 64-character component bound."""
+    data = package_data()
+    shared = "k" * 70
+    data["configuration"]["source"]["settings"][f"{shared}a"] = 1
+    data["configuration"]["source"]["settings"][f"{shared}b"] = 1
+    first, second = collect_findings(package(data))
+    return first, second
+
+
+def test_a_truncated_pointer_that_is_then_redacted_stays_distinguishable() -> None:
+    """Redaction digests a pointer truncation has already cut, and distinctness still composes.
+
+    The concern is that the redaction digest is taken over text that has itself lost
+    information, so two pointers separated only by what truncation dropped could collapse.
+    They cannot: truncation closed that gap where it was opened, by writing a digest of the
+    *untruncated* pointer into the text it hands on. Redaction's input is therefore already
+    distinct, and the surviving truncation digest is what keeps the two apart even before
+    redaction appends a tag of its own.
+    """
+    findings = _two_truncated_pointers()
+    redacted = [configs_service.redact_pointer(finding.location, ["kkk"]) for finding in findings]
+
+    assert findings[0].location != findings[1].location
+    assert redacted[0] != redacted[1]
+    # Not the redaction tag doing the work: drop it and the two are still different, because
+    # the digest truncation wrote survives the redaction pass.
+    assert redacted[0].rsplit(REDACTED, 1)[0] != redacted[1].rsplit(REDACTED, 1)[0]
+    assert all("kkk" not in location for location in redacted)
+    assert all(len(location) <= _POINTER_BOUND and _accepts(location) for location in redacted)
+    # A redacted pointer is rebuilt through the one escaping function the core writes pointers
+    # with, and U+2026 is printable, so the truncation marker comes back as the character
+    # itself rather than as the six characters the core writes. It marks the same cut and is
+    # still single-line displayable; only its spelling differs once a pointer is rebuilt.
+    assert all(_TRUNCATION_MARKER_ESCAPE in finding.location for finding in findings)
+    assert all(_TRUNCATION_MARKER_ESCAPE not in location for location in redacted)
+    assert all(_TRUNCATION_MARKER_CHARACTER in location for location in redacted)
+
+
+def test_an_untouched_component_survives_redaction_of_its_neighbour_byte_for_byte() -> None:
+    """Decoding and re-encoding is exact, so reassembly does not rewrite a component it kept.
+
+    The key holds a literal "~" followed by a literal "1" and a literal "/" — the pair that
+    decodes wrong if "~0" is decoded before "~1", and encodes wrong if "/" is encoded before
+    "~". A redaction elsewhere in the pointer forces the reassembly path, which the unchanged
+    pointer returned by a no-op pass would otherwise never exercise.
+    """
+    collected = "alpha1"
+    location = f"/configuration/source/settings/{_escaped('a~1b/c')}/{collected}"
+
+    redacted = configs_service.redact_pointer(location, [collected])
+
+    assert redacted.startswith("/configuration/source/settings/a~01b~1c/***")
+    assert _accepts(redacted)

--- a/tests/product_store/test_configs_service.py
+++ b/tests/product_store/test_configs_service.py
@@ -11,7 +11,9 @@ import inspect
 import json
 import sqlite3
 import sys
+from collections.abc import Iterator, Mapping
 from datetime import datetime, timezone
+from decimal import Decimal
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1402,8 +1404,124 @@ def test_a_hostile_declared_content_override_cannot_reach_the_store(tmp_path: Pa
 
 
 def test_a_non_mapping_package_is_the_callers_input_not_an_internal_error(tmp_path: Path) -> None:
-    with pytest.raises(configs_service.ConfigsRequestError, match="package must be Mapping"):
+    with pytest.raises(configs_service.ConfigsRequestError, match="package must be a JSON-native dict"):
         configs_service.register(package=_WRONG_TYPED_VALUE, product_cache_location=_store(tmp_path))
+
+
+# --- Property closure P1: the write boundary accepts exactly JSON-native data -----------
+
+
+class _MappingSubclassPackage(Mapping):
+    """A well-behaved ``Mapping`` that is not an exact ``dict``: outside the domain."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+class _DictSubclassPackage(dict):  # noqa: FURB189 - the exact-dict boundary is the subject
+    """An exact-shape ``dict`` subclass: every protocol hook is overridable behavior."""
+
+
+class _RaisingClassPackage:
+    """A hostile argument whose ``__class__`` raises the moment anything consults it."""
+
+    @property
+    def __class__(self) -> type:
+        msg = "__class__ was consulted"
+        raise RuntimeError(msg)
+
+
+class _ProtocolRecordingPackage:
+    """Records every protocol consultation acceptance could make on the untrusted value."""
+
+    def __init__(self) -> None:
+        self.consulted: list[str] = []
+
+    @property
+    def __class__(self) -> type:
+        self.consulted.append("__class__")
+        return _ProtocolRecordingPackage
+
+    def keys(self) -> Iterator[object]:
+        self.consulted.append("keys")
+        return iter(())
+
+    def items(self) -> Iterator[object]:
+        self.consulted.append("items")
+        return iter(())
+
+    def __getitem__(self, key: object) -> object:
+        self.consulted.append("__getitem__")
+        raise KeyError(key)
+
+    def __iter__(self) -> Iterator[object]:
+        self.consulted.append("__iter__")
+        return iter(())
+
+    def __len__(self) -> int:
+        self.consulted.append("__len__")
+        return 0
+
+    def __contains__(self, key: object) -> bool:
+        self.consulted.append("__contains__")
+        return False
+
+
+def _package_with_leaf(leaf: object) -> dict[str, Any]:
+    data = package_data()
+    data["configuration"]["source"]["settings"]["marker"] = leaf
+    return data
+
+
+def _non_json_native_packages() -> tuple[tuple[str, object], ...]:
+    return (
+        ("mapping-subclass", _MappingSubclassPackage(package_data())),
+        ("dict-subclass", _DictSubclassPackage(package_data())),
+        ("raising-class", _RaisingClassPackage()),
+        ("nested-set", _package_with_leaf({"a"})),
+        ("nested-decimal", _package_with_leaf(Decimal(1))),
+        ("nested-object", _package_with_leaf(object())),
+    )
+
+
+@pytest.mark.parametrize("value", [pytest.param(value, id=name) for name, value in _non_json_native_packages()])
+def test_only_recursively_exact_json_data_enters_the_write_boundary(tmp_path: Path, value: object) -> None:
+    # The closed acceptance property: a package is either recursively exact JSON-native
+    # data — exact dict/list containers, exact str/int/float/bool/None leaves — or it is
+    # the caller's own input, refused request-class before any protocol operation runs.
+    location = _store(tmp_path)
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        configs_service.register(package=cast("Any", value), product_cache_location=location)
+
+    assert raised.value.family == "request"
+    assert _registered_configuration_count(tmp_path / "product-cache") == 0
+
+
+def test_an_exact_dict_package_is_the_accepted_domain(tmp_path: Path) -> None:
+    registered = configs_service.register(package=package_data(), product_cache_location=_store(tmp_path))
+
+    assert registered.version.registry_version == 1
+
+
+def test_a_refused_package_is_never_invoked(tmp_path: Path) -> None:
+    # Structural acceptance judges type(...) identity alone: the sentinel records every
+    # protocol hook acceptance could consult — __class__ included — and none may fire.
+    sentinel = _ProtocolRecordingPackage()
+
+    with pytest.raises(configs_service.ConfigsRequestError):
+        configs_service.register(package=cast("Any", sentinel), product_cache_location=_store(tmp_path))
+
+    assert sentinel.consulted == []
 
 
 # --- Pre-PR correction F4: the registry_version domain is exactly positive int ----------

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -1808,6 +1808,7 @@ _ALLOWED_STORE_CONFIGURATION_METHODS = frozenset(
         "add_configuration_version",
         "lookup_configuration",
         "lookup_configuration_version",
+        "list_configurations",
         "list_configuration_versions",
     }
 )
@@ -1817,6 +1818,7 @@ _ALLOWED_PROJECTION_CONFIGURATION_METHODS = frozenset(
         "add_configuration_version",
         "lookup_configuration",
         "lookup_configuration_version",
+        "list_configurations",
         "list_configuration_versions",
     }
 )
@@ -1908,6 +1910,40 @@ def test_configuration_registry_survives_store_reconstruction(profile: str, tmp_
     assert after_restart.lookup_configuration(first.config_id).available
     assert after_restart.list_configuration_versions(first.config_id) == (first, second)
     assert after_restart.lookup_configuration_version(first.config_id, 2) == product_store.LookupResult(value=second)
+
+
+def test_list_configurations_orders_by_created_at_then_config_id_on_both_profiles(
+    provider: ProductProjection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The configurations listing carries one total ORDER BY: ``created_at``, then ``config_id``.
+
+    ``created_at`` is server-generated, so on an append-only table insertion order equals
+    timestamp order and a missing ORDER BY would pass trivially. The generated IDs and the
+    clock are therefore pinned so two rows share one ``created_at`` (only the ``config_id``
+    tiebreak separates them) and the last-inserted row carries the earliest timestamp (only
+    ordering by ``created_at`` puts it first).
+    """
+    assert provider.list_configurations() == ()
+    registrations = (
+        ("config-b", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+        ("config-a", datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+        ("config-z", datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)),
+    )
+    ids = iter([config_id for config_id, _ in registrations])
+    clock = iter([created_at for _, created_at in registrations])
+    monkeypatch.setattr(product_store_store, "_generate_config_id", lambda: next(ids))
+    monkeypatch.setattr(product_store_store, "datetime", SimpleNamespace(now=lambda tz: next(clock)))  # noqa: ARG005
+    for _ in registrations:
+        provider.create_configuration(_configuration_package())
+
+    listed = provider.list_configurations()
+
+    assert listed == (
+        ConfigurationSummary(config_id="config-z", created_at=datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)),
+        ConfigurationSummary(config_id="config-a", created_at=datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+        ConfigurationSummary(config_id="config-b", created_at=datetime(2026, 8, 8, 12, 30, tzinfo=timezone.utc)),
+    )
+    assert provider.list_configurations() == listed
 
 
 def test_distinct_configurations_may_share_identical_package_content(provider: ProductProjection) -> None:

--- a/tests/product_store/test_validate_destination_schema.py
+++ b/tests/product_store/test_validate_destination_schema.py
@@ -1,0 +1,268 @@
+"""The ``validate`` operation's explicit destination-schema opt-in.
+
+The service contract this file pins: the default ``validate`` call is byte-identical to
+the pre-opt-in behavior — zero schema reads, zero network I/O, no adapter construction —
+and only an explicit :class:`DestinationSchemaOptions` request adds the schema checks and
+records the judged snapshot's fingerprint. Snapshots are injected through the capability
+seam; nothing here contacts a server.
+"""
+
+from __future__ import annotations
+
+import ast
+import socket
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub_sync.cache import compute_schema_subhash
+from infrahub_sync.configuration import schema_validation
+from infrahub_sync.configuration import validation as validation_module
+from infrahub_sync.configuration.capabilities import BUILTIN_ADAPTER_CAPABILITIES
+from infrahub_sync.configuration.schema_validation import DestinationSchemaOptions
+from infrahub_sync.configuration.validation import collect_findings
+from infrahub_sync.product_store import configs as configs_service
+from tests.configuration.validation_packages import package, package_data
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from infrahub_sync.configuration import ConfigurationPackage
+
+_SNAPSHOT: dict[str, Any] = {
+    "InfraDevice": {
+        "attributes": {"name": "Text"},
+        "relationships": {"site": {"peer": "LocationSite", "cardinality": "one"}},
+    },
+}
+
+
+class _SpiedAccessor:
+    """An injected accessor that records every read and returns a fixed snapshot."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(self, package_: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+        del package_
+        self.calls.append(branch)
+        return _SNAPSHOT
+
+
+def _inject_accessor(monkeypatch: pytest.MonkeyPatch) -> _SpiedAccessor:
+    accessor = _SpiedAccessor()
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["infrahub"] = replace(table["infrahub"], destination_schema_accessor=accessor)
+    monkeypatch.setattr(schema_validation, "BUILTIN_ADAPTER_CAPABILITIES", table)
+    return accessor
+
+
+def _registered(tmp_path: Path, data: dict[str, Any] | None = None) -> tuple[str, str]:
+    location = str(tmp_path / "product-cache")
+    Path(location).mkdir()
+    registered = configs_service.register(
+        package=package_data() if data is None else data,
+        product_cache_location=location,
+    )
+    return registered.version.config_id, location
+
+
+def _validate(config_id: str, location: str, **kwargs: Any) -> configs_service.ValidationReport:
+    return configs_service.validate(
+        config_id=config_id,
+        registry_version=1,
+        product_cache_location=location,
+        **kwargs,
+    )
+
+
+def _mapping_package_data(kind: str) -> dict[str, Any]:
+    data = package_data()
+    data["configuration"]["schema_mapping"] = [{"name": kind, "mapping": "dcim.devices"}]
+    return data
+
+
+# --- AR7: the default path is byte-identical — no schema read, no network, no adapter ---
+
+
+def test_a_default_validate_never_calls_the_accessor_and_carries_no_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    accessor = _inject_accessor(monkeypatch)
+    config_id, location = _registered(tmp_path)
+
+    report = _validate(config_id, location)
+
+    assert accessor.calls == []
+    assert report.destination_schema_fingerprint is None
+    assert report.findings == ()
+
+
+def test_a_default_validate_performs_no_network_io(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_id, location = _registered(tmp_path)
+
+    def _refuse(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        msg = "the default validate path opened a network socket"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(socket, "socket", _refuse)
+
+    report = _validate(config_id, location)
+
+    assert report.findings == ()
+
+
+def test_the_opt_in_performs_no_network_io_when_the_snapshot_is_injected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    accessor = _inject_accessor(monkeypatch)
+    config_id, location = _registered(tmp_path)
+
+    def _refuse(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        msg = "an injected schema read opened a network socket"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(socket, "socket", _refuse)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert accessor.calls == ["main"]
+    assert report.findings == ()
+
+
+_SERVICE_MODULES = (configs_service.__file__, schema_validation.__file__)
+
+
+def test_the_service_and_schema_modules_construct_no_adapters() -> None:
+    # The structural half of AR7: no adapter module is imported and no dynamic import
+    # mechanism is reachable from the validate path, so no source adapter can be constructed.
+    for module_path in _SERVICE_MODULES:
+        tree = ast.parse(Path(module_path).read_text(encoding="utf-8"))
+        imported = {
+            name.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for name in node.names
+        } | {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
+        called = {
+            node.func.id if isinstance(node.func, ast.Name) else node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
+        }
+
+        assert not {name for name in imported if name.startswith("infrahub_sync.adapters")}, module_path
+        assert not called & {"import_module", "__import__", "import_adapter"}, module_path
+
+
+# --- AR6: the fingerprint and determinism ----------------------------------------------
+
+
+def test_the_opt_in_records_the_snapshot_fingerprint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _inject_accessor(monkeypatch)
+    config_id, location = _registered(tmp_path)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert report.destination_schema_fingerprint == compute_schema_subhash(
+        package(package_data()).configuration, _SNAPSHOT
+    )
+
+
+def test_the_opt_in_report_is_identical_across_invocations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _inject_accessor(monkeypatch)
+    config_id, location = _registered(tmp_path, _mapping_package_data("NopeKind"))
+
+    first = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+    second = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert first.findings == second.findings
+    assert first.findings != ()
+    assert first.destination_schema_fingerprint == second.destination_schema_fingerprint
+
+
+# --- The merged report: core and schema findings under one sort contract ----------------
+
+
+def test_core_and_schema_findings_merge_in_the_stable_sort_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Capability drift after registration: the source adapter disappears from the table,
+    # so the core reports missing-adapter while the schema checks judge the snapshot.
+    accessor = _SpiedAccessor()
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["infrahub"] = replace(table["infrahub"], destination_schema_accessor=accessor)
+    del table["netbox"]
+    data = _mapping_package_data("NopeKind")
+    config_id, location = _registered(tmp_path, data)
+    monkeypatch.setattr(schema_validation, "BUILTIN_ADAPTER_CAPABILITIES", table)
+    monkeypatch.setattr(validation_module, "BUILTIN_ADAPTER_CAPABILITIES", table)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("destination-schema-mismatch", "/configuration/schema_mapping/0/name"),
+        ("missing-adapter", "/configuration/source"),
+    ]
+    # The non-schema portion is exactly what the core reports for the same stored bytes.
+    core = [finding for finding in report.findings if finding.code == "missing-adapter"]
+    assert tuple(core) == collect_findings(package(data))
+
+
+# --- AR9 at the boundary: a failed read is a finding, never a service refusal -----------
+
+
+def test_a_failed_schema_read_returns_a_report_rather_than_a_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from infrahub_sync.configuration.capabilities import DestinationSchemaReadError
+
+    def _raising(package_: ConfigurationPackage, branch: str) -> Mapping[str, Any]:
+        del package_
+        msg = f"schema read failed for branch {branch!r}"
+        raise DestinationSchemaReadError(msg, reason="unreachable")
+
+    table = dict(BUILTIN_ADAPTER_CAPABILITIES)
+    table["infrahub"] = replace(table["infrahub"], destination_schema_accessor=_raising)
+    monkeypatch.setattr(schema_validation, "BUILTIN_ADAPTER_CAPABILITIES", table)
+    config_id, location = _registered(tmp_path)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("destination-schema-read-failed", "/configuration/destination")
+    ]
+    assert report.destination_schema_fingerprint is None
+
+
+# --- The opt-in argument itself ---------------------------------------------------------
+
+
+def test_a_wrong_typed_opt_in_is_a_request_refusal(tmp_path: Path) -> None:
+    config_id, location = _registered(tmp_path)
+
+    with pytest.raises(configs_service.ConfigsRequestError) as raised:
+        _validate(config_id, location, destination_schema=True)
+
+    assert raised.value.family == "request"
+
+
+def test_the_opt_in_against_a_non_declaring_destination_reports_both_gate_findings(
+    tmp_path: Path,
+) -> None:
+    data = package_data()
+    data["configuration"]["destination"]["name"] = "peeringmanager"
+    config_id, location = _registered(tmp_path, data)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("destination-schema-validation-unsupported", "/configuration/destination"),
+        ("unsupported-destination-write", "/configuration/destination"),
+    ]
+    assert report.destination_schema_fingerprint is None

--- a/tests/product_store/test_validate_destination_schema.py
+++ b/tests/product_store/test_validate_destination_schema.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 import socket
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -27,7 +28,7 @@ from infrahub_sync.product_store import configs as configs_service
 from tests.configuration.validation_packages import package, package_data
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import ItemsView, Iterator
 
     from infrahub_sync.configuration import ConfigurationPackage
 
@@ -266,3 +267,110 @@ def test_the_opt_in_against_a_non_declaring_destination_reports_both_gate_findin
         ("unsupported-destination-write", "/configuration/destination"),
     ]
     assert report.destination_schema_fingerprint is None
+
+
+# --- Reduction round: normalization reads nothing from a hostile schema response --------
+
+
+class _ReturningSchemaEndpoint:
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def all(self, branch: str) -> object:
+        del branch
+        return self._response
+
+
+class _ReturningClient:
+    def __init__(self, response: object) -> None:
+        self.schema = _ReturningSchemaEndpoint(response)
+
+
+def _mock_live_schema_read(monkeypatch: pytest.MonkeyPatch, response: object) -> None:
+    """Route the real bundled accessor's client call to a canned hostile response.
+
+    No table injection: the built-in ``infrahub`` declaration already carries the real
+    accessor, so the whole normalization boundary runs under public ``validate()``.
+    """
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "test-token")
+
+    def _fake_client(address: str, config: object) -> _ReturningClient:
+        del address, config
+        return _ReturningClient(response)
+
+    monkeypatch.setattr("infrahub_sdk.InfrahubClientSync", _fake_client)
+
+
+def test_a_metaclass_raising_response_exception_lands_as_a_rejected_finding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Inspection is invocation, one level up: the normalization handler formatted
+    # type(exc).__name__, and a metaclass executes on that read — the probe escaped
+    # public validate() as ConfigsInternalError with the read recorded. The boundary
+    # now reads nothing from the exception: one fixed message, reason "rejected".
+    reads: list[str] = []
+
+    class _ExecutingMeta(type):
+        @property
+        def __name__(cls) -> str:  # noqa: PLW3201 - shadowing type's own descriptor is the fixture
+            reads.append("__name__")
+            msg = "metaclass executed on __name__ read"
+            raise RuntimeError(msg)
+
+    class _HostileError(Exception, metaclass=_ExecutingMeta):
+        """An ordinary exception whose class name read is executable behavior."""
+
+    class _RaisingItems(Mapping):
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+        def __iter__(self) -> Iterator[str]:
+            return iter(())
+
+        def __len__(self) -> int:
+            return 0
+
+        def items(self) -> ItemsView[str, object]:  # noqa: PLR6301 - protocol hook, self unused by design
+            msg = "items() exploded: third-party secret text"
+            raise _HostileError(msg)
+
+    _mock_live_schema_read(monkeypatch, _RaisingItems())
+    config_id, location = _registered(tmp_path)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("destination-schema-read-failed", "/configuration/destination")
+    ]
+    assert "rejected" in report.findings[0].message
+    assert "third-party secret text" not in report.findings[0].message
+    assert reads == []
+
+
+def test_a_response_cannot_forge_its_own_schema_read_reason(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A DestinationSchemaReadError raised by the response's own property used to pass
+    # through normalization untouched, so a hostile response forged its own reason
+    # ("unauthorized") into the finding an operator reads. Normalization now rewraps
+    # every exception into one new fixed error with reason "rejected".
+    from infrahub_sync.configuration.capabilities import DestinationSchemaReadError
+
+    class _ForgingNode:
+        relationships: tuple[object, ...] = ()
+
+        @property
+        def attributes(self) -> tuple[object, ...]:
+            msg = "destination refused the schema read credentials: forged"
+            raise DestinationSchemaReadError(msg, reason="unauthorized")
+
+    _mock_live_schema_read(monkeypatch, {"InfraDevice": _ForgingNode()})
+    config_id, location = _registered(tmp_path)
+
+    report = _validate(config_id, location, destination_schema=DestinationSchemaOptions())
+
+    assert [(finding.code, finding.location) for finding in report.findings] == [
+        ("destination-schema-read-failed", "/configuration/destination")
+    ]
+    message = report.findings[0].message
+    assert "rejected" in message
+    assert "unauthorized" not in message
+    assert "forged" not in message

--- a/tests/product_store/test_validate_destination_schema.py
+++ b/tests/product_store/test_validate_destination_schema.py
@@ -13,7 +13,7 @@ import ast
 import socket
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -69,12 +69,16 @@ def _registered(tmp_path: Path, data: dict[str, Any] | None = None) -> tuple[str
     return registered.version.config_id, location
 
 
-def _validate(config_id: str, location: str, **kwargs: Any) -> configs_service.ValidationReport:
+def _validate(
+    config_id: str,
+    location: str,
+    destination_schema: DestinationSchemaOptions | None = None,
+) -> configs_service.ValidationReport:
     return configs_service.validate(
         config_id=config_id,
         registry_version=1,
         product_cache_location=location,
-        **kwargs,
+        destination_schema=destination_schema,
     )
 
 
@@ -142,12 +146,9 @@ def test_the_service_and_schema_modules_construct_no_adapters() -> None:
     # mechanism is reachable from the validate path, so no source adapter can be constructed.
     for module_path in _SERVICE_MODULES:
         tree = ast.parse(Path(module_path).read_text(encoding="utf-8"))
-        imported = {
-            name.name
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Import)
-            for name in node.names
-        } | {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
+        imported = {name.name for node in ast.walk(tree) if isinstance(node, ast.Import) for name in node.names} | {
+            node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module
+        }
         called = {
             node.func.id if isinstance(node.func, ast.Name) else node.func.attr
             for node in ast.walk(tree)
@@ -172,9 +173,7 @@ def test_the_opt_in_records_the_snapshot_fingerprint(tmp_path: Path, monkeypatch
     )
 
 
-def test_the_opt_in_report_is_identical_across_invocations(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_the_opt_in_report_is_identical_across_invocations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _inject_accessor(monkeypatch)
     config_id, location = _registered(tmp_path, _mapping_package_data("NopeKind"))
 
@@ -246,8 +245,9 @@ def test_a_failed_schema_read_returns_a_report_rather_than_a_refusal(
 def test_a_wrong_typed_opt_in_is_a_request_refusal(tmp_path: Path) -> None:
     config_id, location = _registered(tmp_path)
 
+    wrong_typed = cast("DestinationSchemaOptions", True)  # noqa: FBT003 - the wrong type is the fixture
     with pytest.raises(configs_service.ConfigsRequestError) as raised:
-        _validate(config_id, location, destination_schema=True)
+        _validate(config_id, location, destination_schema=wrong_typed)
 
     assert raised.value.family == "request"
 

--- a/tests/test_effective_diffsync_flags.py
+++ b/tests/test_effective_diffsync_flags.py
@@ -14,7 +14,12 @@ import pytest
 from diffsync import Adapter, DiffSyncModel
 from diffsync.enum import DiffSyncFlags
 
-from infrahub_sync import SyncAdapter, SyncInstance, resolve_effective_diffsync_flags
+from infrahub_sync import (
+    SyncAdapter,
+    SyncInstance,
+    requested_destination_write_operations,
+    resolve_effective_diffsync_flags,
+)
 from infrahub_sync.potenda import Potenda
 
 _DST = DiffSyncFlags.SKIP_UNMATCHED_DST
@@ -184,3 +189,41 @@ def test_post_sync_destination_view_is_complete() -> None:
     engine, destination = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC"])
     engine.sync()
     assert [widget.get_unique_id() for widget in destination.get_all("widget")] == ["stale"]
+
+
+# --- The operations-level sibling: requested destination write operations (AR5) ---
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        # The supported live-sync default: matched objects update, source-only objects create.
+        pytest.param(None, frozenset({"create", "update"}), id="none"),
+        pytest.param([], frozenset({"create", "update"}), id="empty"),
+        pytest.param(["SKIP_UNMATCHED_DST"], frozenset({"create", "update"}), id="dst-only"),
+        # AR5 discriminating fixture: a nonzero flag set lacking SKIP_UNMATCHED_DST does not
+        # yield delete as a requested operation (SYNC-78's settled deletion rule).
+        pytest.param(["SKIP_UNMATCHED_SRC"], frozenset({"update"}), id="src-only"),
+        pytest.param(["CONTINUE_ON_FAILURE"], frozenset({"create", "update"}), id="continue-only"),
+        pytest.param(["SKIP_UNMATCHED_SRC", "SKIP_UNMATCHED_DST"], frozenset({"update"}), id="src-and-dst"),
+        pytest.param([DiffSyncFlags.CONTINUE_ON_FAILURE], frozenset({"create", "update"}), id="enum-member"),
+    ],
+)
+def test_requested_destination_write_operations(
+    configured: list[str | DiffSyncFlags] | None, expected: frozenset[str]
+) -> None:
+    assert requested_destination_write_operations(configured) == expected
+
+
+def test_requested_operations_never_include_delete_for_any_single_named_flag() -> None:
+    # The invariant restated at the operations level: no configured flag shape under the
+    # supported live-sync profile turns a destination-only object into a delete request.
+    for flag in DiffSyncFlags:
+        configured = None if flag == DiffSyncFlags.NONE else [flag]
+        assert "delete" not in requested_destination_write_operations(configured), flag
+
+
+def test_requested_operations_unknown_flag_name_raises_key_error() -> None:
+    # Same failure mode as the flags-level rule it consumes.
+    with pytest.raises(KeyError):
+        requested_destination_write_operations(["NOT_A_FLAG"])

--- a/tests/test_effective_diffsync_flags.py
+++ b/tests/test_effective_diffsync_flags.py
@@ -1,0 +1,186 @@
+"""Effective DiffSync flag resolution — the SYNC-78 deletion-safety rule.
+
+Under the supported live-sync profile, ``SKIP_UNMATCHED_DST`` is invariant: a
+destination-only object is never turned into a delete action, no matter which
+unrelated flags a configuration declares. These tests pin the engine behavior
+(Potenda) and the one centralized rule the engine consumes.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+from diffsync import Adapter, DiffSyncModel
+from diffsync.enum import DiffSyncFlags
+
+from infrahub_sync import SyncAdapter, SyncInstance, resolve_effective_diffsync_flags
+from infrahub_sync.potenda import Potenda
+
+_DST = DiffSyncFlags.SKIP_UNMATCHED_DST
+
+
+# --- The one centralized flag-aggregation rule (SYNC-78) ---------------------
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        # Preservation: no-flags default resolves byte-identically to today.
+        pytest.param(None, _DST, id="none"),
+        pytest.param([], _DST, id="empty"),
+        # Preservation: explicit sets that include SKIP_UNMATCHED_DST.
+        pytest.param(["SKIP_UNMATCHED_DST"], _DST, id="dst-only"),
+        pytest.param(
+            ["SKIP_UNMATCHED_SRC", "SKIP_UNMATCHED_DST"],
+            DiffSyncFlags.SKIP_UNMATCHED_SRC | _DST,
+            id="src-and-dst",
+        ),
+        pytest.param(
+            [DiffSyncFlags.CONTINUE_ON_FAILURE, DiffSyncFlags.SKIP_UNMATCHED_DST],
+            DiffSyncFlags.CONTINUE_ON_FAILURE | _DST,
+            id="continue-and-dst-enum",
+        ),
+        # Defect closure: every unrelated nonzero flag, alone and combined,
+        # keeps the SKIP_UNMATCHED_DST invariant instead of replacing it.
+        pytest.param(["SKIP_UNMATCHED_SRC"], DiffSyncFlags.SKIP_UNMATCHED_SRC | _DST, id="src-only"),
+        pytest.param(["CONTINUE_ON_FAILURE"], DiffSyncFlags.CONTINUE_ON_FAILURE | _DST, id="continue-only"),
+        pytest.param(["LOG_UNCHANGED_RECORDS"], DiffSyncFlags.LOG_UNCHANGED_RECORDS | _DST, id="log-only"),
+        pytest.param(
+            ["SKIP_UNMATCHED_SRC", "CONTINUE_ON_FAILURE"],
+            DiffSyncFlags.SKIP_UNMATCHED_SRC | DiffSyncFlags.CONTINUE_ON_FAILURE | _DST,
+            id="src-and-continue",
+        ),
+    ],
+)
+def test_rule_resolution(configured: list[str | DiffSyncFlags] | None, expected: DiffSyncFlags) -> None:
+    assert resolve_effective_diffsync_flags(configured) == expected
+
+
+def test_rule_invariant_holds_for_every_single_named_flag() -> None:
+    for flag in DiffSyncFlags:
+        if flag == DiffSyncFlags.NONE:
+            continue
+        assert resolve_effective_diffsync_flags([flag]) & _DST, flag
+
+
+def test_rule_unknown_flag_name_raises_key_error() -> None:
+    # Same failure mode as the engine's previous inline coercion.
+    with pytest.raises(KeyError):
+        resolve_effective_diffsync_flags(["NOT_A_FLAG"])
+
+
+# --- Engine fixtures ----------------------------------------------------------
+
+
+def _instance(flags: list[str | DiffSyncFlags] | None) -> SyncInstance | None:
+    """Build a SyncInstance declaring `flags`; `None` means no configuration at all."""
+    if flags is None:
+        return None
+    return SyncInstance(
+        name="flags-under-test",
+        source=SyncAdapter(name="source"),
+        destination=SyncAdapter(name="destination"),
+        diffsync_flags=flags,
+        directory=".",
+    )
+
+
+class _Widget(DiffSyncModel):
+    """Minimal identifier-only model for in-memory sync fixtures."""
+
+    _modelname = "widget"
+    _identifiers = ("name",)
+    _attributes = ()
+
+    name: str
+
+
+class _SpiedWidget(_Widget):
+    """Destination model whose custom ``delete`` records every invocation."""
+
+    delete_calls: ClassVar[list[str]] = []
+
+    def delete(self) -> _SpiedWidget | None:
+        type(self).delete_calls.append(self.name)
+        return super().delete()
+
+
+class _SourceAdapter(Adapter):
+    widget = _Widget
+    top_level: ClassVar[list[str]] = ["widget"]
+
+
+class _DestinationAdapter(Adapter):
+    widget = _SpiedWidget
+    top_level: ClassVar[list[str]] = ["widget"]
+
+
+def _engine_with_destination_only_object(
+    flags: list[str | DiffSyncFlags] | None,
+) -> tuple[Potenda, _DestinationAdapter]:
+    """Build a Potenda over one empty source and one destination-only widget."""
+    _SpiedWidget.delete_calls.clear()
+    source = _SourceAdapter(name="source")
+    destination = _DestinationAdapter(name="destination")
+    destination.add(_SpiedWidget(name="stale"))
+    engine = Potenda(
+        source=source,
+        destination=destination,
+        config=_instance(flags),  # ty: ignore[invalid-argument-type]  # engine guards config=None
+        top_level=["widget"],
+        show_progress=False,
+    )
+    return engine, destination
+
+
+# --- Potenda resolves configured flags through the shared SYNC-78 rule --------
+
+
+def test_engine_no_config_defaults_to_skip_unmatched_dst() -> None:
+    # Preservation guard (green before the fix): no-flags default unchanged.
+    engine, _ = _engine_with_destination_only_object(None)
+    assert engine.flags == DiffSyncFlags.SKIP_UNMATCHED_DST
+
+
+def test_engine_empty_flag_list_defaults_to_skip_unmatched_dst() -> None:
+    # Preservation guard (green before the fix).
+    engine, _ = _engine_with_destination_only_object([])
+    assert engine.flags == DiffSyncFlags.SKIP_UNMATCHED_DST
+
+
+def test_engine_explicit_set_including_skip_unmatched_dst_is_unchanged() -> None:
+    # Preservation guard (green before the fix): explicit sets that already
+    # carry SKIP_UNMATCHED_DST resolve byte-identically to the old rule.
+    engine, _ = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC", "SKIP_UNMATCHED_DST"])
+    assert engine.flags == DiffSyncFlags.SKIP_UNMATCHED_SRC | DiffSyncFlags.SKIP_UNMATCHED_DST
+
+
+def test_engine_nonzero_set_lacking_skip_unmatched_dst_keeps_the_invariant() -> None:
+    # SYNC-78 defect: a nonzero flag set lacking SKIP_UNMATCHED_DST used to
+    # replace the safe default entirely, silently enabling delete actions.
+    engine, _ = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC"])
+    assert engine.flags == DiffSyncFlags.SKIP_UNMATCHED_SRC | DiffSyncFlags.SKIP_UNMATCHED_DST
+
+
+# --- SYNC-78 reproduction row 2: SKIP_UNMATCHED_SRC alone must not delete -----
+
+
+def test_diff_requests_no_delete_for_destination_only_object() -> None:
+    engine, _ = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC"])
+    diff = engine.diff()
+    assert not diff.has_diffs()
+
+
+def test_custom_delete_implementation_is_never_invoked() -> None:
+    engine, _ = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC"])
+    engine.sync()
+    assert _SpiedWidget.delete_calls == []
+
+
+def test_post_sync_destination_view_is_complete() -> None:
+    # The post-sync snapshot is written from the in-memory destination
+    # store; the destination-only object must survive the sync.
+    engine, destination = _engine_with_destination_only_object(["SKIP_UNMATCHED_SRC"])
+    engine.sync()
+    assert [widget.get_unique_id() for widget in destination.get_all("widget")] == ["stale"]


### PR DESCRIPTION
Move configuration registry and validation behavior behind one application service so the service-first V3 stack has one implementation for registration, reads, and validation. Later HTTP, CLI, and Python clients can use that service without publishing the superseded embedded `configs` surface.

The branch also closes the V3 effective-operation safety rule, adds opt-in destination-schema validation, and adds the warning channel for intentional omissions and unqualified optional features.

## Before and after

Before, callers had validation fragments and product-store operations without one owning service boundary:

```python
package = parse_configuration_package(content)
# callers coordinated validation and persistence themselves
```

After, one service owns the operation and its typed outcome:

```python
report = configs.validate(
    config_id=config_id,
    registry_version=registry_version,
    product_cache_location=cache_root,
    destination_schema=options,
)
```

## Key changes

- Add one configuration application service for registration, immutable versioning, validation, and typed failures.
- Add deterministic registry reads: list configurations, get one configuration, list its versions, and retrieve one exact version.
- Keep `SKIP_UNMATCHED_DST` invariant when effective DiffSync flags are resolved, preventing declared flags from implicitly enabling destination deletes.
- Add destination-schema checks behind an explicit opt-in; the default validation path performs no schema read or network request.
- Add error/warning severity, declared `omissions:`, incremental-qualification warnings, deterministic ordering, and closed finding-code documentation.
- Keep the embedded `configs` CLI and Python API unpublished; service-boundary will expose the HTTP contract in the next parent unit.

## Related context

- [configuration-service acceptance packet](https://github.com/opsmill/infrahub-sync-lab/blob/main/.planning/active-path/configuration-foundation/cf-004-acceptance-packet.md)

## User-visible changes

- The durable product-records reference now documents the configuration registry and every shipped validation finding code.
- No new CLI command or public configuration client ships in this PR.

## Validation

- `uv run invoke lint` — exit 0; four pre-existing unused-ignore warnings, zero errors
- `uv run pytest -q` — 2,562 passed, 24 skipped, 1 xfailed
- `uv run infrahub-sync --help` — exit 0; no `configs` group
- `uv run infrahub-sync list --directory examples/` — exit 0
- `uv run infrahub-sync generate --name from-netbox --directory examples/` — reaches the documented no-server `ServerNotReachableError` with no local Infrahub running

## Known limitations

- PostgreSQL provider SQL is asserted through the SQLite emulator in CI; the real-PostgreSQL gap remains tracked separately.
- Live destination-schema reads remain opt-in integration coverage and skip without an environment.
- The documented redaction limitations remain unchanged; this PR adds no new matching forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration registry for registering, versioning, listing, retrieving, and validating product configurations.
  * Added comprehensive validation reports with stable finding codes, locations, severities, warnings, and capped output.
  * Added optional destination-schema validation with schema fingerprints and actionable mismatch findings.
  * Added support for intentional omissions and incremental-extraction capability checks.
  * Added deterministic configuration listing and safer product-cache path handling.

* **Bug Fixes**
  * Prevented destination-only records from being deleted during supported synchronization.
  * Improved credential and sensitive-value redaction in API and CLI errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->