### PR TITLE
feat: expose configuration service over HTTP

### DIFF
--- a/dev/knowledge/configuration-route-boundary.md
+++ b/dev/knowledge/configuration-route-boundary.md
@@ -1,9 +1,0 @@
-# Configuration route boundary
-
-The configuration-route change set was reviewed against `b52485a`.
-
-It adds only managed configuration registration, immutable-version reads and validation,
-their request grammar, pagination, idempotency receipts, and secret-safe audit evidence.
-It does not add a CLI or Python client, server-version endpoint, client-version-range
-refusal, Prefect parameter, worker resolver, storage-profile selection, or a new redaction
-form.

--- a/dev/knowledge/configuration-route-boundary.md
+++ b/dev/knowledge/configuration-route-boundary.md
@@ -1,0 +1,9 @@
+# Configuration route boundary
+
+The configuration-route change set was reviewed against `b52485a`.
+
+It adds only managed configuration registration, immutable-version reads and validation,
+their request grammar, pagination, idempotency receipts, and secret-safe audit evidence.
+It does not add a CLI or Python client, server-version endpoint, client-version-range
+refusal, Prefect parameter, worker resolver, storage-profile selection, or a new redaction
+form.

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -10,11 +10,13 @@ from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .auth import Principal, PrincipalResolver
-from .config_routes import ConfigurationRoutes, configuration_router
+from .config_routes import ConfigurationAPIError, ConfigurationRoutes, configuration_router
 from .models import (
     ApplyRunRequest,
     ArtifactListResource,
     CancelRunRequest,
+    ConfigErrorDetail,
+    ConfigErrorEnvelope,
     CreateRunRequest,
     ErrorDetail,
     ErrorEnvelope,
@@ -74,6 +76,19 @@ def create_app(
         )
         headers = {"WWW-Authenticate": "Bearer"} if exc.status == 401 else None
         return JSONResponse(status_code=exc.status, content=envelope.model_dump(mode="json"), headers=headers)
+
+    @application.exception_handler(ConfigurationAPIError)
+    async def configuration_error(_request: Request, exc: ConfigurationAPIError) -> JSONResponse:  # noqa: RUF029
+        envelope = ConfigErrorEnvelope(
+            error=ConfigErrorDetail(
+                code=f"configs-{exc.family}",
+                message="the configuration service refused the request",
+                status=exc.status,
+                family=exc.family,
+                reason=exc.reason,
+            )
+        )
+        return JSONResponse(status_code=exc.status, content=envelope.model_dump(mode="json"))
 
     @application.exception_handler(RequestValidationError)
     async def validation_error(_request: Request, _exc: RequestValidationError) -> JSONResponse:  # noqa: RUF029

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -183,6 +183,6 @@ def create_app(
         return JSONResponse(status_code=status, content=content)
 
     if configuration_routes is not None:
-        application.include_router(configuration_router(configuration_routes, authenticate))
+        application.include_router(configuration_router(configuration_routes, authenticate, idempotency_key))
 
     return application

--- a/infrahub_sync/managed/app.py
+++ b/infrahub_sync/managed/app.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .auth import Principal, PrincipalResolver
+from .config_routes import ConfigurationRoutes, configuration_router
 from .models import (
     ApplyRunRequest,
     ArtifactListResource,
@@ -31,7 +32,9 @@ ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
 }
 
 
-def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastAPI:
+def create_app(
+    service: ManagedRunService, resolver: PrincipalResolver, configuration_routes: ConfigurationRoutes | None = None
+) -> FastAPI:
     """Create the managed application from explicit providers."""
     application = FastAPI(title="Infrahub Sync managed API", version="1.0.0")
     bearer_auth = HTTPBearer(auto_error=False, scheme_name="BearerAuth")
@@ -163,5 +166,8 @@ def create_app(service: ManagedRunService, resolver: PrincipalResolver) -> FastA
     ) -> JSONResponse:
         status, content = await service.cancel_run(run_id, body, principal, key)
         return JSONResponse(status_code=status, content=content)
+
+    if configuration_routes is not None:
+        application.include_router(configuration_router(configuration_routes, authenticate))
 
     return application

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -1,0 +1,101 @@
+"""HTTP-only adapter for the shared configuration application service."""
+
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+
+from infrahub_sync.product_store import configs
+
+from .auth import Principal
+from .models import ConfigMutationRequest
+from .service import ManagedAPIError
+
+
+class ConfigurationRoutes:
+    """Bind configuration operations to this server's durable cache location."""
+
+    def __init__(self, product_cache_location: Path, *, secrets: tuple[str, ...] = ()) -> None:
+        self._location = product_cache_location
+        self._secrets = secrets
+
+    def _call(self, operation: Any, **kwargs: Any) -> Any:
+        try:
+            return operation(product_cache_location=self._location, **kwargs)
+        except configs.ConfigsRequestError:
+            raise ManagedAPIError(400, "configs-request", "the configuration request is invalid") from None
+        except configs.ConfigsValidationError:
+            raise ManagedAPIError(422, "configs-validation", "the configuration is invalid") from None
+        except configs.ConfigsNotFoundError as exc:
+            reason = exc.reason
+            raise ManagedAPIError(404, "configs-not-found", reason) from None
+        except configs.ConfigsStorageError:
+            raise ManagedAPIError(503, "configs-storage", "configuration storage is unavailable") from None
+        except configs.ConfigsInternalError:
+            raise ManagedAPIError(503, "configs-internal", "configuration service is unavailable") from None
+        except configs.ConfigsError:
+            raise ManagedAPIError(503, "configs-error", "configuration service is unavailable") from None
+
+    def register(self, package: dict[str, Any]) -> Any:
+        return self._call(configs.register, package=package)
+
+    def create_version(self, config_id: str, package: dict[str, Any]) -> Any:
+        return self._call(configs.create_version, config_id=config_id, package=package)
+
+    def list_configs(self) -> Any:
+        return self._call(configs.list_configs)
+
+    def get_config(self, config_id: str) -> Any:
+        return self._call(configs.get_config, config_id=config_id)
+
+    def list_versions(self, config_id: str) -> Any:
+        return self._call(configs.list_versions, config_id=config_id)
+
+    def get_version(self, config_id: str, registry_version: int) -> Any:
+        return self._call(configs.get_version, config_id=config_id, registry_version=registry_version)
+
+    def validate(self, config_id: str, registry_version: int) -> Any:
+        return self._call(configs.validate, config_id=config_id, registry_version=registry_version)
+
+
+def configuration_router(routes: ConfigurationRoutes, authenticate: Any) -> APIRouter:
+    """Create the seven authenticated configuration resources."""
+    router = APIRouter()
+
+    @router.post("/configs", status_code=201)
+    def register(body: ConfigMutationRequest, principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+        if not principal.administrator:
+            raise ManagedAPIError(403, "forbidden", "administrator access is required")
+        return routes.register(body.package)
+
+    @router.post("/configs/{config_id}/versions", status_code=201)
+    def create_version(
+        config_id: str, body: ConfigMutationRequest, principal: Annotated[Principal, Depends(authenticate)]
+    ) -> Any:
+        if not principal.administrator:
+            raise ManagedAPIError(403, "forbidden", "administrator access is required")
+        return routes.create_version(config_id, body.package)
+
+    @router.get("/configs")
+    def list_configs(_principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+        return routes.list_configs()
+
+    @router.get("/configs/{config_id}")
+    def get_config(config_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+        return routes.get_config(config_id)
+
+    @router.get("/configs/{config_id}/versions")
+    def list_versions(config_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+        return routes.list_versions(config_id)
+
+    @router.get("/configs/{config_id}/versions/{registry_version}")
+    def get_version(
+        config_id: str, registry_version: int, _principal: Annotated[Principal, Depends(authenticate)]
+    ) -> Any:
+        return routes.get_version(config_id, registry_version)
+
+    @router.post("/configs/{config_id}/versions/{registry_version}/validate")
+    def validate(config_id: str, registry_version: int, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+        return routes.validate(config_id, registry_version)
+
+    return router

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -33,6 +33,16 @@ class ConfigurationAPIError(Exception):
         self.reason = reason
 
 
+def _strict_integer(value: str, *, minimum: int, maximum: int) -> int:
+    """Parse one bounded API integer without accepting FastAPI's coercions."""
+    if not value.isascii() or not value.isdecimal():
+        raise ManagedAPIError(422, "request-invalid", "the request does not match the API schema")
+    number = int(value)
+    if number < minimum or number > maximum:
+        raise ManagedAPIError(422, "request-invalid", "the request does not match the API schema")
+    return number
+
+
 class ConfigurationRoutes:
     """Bind configuration operations to this server's durable cache location."""
 
@@ -175,9 +185,9 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
     """Create the seven authenticated configuration resources."""
     router = APIRouter()
     config_id_parameter = APIPath(pattern=_CONFIG_ID_PATTERN)
-    registry_version_parameter = APIPath(ge=1, le=_MAX_REGISTRY_VERSION)
-    page_offset = Query(ge=0, le=_MAX_REGISTRY_VERSION)
-    page_limit = Query(ge=1, le=_MAX_PAGE_LIMIT)
+    registry_version_parameter = APIPath()
+    page_offset = Query()
+    page_limit = Query()
 
     @router.post("/configs", status_code=201)
     def register(
@@ -221,10 +231,13 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
     @router.get("/configs")
     def list_configs(
         _principal: Annotated[Principal, Depends(authenticate)],
-        offset: Annotated[int, page_offset] = 0,
-        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+        offset: Annotated[str, page_offset] = "0",
+        limit: Annotated[str, page_limit] = str(_MAX_PAGE_LIMIT),
     ) -> Any:
-        return routes.list_configs(offset=offset, limit=limit)
+        return routes.list_configs(
+            offset=_strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION),
+            limit=_strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT),
+        )
 
     @router.get("/configs/{config_id}")
     def get_config(
@@ -236,27 +249,36 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
     def list_versions(
         config_id: Annotated[str, config_id_parameter],
         _principal: Annotated[Principal, Depends(authenticate)],
-        offset: Annotated[int, page_offset] = 0,
-        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+        offset: Annotated[str, page_offset] = "0",
+        limit: Annotated[str, page_limit] = str(_MAX_PAGE_LIMIT),
     ) -> Any:
-        return routes.list_versions(config_id, offset=offset, limit=limit)
+        return routes.list_versions(
+            config_id,
+            offset=_strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION),
+            limit=_strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT),
+        )
 
     @router.get("/configs/{config_id}/versions/{registry_version}")
     def get_version(
         config_id: Annotated[str, config_id_parameter],
-        registry_version: Annotated[int, registry_version_parameter],
+        registry_version: Annotated[str, registry_version_parameter],
         _principal: Annotated[Principal, Depends(authenticate)],
     ) -> Any:
-        return routes.get_version(config_id, registry_version)
+        return routes.get_version(config_id, _strict_integer(registry_version, minimum=1, maximum=_MAX_REGISTRY_VERSION))
 
     @router.post("/configs/{config_id}/versions/{registry_version}/validate")
     def validate(
         config_id: Annotated[str, config_id_parameter],
-        registry_version: Annotated[int, registry_version_parameter],
+        registry_version: Annotated[str, registry_version_parameter],
         _principal: Annotated[Principal, Depends(authenticate)],
-        offset: Annotated[int, page_offset] = 0,
-        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+        offset: Annotated[str, page_offset] = "0",
+        limit: Annotated[str, page_limit] = str(_MAX_PAGE_LIMIT),
     ) -> Any:
-        return routes.validate(config_id, registry_version, offset=offset, limit=limit)
+        return routes.validate(
+            config_id,
+            _strict_integer(registry_version, minimum=1, maximum=_MAX_REGISTRY_VERSION),
+            offset=_strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION),
+            limit=_strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT),
+        )
 
     return router

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -1,6 +1,5 @@
 """HTTP-only adapter for the shared configuration application service."""
 
-from dataclasses import replace
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
@@ -272,7 +271,9 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         registry_version: Annotated[str, registry_version_parameter],
         _principal: Annotated[Principal, Depends(authenticate)],
     ) -> Any:
-        return routes.get_version(config_id, _strict_integer(registry_version, minimum=1, maximum=_MAX_REGISTRY_VERSION))
+        return routes.get_version(
+            config_id, _strict_integer(registry_version, minimum=1, maximum=_MAX_REGISTRY_VERSION)
+        )
 
     @router.post("/configs/{config_id}/versions/{registry_version}/validate")
     def validate(

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -1,11 +1,18 @@
 """HTTP-only adapter for the shared configuration application service."""
 
+from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path
 from typing import Annotated, Any
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 
 from infrahub_sync.product_store import configs
+from infrahub_sync.product_store import MutationReceipt, local_product_projection
+from infrahub_sync.plan.canonical import canonical_json_bytes
 
 from .auth import Principal
 from .models import ConfigMutationRequest
@@ -69,24 +76,103 @@ class ConfigurationRoutes:
     def validate(self, config_id: str, registry_version: int) -> Any:
         return self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
 
+    def mutate(
+        self,
+        *,
+        actor: str,
+        idempotency_key: str,
+        operation: str,
+        resource_path: str,
+        package: dict[str, Any],
+        reason: str,
+    ) -> tuple[int, dict[str, Any]]:
+        """Persist one configuration mutation response and replay it exactly."""
+        now = datetime.now(timezone.utc)
+        receipt = MutationReceipt(
+            receipt_id=f"m-{uuid4().hex}",
+            actor=actor,
+            key_digest=sha256(idempotency_key.encode()).hexdigest(),
+            operation=operation,
+            request_fingerprint=sha256(
+                canonical_json_bytes(
+                    {"resource": resource_path, "operation": operation, "package": package, "reason": reason}
+                )
+            ).hexdigest(),
+            reason=reason,
+            resource="configuration",
+            created_at=now,
+            updated_at=now,
+        )
+        projection = local_product_projection(self._location)
+        stored, created = projection.reserve_mutation(receipt, secrets=self._secrets)
+        if not created:
+            if (
+                stored.resource != receipt.resource
+                or stored.operation != receipt.operation
+                or stored.request_fingerprint != receipt.request_fingerprint
+            ):
+                raise ManagedAPIError(
+                    409, "idempotency-conflict", "Idempotency-Key was already used by this actor for different content"
+                )
+            if stored.state == "accepted":
+                assert stored.response_status is not None and stored.response_body is not None
+                return stored.response_status, stored.response_body
+        if operation == "register-config":
+            response = jsonable_encoder(self.register(package))
+        else:
+            config_id = resource_path.rsplit("/", 2)[1]
+            response = jsonable_encoder(self.create_version(config_id, package))
+        completed = projection.complete_mutation(
+            stored.receipt_id,
+            response_status=201,
+            response_body=response,
+            flow_run_id=None,
+            secrets=self._secrets,
+        )
+        assert completed.response_body is not None and completed.response_status is not None
+        return completed.response_status, completed.response_body
 
-def configuration_router(routes: ConfigurationRoutes, authenticate: Any) -> APIRouter:
+
+def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempotency_key: Any) -> APIRouter:
     """Create the seven authenticated configuration resources."""
     router = APIRouter()
 
     @router.post("/configs", status_code=201)
-    def register(body: ConfigMutationRequest, principal: Annotated[Principal, Depends(authenticate)]) -> Any:
-        if not principal.administrator:
-            raise ManagedAPIError(403, "forbidden", "administrator access is required")
-        return routes.register(body.package)
-
-    @router.post("/configs/{config_id}/versions", status_code=201)
-    def create_version(
-        config_id: str, body: ConfigMutationRequest, principal: Annotated[Principal, Depends(authenticate)]
+    def register(
+        body: ConfigMutationRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
     ) -> Any:
         if not principal.administrator:
             raise ManagedAPIError(403, "forbidden", "administrator access is required")
-        return routes.create_version(config_id, body.package)
+        status, content = routes.mutate(
+            actor=principal.actor,
+            idempotency_key=key,
+            operation="register-config",
+            resource_path="/configs",
+            package=body.package,
+            reason=body.reason,
+        )
+        return JSONResponse(status_code=status, content=content)
+
+    @router.post("/configs/{config_id}/versions", status_code=201)
+    def create_version(
+        config_id: str,
+        body: ConfigMutationRequest,
+        principal: Annotated[Principal, Depends(authenticate)],
+        key: Annotated[str, Depends(idempotency_key)],
+    ) -> Any:
+        if not principal.administrator:
+            raise ManagedAPIError(403, "forbidden", "administrator access is required")
+        status, content = routes.mutate(
+            actor=principal.actor,
+            idempotency_key=key,
+            operation="create-config-version",
+            resource_path=f"/configs/{config_id}/versions",
+            package=body.package,
+            reason=body.reason,
+        )
+        return JSONResponse(status_code=status, content=content)
 
     @router.get("/configs")
     def list_configs(_principal: Annotated[Principal, Depends(authenticate)]) -> Any:

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -10,9 +10,8 @@ from fastapi import APIRouter, Depends
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
-from infrahub_sync.product_store import configs
-from infrahub_sync.product_store import AuditEvent, MutationReceipt, local_product_projection
 from infrahub_sync.plan.canonical import canonical_json_bytes
+from infrahub_sync.product_store import AuditEvent, MutationReceipt, configs, local_product_projection
 
 from .auth import Principal
 from .models import ConfigMutationRequest
@@ -116,7 +115,8 @@ class ConfigurationRoutes:
                     409, "idempotency-conflict", "Idempotency-Key was already used by this actor for different content"
                 )
             if stored.state == "accepted":
-                assert stored.response_status is not None and stored.response_body is not None
+                assert stored.response_status is not None
+                assert stored.response_body is not None
                 self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
         if operation == "register-config":
@@ -131,7 +131,8 @@ class ConfigurationRoutes:
             flow_run_id=None,
             secrets=self._secrets,
         )
-        assert completed.response_body is not None and completed.response_status is not None
+        assert completed.response_body is not None
+        assert completed.response_status is not None
         self._audit(actor, operation, reason, "accepted")
         return completed.response_status, completed.response_body
 

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Annotated, Any
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Path as APIPath, Query
+from fastapi import APIRouter, Depends, Query
+from fastapi import Path as APIPath
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
@@ -17,7 +18,6 @@ from infrahub_sync.product_store import AuditEvent, MutationReceipt, configs, lo
 from .auth import Principal
 from .models import ConfigMutationRequest
 from .service import ManagedAPIError
-
 
 _CONFIG_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
 _MAX_REGISTRY_VERSION = 2**63 - 1

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Query
@@ -66,8 +66,6 @@ class ConfigurationRoutes:
             if error_type is self._service.ConfigsInternalError:
                 raise ConfigurationAPIError(503, "internal") from None
             raise ConfigurationAPIError(503, "configs") from None
-        except AssertionError:
-            raise ConfigurationAPIError(503, "internal") from None
 
     def register(self, package: dict[str, Any]) -> Any:
         return self._call(self._service.register, package=package)
@@ -108,7 +106,8 @@ class ConfigurationRoutes:
         actor: str,
         idempotency_key: str,
         operation: str,
-        resource_path: str,
+        resource_kind: Literal["configuration", "configuration-registry"],
+        resource_id: str,
         package: dict[str, Any],
         reason: str,
     ) -> tuple[int, dict[str, Any]]:
@@ -121,12 +120,18 @@ class ConfigurationRoutes:
             operation=operation,
             request_fingerprint=sha256(
                 canonical_json_bytes(
-                    {"resource": resource_path, "operation": operation, "package": package, "reason": reason}
+                    {
+                        "resource_kind": resource_kind,
+                        "resource_id": resource_id,
+                        "operation": operation,
+                        "package": package,
+                        "reason": reason,
+                    }
                 )
             ).hexdigest(),
             reason=reason,
-            resource_kind="configuration",
-            resource_id=resource_path,
+            resource_kind=resource_kind,
+            resource_id=resource_id,
             created_at=now,
             updated_at=now,
         )
@@ -148,15 +153,17 @@ class ConfigurationRoutes:
                 assert stored.response_body is not None
                 self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
+        if not projection.claim_mutation(stored.receipt_id, secrets=self._secrets):
+            raise ManagedAPIError(409, "idempotency-in-progress", "the matching request is still being processed")
         try:
             if operation == "register-config":
                 result = self.register(package)
                 response_status = 201
             else:
-                config_id = resource_path.rsplit("/", 2)[1]
-                result = self.create_version(config_id, package)
+                result = self.create_version(resource_id, package)
                 response_status = 201 if result.created else 200
         except ConfigurationAPIError:
+            projection.release_mutation(stored.receipt_id, secrets=self._secrets)
             self._audit(actor, operation, reason, "unavailable")
             raise
         response = jsonable_encoder(result)
@@ -212,7 +219,8 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
             actor=principal.actor,
             idempotency_key=key,
             operation="register-config",
-            resource_path="/configs",
+            resource_kind="configuration-registry",
+            resource_id="configs",
             package=body.package,
             reason=body.reason,
         )
@@ -232,7 +240,8 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
             actor=principal.actor,
             idempotency_key=key,
             operation="create-config-version",
-            resource_path=f"/configs/{config_id}/versions",
+            resource_kind="configuration",
+            resource_id=config_id,
             package=body.package,
             reason=body.reason,
         )

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -26,10 +26,11 @@ _MAX_PAGE_LIMIT = 256
 class ConfigurationAPIError(Exception):
     """Fixed public representation of one shared configuration-service refusal."""
 
-    def __init__(self, status: int, family: str, *, reason: str | None = None) -> None:
+    def __init__(self, status: int, family: str, *, reason: str | None = None, proven_pre_effect: bool = False) -> None:
         self.status = status
         self.family = family
         self.reason = reason
+        self.proven_pre_effect = proven_pre_effect
 
 
 def _strict_integer(value: str, *, minimum: int, maximum: int) -> int:
@@ -56,11 +57,11 @@ class ConfigurationRoutes:
         except self._service.ConfigsError as error:
             error_type = type(error)
             if error_type is self._service.ConfigsRequestError:
-                raise ConfigurationAPIError(400, "request") from None
+                raise ConfigurationAPIError(400, "request", proven_pre_effect=True) from None
             if error_type is self._service.ConfigsValidationError:
-                raise ConfigurationAPIError(422, "validation") from None
+                raise ConfigurationAPIError(422, "validation", proven_pre_effect=True) from None
             if error_type is self._service.ConfigsNotFoundError:
-                raise ConfigurationAPIError(404, "not-found", reason=error.reason) from None
+                raise ConfigurationAPIError(404, "not-found", reason=error.reason, proven_pre_effect=True) from None
             if error_type is self._service.ConfigsStorageError:
                 raise ConfigurationAPIError(503, "storage") from None
             if error_type is self._service.ConfigsInternalError:
@@ -154,6 +155,7 @@ class ConfigurationRoutes:
                 self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
         if not projection.claim_mutation(stored.receipt_id, secrets=self._secrets):
+            self._audit(actor, operation, reason, "refused-idempotency-in-progress")
             raise ManagedAPIError(409, "idempotency-in-progress", "the matching request is still being processed")
         try:
             if operation == "register-config":
@@ -162,8 +164,9 @@ class ConfigurationRoutes:
             else:
                 result = self.create_version(resource_id, package)
                 response_status = 201 if result.created else 200
-        except ConfigurationAPIError:
-            projection.release_mutation(stored.receipt_id, secrets=self._secrets)
+        except ConfigurationAPIError as error:
+            if error.proven_pre_effect:
+                projection.release_mutation(stored.receipt_id, secrets=self._secrets)
             self._audit(actor, operation, reason, "unavailable")
             raise
         response = jsonable_encoder(result)

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -105,7 +105,8 @@ class ConfigurationRoutes:
                 )
             ).hexdigest(),
             reason=reason,
-            resource="configuration",
+            resource_kind="configuration",
+            resource_id=resource_path,
             created_at=now,
             updated_at=now,
         )
@@ -113,7 +114,8 @@ class ConfigurationRoutes:
         stored, created = projection.reserve_mutation(receipt, secrets=self._secrets)
         if not created:
             if (
-                stored.resource != receipt.resource
+                stored.resource_kind != receipt.resource_kind
+                or stored.resource_id != receipt.resource_id
                 or stored.operation != receipt.operation
                 or stored.request_fingerprint != receipt.request_fingerprint
             ):

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -76,21 +76,32 @@ class ConfigurationRoutes:
     def create_version(self, config_id: str, package: dict[str, Any]) -> Any:
         return self._call(self._service.create_version, config_id=config_id, package=package)
 
-    def list_configs(self, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
-        return self._call(self._service.list_configs)[offset : offset + limit]
+    def list_configs(self) -> Any:
+        return self._call(self._service.list_configs)
 
     def get_config(self, config_id: str) -> Any:
         return self._call(self._service.get_config, config_id=config_id)
 
-    def list_versions(self, config_id: str, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
-        return self._call(self._service.list_versions, config_id=config_id)[offset : offset + limit]
+    def list_versions(self, config_id: str) -> Any:
+        return self._call(self._service.list_versions, config_id=config_id)
 
     def get_version(self, config_id: str, registry_version: int) -> Any:
         return self._call(self._service.get_version, config_id=config_id, registry_version=registry_version)
 
     def validate(self, config_id: str, registry_version: int, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
         report = self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
-        return replace(report, findings=report.findings[offset : offset + limit])
+        findings = report.findings[offset : offset + limit]
+        return {
+            "config_id": report.config_id,
+            "registry_version": report.registry_version,
+            "package_checksum": report.package_checksum,
+            "destination_schema_fingerprint": report.destination_schema_fingerprint,
+            "findings": findings,
+            "offset": offset,
+            "limit": limit,
+            "total_findings": len(report.findings),
+            "next_offset": offset + len(findings) if offset + len(findings) < len(report.findings) else None,
+        }
 
     def mutate(
         self,
@@ -234,10 +245,9 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         offset: Annotated[str, page_offset] = "0",
         limit: Annotated[str, page_limit] = str(_MAX_PAGE_LIMIT),
     ) -> Any:
-        return routes.list_configs(
-            offset=_strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION),
-            limit=_strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT),
-        )
+        _strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION)
+        _strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT)
+        return routes.list_configs()
 
     @router.get("/configs/{config_id}")
     def get_config(
@@ -252,11 +262,9 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         offset: Annotated[str, page_offset] = "0",
         limit: Annotated[str, page_limit] = str(_MAX_PAGE_LIMIT),
     ) -> Any:
-        return routes.list_versions(
-            config_id,
-            offset=_strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION),
-            limit=_strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT),
-        )
+        _strict_integer(offset, minimum=0, maximum=_MAX_REGISTRY_VERSION)
+        _strict_integer(limit, minimum=1, maximum=_MAX_PAGE_LIMIT)
+        return routes.list_versions(config_id)
 
     @router.get("/configs/{config_id}/versions/{registry_version}")
     def get_version(

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -127,13 +127,16 @@ class ConfigurationRoutes:
                 self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
         if operation == "register-config":
-            response = jsonable_encoder(self.register(package))
+            result = self.register(package)
+            response_status = 201
         else:
             config_id = resource_path.rsplit("/", 2)[1]
-            response = jsonable_encoder(self.create_version(config_id, package))
+            result = self.create_version(config_id, package)
+            response_status = 201 if result.created else 200
+        response = jsonable_encoder(result)
         completed = projection.complete_mutation(
             stored.receipt_id,
-            response_status=201,
+            response_status=response_status,
             response_body=response,
             flow_run_id=None,
             secrets=self._secrets,

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -128,13 +128,17 @@ class ConfigurationRoutes:
                 assert stored.response_body is not None
                 self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
-        if operation == "register-config":
-            result = self.register(package)
-            response_status = 201
-        else:
-            config_id = resource_path.rsplit("/", 2)[1]
-            result = self.create_version(config_id, package)
-            response_status = 201 if result.created else 200
+        try:
+            if operation == "register-config":
+                result = self.register(package)
+                response_status = 201
+            else:
+                config_id = resource_path.rsplit("/", 2)[1]
+                result = self.create_version(config_id, package)
+                response_status = 201 if result.created else 200
+        except ConfigurationAPIError:
+            self._audit(actor, operation, reason, "unavailable")
+            raise
         response = jsonable_encoder(result)
         completed = projection.complete_mutation(
             stored.receipt_id,

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -1,12 +1,13 @@
 """HTTP-only adapter for the shared configuration application service."""
 
+from dataclasses import replace
 from datetime import datetime, timezone
 from hashlib import sha256
 from pathlib import Path
 from typing import Annotated, Any
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path as APIPath, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
@@ -16,6 +17,11 @@ from infrahub_sync.product_store import AuditEvent, MutationReceipt, configs, lo
 from .auth import Principal
 from .models import ConfigMutationRequest
 from .service import ManagedAPIError
+
+
+_CONFIG_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+_MAX_REGISTRY_VERSION = 2**63 - 1
+_MAX_PAGE_LIMIT = 256
 
 
 class ConfigurationAPIError(Exception):
@@ -60,19 +66,22 @@ class ConfigurationRoutes:
     def create_version(self, config_id: str, package: dict[str, Any]) -> Any:
         return self._call(self._service.create_version, config_id=config_id, package=package)
 
-    def list_configs(self) -> Any:
+    def list_configs(self, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
+        del offset, limit
         return self._call(self._service.list_configs)
 
     def get_config(self, config_id: str) -> Any:
         return self._call(self._service.get_config, config_id=config_id)
 
-    def list_versions(self, config_id: str) -> Any:
+    def list_versions(self, config_id: str, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
+        del offset, limit
         return self._call(self._service.list_versions, config_id=config_id)
 
     def get_version(self, config_id: str, registry_version: int) -> Any:
         return self._call(self._service.get_version, config_id=config_id, registry_version=registry_version)
 
-    def validate(self, config_id: str, registry_version: int) -> Any:
+    def validate(self, config_id: str, registry_version: int, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
+        del offset, limit
         return self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
 
     def mutate(
@@ -158,6 +167,10 @@ class ConfigurationRoutes:
 def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempotency_key: Any) -> APIRouter:
     """Create the seven authenticated configuration resources."""
     router = APIRouter()
+    config_id_parameter = APIPath(pattern=_CONFIG_ID_PATTERN)
+    registry_version_parameter = APIPath(ge=1, le=_MAX_REGISTRY_VERSION)
+    page_offset = Query(ge=0, le=_MAX_REGISTRY_VERSION)
+    page_limit = Query(ge=1, le=_MAX_PAGE_LIMIT)
 
     @router.post("/configs", status_code=201)
     def register(
@@ -180,7 +193,7 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
 
     @router.post("/configs/{config_id}/versions", status_code=201)
     def create_version(
-        config_id: str,
+        config_id: Annotated[str, config_id_parameter],
         body: ConfigMutationRequest,
         principal: Annotated[Principal, Depends(authenticate)],
         key: Annotated[str, Depends(idempotency_key)],
@@ -199,25 +212,44 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         return JSONResponse(status_code=status, content=content)
 
     @router.get("/configs")
-    def list_configs(_principal: Annotated[Principal, Depends(authenticate)]) -> Any:
-        return routes.list_configs()
+    def list_configs(
+        _principal: Annotated[Principal, Depends(authenticate)],
+        offset: Annotated[int, page_offset] = 0,
+        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+    ) -> Any:
+        return routes.list_configs(offset=offset, limit=limit)
 
     @router.get("/configs/{config_id}")
-    def get_config(config_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
+    def get_config(
+        config_id: Annotated[str, config_id_parameter], _principal: Annotated[Principal, Depends(authenticate)]
+    ) -> Any:
         return routes.get_config(config_id)
 
     @router.get("/configs/{config_id}/versions")
-    def list_versions(config_id: str, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
-        return routes.list_versions(config_id)
+    def list_versions(
+        config_id: Annotated[str, config_id_parameter],
+        _principal: Annotated[Principal, Depends(authenticate)],
+        offset: Annotated[int, page_offset] = 0,
+        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+    ) -> Any:
+        return routes.list_versions(config_id, offset=offset, limit=limit)
 
     @router.get("/configs/{config_id}/versions/{registry_version}")
     def get_version(
-        config_id: str, registry_version: int, _principal: Annotated[Principal, Depends(authenticate)]
+        config_id: Annotated[str, config_id_parameter],
+        registry_version: Annotated[int, registry_version_parameter],
+        _principal: Annotated[Principal, Depends(authenticate)],
     ) -> Any:
         return routes.get_version(config_id, registry_version)
 
     @router.post("/configs/{config_id}/versions/{registry_version}/validate")
-    def validate(config_id: str, registry_version: int, _principal: Annotated[Principal, Depends(authenticate)]) -> Any:
-        return routes.validate(config_id, registry_version)
+    def validate(
+        config_id: Annotated[str, config_id_parameter],
+        registry_version: Annotated[int, registry_version_parameter],
+        _principal: Annotated[Principal, Depends(authenticate)],
+        offset: Annotated[int, page_offset] = 0,
+        limit: Annotated[int, page_limit] = _MAX_PAGE_LIMIT,
+    ) -> Any:
+        return routes.validate(config_id, registry_version, offset=offset, limit=limit)
 
     return router

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -67,22 +67,20 @@ class ConfigurationRoutes:
         return self._call(self._service.create_version, config_id=config_id, package=package)
 
     def list_configs(self, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
-        del offset, limit
-        return self._call(self._service.list_configs)
+        return self._call(self._service.list_configs)[offset : offset + limit]
 
     def get_config(self, config_id: str) -> Any:
         return self._call(self._service.get_config, config_id=config_id)
 
     def list_versions(self, config_id: str, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
-        del offset, limit
-        return self._call(self._service.list_versions, config_id=config_id)
+        return self._call(self._service.list_versions, config_id=config_id)[offset : offset + limit]
 
     def get_version(self, config_id: str, registry_version: int) -> Any:
         return self._call(self._service.get_version, config_id=config_id, registry_version=registry_version)
 
     def validate(self, config_id: str, registry_version: int, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT) -> Any:
-        del offset, limit
-        return self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
+        report = self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
+        return replace(report, findings=report.findings[offset : offset + limit])
 
     def mutate(
         self,

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -12,50 +12,62 @@ from .models import ConfigMutationRequest
 from .service import ManagedAPIError
 
 
+class ConfigurationAPIError(Exception):
+    """Fixed public representation of one shared configuration-service refusal."""
+
+    def __init__(self, status: int, family: str, *, reason: str | None = None) -> None:
+        self.status = status
+        self.family = family
+        self.reason = reason
+
+
 class ConfigurationRoutes:
     """Bind configuration operations to this server's durable cache location."""
 
-    def __init__(self, product_cache_location: Path, *, secrets: tuple[str, ...] = ()) -> None:
+    def __init__(self, product_cache_location: Path, *, service: Any = configs, secrets: tuple[str, ...] = ()) -> None:
         self._location = product_cache_location
+        self._service = service
         self._secrets = secrets
 
     def _call(self, operation: Any, **kwargs: Any) -> Any:
         try:
             return operation(product_cache_location=self._location, **kwargs)
-        except configs.ConfigsRequestError:
-            raise ManagedAPIError(400, "configs-request", "the configuration request is invalid") from None
-        except configs.ConfigsValidationError:
-            raise ManagedAPIError(422, "configs-validation", "the configuration is invalid") from None
-        except configs.ConfigsNotFoundError as exc:
+        except self._service.ConfigsRequestError:
+            raise ConfigurationAPIError(400, "request") from None
+        except self._service.ConfigsValidationError:
+            raise ConfigurationAPIError(422, "validation") from None
+        except self._service.ConfigsNotFoundError as exc:
             reason = exc.reason
-            raise ManagedAPIError(404, "configs-not-found", reason) from None
-        except configs.ConfigsStorageError:
-            raise ManagedAPIError(503, "configs-storage", "configuration storage is unavailable") from None
-        except configs.ConfigsInternalError:
-            raise ManagedAPIError(503, "configs-internal", "configuration service is unavailable") from None
-        except configs.ConfigsError:
-            raise ManagedAPIError(503, "configs-error", "configuration service is unavailable") from None
+            raise ConfigurationAPIError(404, "not-found", reason=reason) from None
+        except self._service.ConfigsStorageError:
+            raise ConfigurationAPIError(503, "storage") from None
+        except self._service.ConfigsInternalError:
+            raise ConfigurationAPIError(503, "internal") from None
+        except self._service.ConfigsError:
+            raise ConfigurationAPIError(503, "configs") from None
+        except AssertionError:
+            raise ConfigurationAPIError(503, "internal") from None
 
     def register(self, package: dict[str, Any]) -> Any:
-        return self._call(configs.register, package=package)
+        return self._call(self._service.register, package=package)
 
     def create_version(self, config_id: str, package: dict[str, Any]) -> Any:
-        return self._call(configs.create_version, config_id=config_id, package=package)
+        return self._call(self._service.create_version, config_id=config_id, package=package)
 
     def list_configs(self) -> Any:
-        return self._call(configs.list_configs)
+        return self._call(self._service.list_configs)
 
     def get_config(self, config_id: str) -> Any:
-        return self._call(configs.get_config, config_id=config_id)
+        return self._call(self._service.get_config, config_id=config_id)
 
     def list_versions(self, config_id: str) -> Any:
-        return self._call(configs.list_versions, config_id=config_id)
+        return self._call(self._service.list_versions, config_id=config_id)
 
     def get_version(self, config_id: str, registry_version: int) -> Any:
-        return self._call(configs.get_version, config_id=config_id, registry_version=registry_version)
+        return self._call(self._service.get_version, config_id=config_id, registry_version=registry_version)
 
     def validate(self, config_id: str, registry_version: int) -> Any:
-        return self._call(configs.validate, config_id=config_id, registry_version=registry_version)
+        return self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
 
 
 def configuration_router(routes: ConfigurationRoutes, authenticate: Any) -> APIRouter:

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -11,7 +11,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
 from infrahub_sync.product_store import configs
-from infrahub_sync.product_store import MutationReceipt, local_product_projection
+from infrahub_sync.product_store import AuditEvent, MutationReceipt, local_product_projection
 from infrahub_sync.plan.canonical import canonical_json_bytes
 
 from .auth import Principal
@@ -111,11 +111,13 @@ class ConfigurationRoutes:
                 or stored.operation != receipt.operation
                 or stored.request_fingerprint != receipt.request_fingerprint
             ):
+                self._audit(actor, operation, reason, "refused-idempotency")
                 raise ManagedAPIError(
                     409, "idempotency-conflict", "Idempotency-Key was already used by this actor for different content"
                 )
             if stored.state == "accepted":
                 assert stored.response_status is not None and stored.response_body is not None
+                self._audit(actor, operation, reason, "replayed")
                 return stored.response_status, stored.response_body
         if operation == "register-config":
             response = jsonable_encoder(self.register(package))
@@ -130,7 +132,26 @@ class ConfigurationRoutes:
             secrets=self._secrets,
         )
         assert completed.response_body is not None and completed.response_status is not None
+        self._audit(actor, operation, reason, "accepted")
         return completed.response_status, completed.response_body
+
+    def audit_refusal(self, actor: str, operation: str, reason: str) -> None:
+        """Record a refused configuration mutation without reserving it."""
+        self._audit(actor, operation, reason, "refused-authorization")
+
+    def _audit(self, actor: str, operation: str, reason: str, outcome: str) -> None:
+        local_product_projection(self._location).record_audit(
+            AuditEvent(
+                event_id=f"a-{uuid4().hex}",
+                run_id=None,
+                actor=actor,
+                operation=operation,
+                reason=reason,
+                outcome=outcome,
+                created_at=datetime.now(timezone.utc),
+            ),
+            secrets=self._secrets,
+        )
 
 
 def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempotency_key: Any) -> APIRouter:
@@ -144,6 +165,7 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         key: Annotated[str, Depends(idempotency_key)],
     ) -> Any:
         if not principal.administrator:
+            routes.audit_refusal(principal.actor, "register-config", body.reason)
             raise ManagedAPIError(403, "forbidden", "administrator access is required")
         status, content = routes.mutate(
             actor=principal.actor,
@@ -163,6 +185,7 @@ def configuration_router(routes: ConfigurationRoutes, authenticate: Any, idempot
         key: Annotated[str, Depends(idempotency_key)],
     ) -> Any:
         if not principal.administrator:
+            routes.audit_refusal(principal.actor, "create-config-version", body.reason)
             raise ManagedAPIError(403, "forbidden", "administrator access is required")
         status, content = routes.mutate(
             actor=principal.actor,

--- a/infrahub_sync/managed/config_routes.py
+++ b/infrahub_sync/managed/config_routes.py
@@ -44,18 +44,18 @@ class ConfigurationRoutes:
     def _call(self, operation: Any, **kwargs: Any) -> Any:
         try:
             return operation(product_cache_location=self._location, **kwargs)
-        except self._service.ConfigsRequestError:
-            raise ConfigurationAPIError(400, "request") from None
-        except self._service.ConfigsValidationError:
-            raise ConfigurationAPIError(422, "validation") from None
-        except self._service.ConfigsNotFoundError as exc:
-            reason = exc.reason
-            raise ConfigurationAPIError(404, "not-found", reason=reason) from None
-        except self._service.ConfigsStorageError:
-            raise ConfigurationAPIError(503, "storage") from None
-        except self._service.ConfigsInternalError:
-            raise ConfigurationAPIError(503, "internal") from None
-        except self._service.ConfigsError:
+        except self._service.ConfigsError as error:
+            error_type = type(error)
+            if error_type is self._service.ConfigsRequestError:
+                raise ConfigurationAPIError(400, "request") from None
+            if error_type is self._service.ConfigsValidationError:
+                raise ConfigurationAPIError(422, "validation") from None
+            if error_type is self._service.ConfigsNotFoundError:
+                raise ConfigurationAPIError(404, "not-found", reason=error.reason) from None
+            if error_type is self._service.ConfigsStorageError:
+                raise ConfigurationAPIError(503, "storage") from None
+            if error_type is self._service.ConfigsInternalError:
+                raise ConfigurationAPIError(503, "internal") from None
             raise ConfigurationAPIError(503, "configs") from None
         except AssertionError:
             raise ConfigurationAPIError(503, "internal") from None

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from infrahub_sync.product_store import ArtifactReference, ProductRun  # noqa: TC001 - Pydantic resolves at runtime.
 
 ManagedStage = Literal["plan", "verify", "apply", "sync"]
+_REASON_GRAMMAR_MESSAGE = "reason must be printable and trimmed"
+_JSON_NATIVE_PACKAGE_MESSAGE = "package must be recursively exact JSON-native"
 
 
 class _StrictModel(BaseModel):
@@ -119,7 +121,7 @@ class ConfigMutationRequest(_StrictModel):
     @classmethod
     def _require_printable_trimmed_reason(cls, value: str) -> str:
         if value != value.strip() or not value.isprintable():
-            raise ValueError("reason must be printable and trimmed")
+            raise ValueError(_REASON_GRAMMAR_MESSAGE)
         return value
 
     @field_validator("package")
@@ -130,7 +132,7 @@ class ConfigMutationRequest(_StrictModel):
             if item_type is dict:
                 for key, child in item.items():
                     if type(key) is not str:
-                        raise ValueError("package must be recursively exact JSON-native")
+                        raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)
                     visit(child)
                 return
             if item_type is list:
@@ -138,9 +140,9 @@ class ConfigMutationRequest(_StrictModel):
                     visit(child)
                 return
             if item_type is float and not isfinite(item):
-                raise ValueError("package must be recursively exact JSON-native")
+                raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)
             if item_type not in {str, int, float, bool, type(None)}:
-                raise ValueError("package must be recursively exact JSON-native")
+                raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)
 
         visit(value)
         return value

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from math import isfinite
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from infrahub_sync.product_store import ArtifactReference, ProductRun  # noqa: TC001 - Pydantic resolves at runtime.
 
@@ -109,8 +110,40 @@ class ErrorEnvelope(_StrictModel):
 class ConfigMutationRequest(_StrictModel):
     """JSON package submitted for a configuration mutation."""
 
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=False)
+
     package: dict[str, Any]
     reason: str = Field(min_length=1, max_length=512)
+
+    @field_validator("reason")
+    @classmethod
+    def _require_printable_trimmed_reason(cls, value: str) -> str:
+        if value != value.strip() or not value.isprintable():
+            raise ValueError("reason must be printable and trimmed")
+        return value
+
+    @field_validator("package")
+    @classmethod
+    def _require_exact_json_native_package(cls, value: dict[str, Any]) -> dict[str, Any]:
+        def visit(item: object) -> None:
+            item_type = type(item)
+            if item_type is dict:
+                for key, child in item.items():
+                    if type(key) is not str:
+                        raise ValueError("package must be recursively exact JSON-native")
+                    visit(child)
+                return
+            if item_type is list:
+                for child in item:
+                    visit(child)
+                return
+            if item_type is float and not isfinite(item):
+                raise ValueError("package must be recursively exact JSON-native")
+            if item_type not in {str, int, float, bool, type(None)}:
+                raise ValueError("package must be recursively exact JSON-native")
+
+        visit(value)
+        return value
 
 
 class ConfigErrorDetail(_StrictModel):

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -104,3 +104,24 @@ class ErrorEnvelope(_StrictModel):
     """Stable envelope used by every managed API error."""
 
     error: ErrorDetail
+
+
+class ConfigMutationRequest(_StrictModel):
+    """JSON package submitted for a configuration mutation."""
+
+    package: dict[str, Any]
+    reason: str = Field(min_length=1, max_length=512)
+
+
+class ConfigErrorDetail(_StrictModel):
+    """Secret-safe configuration service refusal."""
+
+    code: str
+    message: str
+    status: int
+    family: str
+    reason: str | None = None
+
+
+class ConfigErrorEnvelope(_StrictModel):
+    error: ConfigErrorDetail

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import isfinite
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -130,16 +130,16 @@ class ConfigMutationRequest(_StrictModel):
         def visit(item: object) -> None:
             item_type = type(item)
             if item_type is dict:
-                for key, child in item.items():
-                    if type(key) is not str:
+                for key, child in cast("dict[object, object]", item).items():
+                    if type(key) is not str:  # pylint: disable=unidiomatic-typecheck  # Exact JSON key type.
                         raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)
                     visit(child)
                 return
             if item_type is list:
-                for child in item:
+                for child in cast("list[object]", item):
                     visit(child)
                 return
-            if item_type is float and not isfinite(item):
+            if item_type is float and not isfinite(cast("float", item)):
                 raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)
             if item_type not in {str, int, float, bool, type(None)}:
                 raise ValueError(_JSON_NATIVE_PACKAGE_MESSAGE)

--- a/infrahub_sync/managed/serve.py
+++ b/infrahub_sync/managed/serve.py
@@ -14,6 +14,7 @@ from infrahub_sync.product_store import local_product_projection
 from ._settings import PRODUCT_CACHE_ENV
 from .app import create_app
 from .auth import EnvironmentPrincipalResolver
+from .config_routes import ConfigurationRoutes
 from .orchestration import Observation, PrefectOrchestration, Submission
 from .service import ManagedRunService
 
@@ -47,7 +48,8 @@ def build_app() -> FastAPI:
     projection = local_product_projection(cache_location)
     resolver = EnvironmentPrincipalResolver.from_environment()
     service = ManagedRunService(projection, _ClientPerCallOrchestration(), secrets=resolver.secret_values)
-    return create_app(service, resolver)
+    configuration_routes = ConfigurationRoutes(cache_location, secrets=resolver.secret_values)
+    return create_app(service, resolver, configuration_routes)
 
 
 def main() -> None:

--- a/infrahub_sync/managed/serve.py
+++ b/infrahub_sync/managed/serve.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import uvicorn
 from prefect.client.orchestration import get_client
@@ -38,18 +38,25 @@ class _ClientPerCallOrchestration:
             return await PrefectOrchestration(client).cancel(flow_run_id)
 
 
-def build_app() -> FastAPI:
+def build_app(
+    *,
+    projection_factory: Any = local_product_projection,
+    resolver_factory: Any = EnvironmentPrincipalResolver.from_environment,
+    run_service_factory: Any = ManagedRunService,
+    configuration_routes_factory: Any = ConfigurationRoutes,
+    app_factory: Any = create_app,
+) -> FastAPI:
     """Construct the managed app from its explicit runtime environment."""
     value = os.environ.get(PRODUCT_CACHE_ENV)
     if not value:
         msg = f"{PRODUCT_CACHE_ENV} must name an absolute durable product-cache directory"
         raise ValueError(msg)
     cache_location = Path(value).expanduser()
-    projection = local_product_projection(cache_location)
-    resolver = EnvironmentPrincipalResolver.from_environment()
-    service = ManagedRunService(projection, _ClientPerCallOrchestration(), secrets=resolver.secret_values)
-    configuration_routes = ConfigurationRoutes(cache_location, secrets=resolver.secret_values)
-    return create_app(service, resolver, configuration_routes)
+    projection = projection_factory(cache_location)
+    resolver = resolver_factory()
+    service = run_service_factory(projection, _ClientPerCallOrchestration(), secrets=resolver.secret_values)
+    configuration_routes = configuration_routes_factory(cache_location, secrets=resolver.secret_values)
+    return app_factory(service, resolver, configuration_routes)
 
 
 def main() -> None:

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -422,7 +422,7 @@ class ManagedRunService:
         principal: Principal,
         reason: str,
     ) -> tuple[int, dict[str, Any]]:
-        assert receipt.resource == "run"
+        assert receipt.resource_kind == "run"
         assert receipt.run_id is not None
         assert receipt.prefect_key is not None
         try:
@@ -586,6 +586,7 @@ class ManagedRunService:
             target_run_id=target_run_id,
             request_fingerprint=fingerprint,
             reason=reason,
+            resource_id=run_id,
             run_id=run_id,
             prefect_key=prefect_key,
             created_at=now,

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -422,6 +422,9 @@ class ManagedRunService:
         principal: Principal,
         reason: str,
     ) -> tuple[int, dict[str, Any]]:
+        assert receipt.resource == "run"
+        assert receipt.run_id is not None
+        assert receipt.prefect_key is not None
         try:
             submission = await self._orchestration.submit(parameters, idempotency_key=receipt.prefect_key)
         except Exception as exc:  # noqa: BLE001 - remote boundary is translated and cause-sanitized

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -129,7 +129,8 @@ class MutationReceipt(BaseModel):
     target_run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
     request_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
     reason: str = Field(min_length=1)
-    resource: Literal["run", "configuration"] = "run"
+    resource_kind: Literal["run", "configuration"] = "run"
+    resource_id: str = Field(min_length=1)
     run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
     prefect_key: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     state: Literal["reserved", "accepted"] = "reserved"
@@ -150,10 +151,10 @@ class MutationReceipt(BaseModel):
     @model_validator(mode="after")
     def _require_accepted_response(self) -> MutationReceipt:
         accepted_values = (self.response_status, self.response_body, self.flow_run_id)
-        if self.resource == "run" and (self.run_id is None or self.prefect_key is None):
+        if self.resource_kind == "run" and (self.run_id is None or self.prefect_key is None):
             msg = "a run mutation receipt requires its run and Prefect identifiers"
             raise ValueError(msg)
-        if self.resource == "configuration" and any(
+        if self.resource_kind == "configuration" and any(
             value is not None for value in (self.run_id, self.prefect_key, self.flow_run_id, self.target_run_id)
         ):
             msg = "a configuration mutation receipt cannot carry run or Prefect identifiers"
@@ -161,7 +162,7 @@ class MutationReceipt(BaseModel):
         if self.state == "accepted" and (
             self.response_status is None
             or self.response_body is None
-            or (self.resource == "run" and self.flow_run_id is None)
+            or (self.resource_kind == "run" and self.flow_run_id is None)
         ):
             msg = "an accepted mutation receipt requires its status, response, and Prefect flow-run ID"
             raise ValueError(msg)

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -129,11 +129,11 @@ class MutationReceipt(BaseModel):
     target_run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
     request_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
     reason: str = Field(min_length=1)
-    resource_kind: Literal["run", "configuration"] = "run"
+    resource_kind: Literal["run", "configuration", "configuration-registry"] = "run"
     resource_id: str = Field(min_length=1)
     run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
     prefect_key: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
-    state: Literal["reserved", "accepted"] = "reserved"
+    state: Literal["reserved", "processing", "accepted"] = "reserved"
     response_status: int | None = Field(default=None, ge=100, le=599)
     response_body: dict[str, Any] | None = None
     flow_run_id: str | None = None
@@ -154,7 +154,7 @@ class MutationReceipt(BaseModel):
         if self.resource_kind == "run" and (self.run_id is None or self.prefect_key is None):
             msg = "a run mutation receipt requires its run and Prefect identifiers"
             raise ValueError(msg)
-        if self.resource_kind == "configuration" and any(
+        if self.resource_kind in {"configuration", "configuration-registry"} and any(
             value is not None for value in (self.run_id, self.prefect_key, self.flow_run_id, self.target_run_id)
         ):
             msg = "a configuration mutation receipt cannot carry run or Prefect identifiers"
@@ -166,8 +166,8 @@ class MutationReceipt(BaseModel):
         ):
             msg = "an accepted mutation receipt requires its status, response, and Prefect flow-run ID"
             raise ValueError(msg)
-        if self.state == "reserved" and any(value is not None for value in accepted_values):
-            msg = "a reserved mutation receipt cannot carry an accepted response"
+        if self.state in {"reserved", "processing"} and any(value is not None for value in accepted_values):
+            msg = "an incomplete mutation receipt cannot carry an accepted response"
             raise ValueError(msg)
         return self
 

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -129,8 +129,9 @@ class MutationReceipt(BaseModel):
     target_run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
     request_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
     reason: str = Field(min_length=1)
-    run_id: str = Field(pattern=_IDENTIFIER_PATTERN)
-    prefect_key: str = Field(pattern=r"^[0-9a-f]{64}$")
+    resource: Literal["run", "configuration"] = "run"
+    run_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
+    prefect_key: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     state: Literal["reserved", "accepted"] = "reserved"
     response_status: int | None = Field(default=None, ge=100, le=599)
     response_body: dict[str, Any] | None = None
@@ -149,7 +150,19 @@ class MutationReceipt(BaseModel):
     @model_validator(mode="after")
     def _require_accepted_response(self) -> MutationReceipt:
         accepted_values = (self.response_status, self.response_body, self.flow_run_id)
-        if self.state == "accepted" and any(value is None for value in accepted_values):
+        if self.resource == "run" and (self.run_id is None or self.prefect_key is None):
+            msg = "a run mutation receipt requires its run and Prefect identifiers"
+            raise ValueError(msg)
+        if self.resource == "configuration" and any(
+            value is not None for value in (self.run_id, self.prefect_key, self.flow_run_id, self.target_run_id)
+        ):
+            msg = "a configuration mutation receipt cannot carry run or Prefect identifiers"
+            raise ValueError(msg)
+        if self.state == "accepted" and (
+            self.response_status is None
+            or self.response_body is None
+            or (self.resource == "run" and self.flow_run_id is None)
+        ):
             msg = "an accepted mutation receipt requires its status, response, and Prefect flow-run ID"
             raise ValueError(msg)
         if self.state == "reserved" and any(value is not None for value in accepted_values):

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -55,12 +55,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_purpose_attempt
 CREATE TABLE IF NOT EXISTS mutation_receipts (
     receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL,
     operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL,
-    reason TEXT NOT NULL, resource TEXT NOT NULL DEFAULT 'run', run_id TEXT, prefect_key TEXT,
+    reason TEXT NOT NULL, resource_kind TEXT NOT NULL DEFAULT 'run', resource_id TEXT NOT NULL, run_id TEXT, prefect_key TEXT,
     state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
     CHECK (
-        (resource = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL)
-        OR (resource = 'configuration' AND run_id IS NULL AND prefect_key IS NULL AND target_run_id IS NULL AND flow_run_id IS NULL)
+        (resource_kind = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL)
+        OR (resource_kind = 'configuration' AND run_id IS NULL AND prefect_key IS NULL AND target_run_id IS NULL AND flow_run_id IS NULL)
     ),
     UNIQUE (actor, key_digest)
 );
@@ -184,10 +184,10 @@ last_observed_at, position FROM prefect_executions WHERE run_id = ? ORDER BY pos
 _INSERT_PREFECT_EXECUTION = """INSERT INTO prefect_executions (run_id, flow_run_id, deployment_id, purpose, attempt,
 last_observed_state, last_observed_at, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
 _INSERT_MUTATION_RECEIPT = """INSERT INTO mutation_receipts (receipt_id, actor, key_digest, operation,
-target_run_id, request_fingerprint, reason, resource, run_id, prefect_key, state, response_status, response_body,
-flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+target_run_id, request_fingerprint, reason, resource_kind, resource_id, run_id, prefect_key, state, response_status, response_body,
+flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _SELECT_MUTATION_RECEIPT = """SELECT receipt_id, actor, key_digest, operation, target_run_id,
-request_fingerprint, reason, resource, run_id, prefect_key, state, response_status, response_body, flow_run_id,
+request_fingerprint, reason, resource_kind, resource_id, run_id, prefect_key, state, response_status, response_body, flow_run_id,
 created_at, updated_at FROM mutation_receipts WHERE actor = ? AND key_digest = ?"""
 _INSERT_AUDIT_EVENT = """INSERT INTO audit_events (event_id, run_id, actor, operation, reason, outcome, created_at)
 VALUES (?, ?, ?, ?, ?, ?, ?)"""
@@ -413,13 +413,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.execute(f"ALTER TABLE product_runs ADD COLUMN {column} {sql_type}")
 
     def _migrate_mutation_receipts(self, cursor: _Cursor) -> None:
-        """Replace the legacy run-only receipt shape with the nullable resource-aware shape.
-
-        SQLite cannot relax ``NOT NULL`` columns in place.  The additive replacement preserves
-        each legacy row and its write admission, while backfilling ``resource = 'run'``.
-        PostgreSQL accepts the same portable DDL under the provider contract, avoiding a
-        divergent receipt layout between profiles.
-        """
+        """Add resource identity columns and preserve every legacy receipt in place."""
         if self._dialect == "sqlite":
             cursor.execute("PRAGMA table_info(mutation_receipts)")
             columns = frozenset(str(row[1]) for row in cursor.fetchall())
@@ -432,38 +426,27 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 ("mutation_receipts",),
             )
             columns = frozenset(str(row[0]) for row in cursor.fetchall())
-        if "resource" in columns:
-            return
-        cursor.execute("CREATE TABLE mutation_receipts_migration AS SELECT * FROM write_admissions")
-        cursor.execute("DROP TABLE write_admissions")
+        if "resource_kind" not in columns:
+            cursor.execute("ALTER TABLE mutation_receipts ADD COLUMN resource_kind TEXT")
+        if "resource_id" not in columns:
+            cursor.execute("ALTER TABLE mutation_receipts ADD COLUMN resource_id TEXT")
         cursor.execute(
-            "CREATE TABLE mutation_receipts_replacement ("
-            "receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL, "
-            "operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL, "
-            "reason TEXT NOT NULL, resource TEXT NOT NULL, run_id TEXT, prefect_key TEXT, "
-            "state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT, "
-            "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
-            "CHECK ((resource = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL) "
-            "OR (resource = 'configuration' AND run_id IS NULL AND prefect_key IS NULL "
-            "AND target_run_id IS NULL AND flow_run_id IS NULL)), UNIQUE (actor, key_digest))"
+            "UPDATE mutation_receipts SET resource_kind = 'run', resource_id = run_id "
+            "WHERE resource_kind IS NULL OR resource_id IS NULL"
         )
-        cursor.execute(
-            "INSERT INTO mutation_receipts_replacement "
-            "SELECT receipt_id, actor, key_digest, operation, target_run_id, request_fingerprint, reason, "
-            "'run', run_id, prefect_key, state, response_status, response_body, flow_run_id, created_at, updated_at "
-            "FROM mutation_receipts"
-        )
-        cursor.execute("DROP TABLE mutation_receipts")
-        cursor.execute("ALTER TABLE mutation_receipts_replacement RENAME TO mutation_receipts")
-        cursor.execute(
-            "CREATE TABLE write_admissions (run_id TEXT PRIMARY KEY, receipt_id TEXT NOT NULL UNIQUE, operation TEXT NOT NULL, "
-            "FOREIGN KEY (run_id) REFERENCES product_runs(run_id), "
-            "FOREIGN KEY (receipt_id) REFERENCES mutation_receipts(receipt_id))"
-        )
-        cursor.execute(
-            "INSERT INTO write_admissions SELECT run_id, receipt_id, operation FROM mutation_receipts_migration"
-        )
-        cursor.execute("DROP TABLE mutation_receipts_migration")
+        if self._dialect == "sqlite":
+            # SQLite has no ALTER COLUMN.  Editing only the table declaration preserves the
+            # table, rows, indexes, and foreign-key references while making legacy run-only
+            # columns nullable for configuration receipts.
+            cursor.execute("PRAGMA writable_schema = ON")
+            cursor.execute(
+                "UPDATE sqlite_master SET sql = REPLACE(REPLACE(sql, 'run_id TEXT NOT NULL', 'run_id TEXT'), "
+                "'prefect_key TEXT NOT NULL', 'prefect_key TEXT') WHERE type = 'table' AND name = 'mutation_receipts'"
+            )
+            cursor.execute("PRAGMA writable_schema = OFF")
+        else:
+            cursor.execute("ALTER TABLE mutation_receipts ALTER COLUMN run_id DROP NOT NULL")
+            cursor.execute("ALTER TABLE mutation_receipts ALTER COLUMN prefect_key DROP NOT NULL")
 
     def _configuration_binding_constraint_exists(self, cursor: _Cursor) -> bool:
         """Check for the binding safeguard by name instead of attempting and hoping.
@@ -924,7 +907,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.execute(
                     self._sql(
                         "SELECT receipt_id, actor, key_digest, operation, target_run_id, request_fingerprint, "
-                        "reason, resource, run_id, prefect_key, state, response_status, response_body, flow_run_id, "
+                        "reason, resource_kind, resource_id, run_id, prefect_key, state, response_status, response_body, flow_run_id, "
                         "created_at, updated_at FROM mutation_receipts WHERE receipt_id = ?"
                     ),
                     (receipt_id,),
@@ -1783,7 +1766,8 @@ def _receipt_values(receipt: MutationReceipt) -> tuple[Any, ...]:
         receipt.target_run_id,
         receipt.request_fingerprint,
         receipt.reason,
-        receipt.resource,
+        receipt.resource_kind,
+        receipt.resource_id,
         receipt.run_id,
         receipt.prefect_key,
         receipt.state,
@@ -1805,15 +1789,16 @@ def _receipt_from_row(row: Sequence[Any]) -> MutationReceipt:
             "target_run_id": row[4],
             "request_fingerprint": row[5],
             "reason": row[6],
-            "resource": row[7],
-            "run_id": row[8],
-            "prefect_key": row[9],
-            "state": row[10],
-            "response_status": row[11],
-            "response_body": None if row[12] is None else json.loads(row[12]),
-            "flow_run_id": row[13],
-            "created_at": row[14],
-            "updated_at": row[15],
+            "resource_kind": row[7],
+            "resource_id": row[8],
+            "run_id": row[9],
+            "prefect_key": row[10],
+            "state": row[11],
+            "response_status": row[12],
+            "response_body": None if row[13] is None else json.loads(row[13]),
+            "flow_run_id": row[14],
+            "created_at": row[15],
+            "updated_at": row[16],
         }
     )
 

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -55,9 +55,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_purpose_attempt
 CREATE TABLE IF NOT EXISTS mutation_receipts (
     receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL,
     operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL,
-    reason TEXT NOT NULL, run_id TEXT NOT NULL, prefect_key TEXT NOT NULL,
+    reason TEXT NOT NULL, resource TEXT NOT NULL DEFAULT 'run', run_id TEXT, prefect_key TEXT,
     state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+    CHECK (
+        (resource = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL)
+        OR (resource = 'configuration' AND run_id IS NULL AND prefect_key IS NULL AND target_run_id IS NULL AND flow_run_id IS NULL)
+    ),
     UNIQUE (actor, key_digest)
 );
 CREATE TABLE IF NOT EXISTS write_admissions (
@@ -180,10 +184,10 @@ last_observed_at, position FROM prefect_executions WHERE run_id = ? ORDER BY pos
 _INSERT_PREFECT_EXECUTION = """INSERT INTO prefect_executions (run_id, flow_run_id, deployment_id, purpose, attempt,
 last_observed_state, last_observed_at, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
 _INSERT_MUTATION_RECEIPT = """INSERT INTO mutation_receipts (receipt_id, actor, key_digest, operation,
-target_run_id, request_fingerprint, reason, run_id, prefect_key, state, response_status, response_body,
-flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+target_run_id, request_fingerprint, reason, resource, run_id, prefect_key, state, response_status, response_body,
+flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _SELECT_MUTATION_RECEIPT = """SELECT receipt_id, actor, key_digest, operation, target_run_id,
-request_fingerprint, reason, run_id, prefect_key, state, response_status, response_body, flow_run_id,
+request_fingerprint, reason, resource, run_id, prefect_key, state, response_status, response_body, flow_run_id,
 created_at, updated_at FROM mutation_receipts WHERE actor = ? AND key_digest = ?"""
 _INSERT_AUDIT_EVENT = """INSERT INTO audit_events (event_id, run_id, actor, operation, reason, outcome, created_at)
 VALUES (?, ?, ?, ?, ?, ?, ?)"""
@@ -362,6 +366,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                         if statement.strip():
                             cursor.execute(statement)
                     self._migrate_product_runs_columns(cursor)
+                    self._migrate_mutation_receipts(cursor)
                     self._ensure_configuration_binding_constraint(cursor)
                     connection.commit()
                 except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -406,6 +411,59 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         for column, sql_type in _CONFIGURATION_BINDING_COLUMNS:
             if column not in existing:
                 cursor.execute(f"ALTER TABLE product_runs ADD COLUMN {column} {sql_type}")
+
+    def _migrate_mutation_receipts(self, cursor: _Cursor) -> None:
+        """Replace the legacy run-only receipt shape with the nullable resource-aware shape.
+
+        SQLite cannot relax ``NOT NULL`` columns in place.  The additive replacement preserves
+        each legacy row and its write admission, while backfilling ``resource = 'run'``.
+        PostgreSQL accepts the same portable DDL under the provider contract, avoiding a
+        divergent receipt layout between profiles.
+        """
+        if self._dialect == "sqlite":
+            cursor.execute("PRAGMA table_info(mutation_receipts)")
+            columns = frozenset(str(row[1]) for row in cursor.fetchall())
+        else:
+            cursor.execute(
+                self._sql(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = ? AND table_schema = current_schema()"
+                ),
+                ("mutation_receipts",),
+            )
+            columns = frozenset(str(row[0]) for row in cursor.fetchall())
+        if "resource" in columns:
+            return
+        cursor.execute("CREATE TABLE mutation_receipts_migration AS SELECT * FROM write_admissions")
+        cursor.execute("DROP TABLE write_admissions")
+        cursor.execute(
+            "CREATE TABLE mutation_receipts_replacement ("
+            "receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL, "
+            "operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL, "
+            "reason TEXT NOT NULL, resource TEXT NOT NULL, run_id TEXT, prefect_key TEXT, "
+            "state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT, "
+            "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
+            "CHECK ((resource = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL) "
+            "OR (resource = 'configuration' AND run_id IS NULL AND prefect_key IS NULL "
+            "AND target_run_id IS NULL AND flow_run_id IS NULL)), UNIQUE (actor, key_digest))"
+        )
+        cursor.execute(
+            "INSERT INTO mutation_receipts_replacement "
+            "SELECT receipt_id, actor, key_digest, operation, target_run_id, request_fingerprint, reason, "
+            "'run', run_id, prefect_key, state, response_status, response_body, flow_run_id, created_at, updated_at "
+            "FROM mutation_receipts"
+        )
+        cursor.execute("DROP TABLE mutation_receipts")
+        cursor.execute("ALTER TABLE mutation_receipts_replacement RENAME TO mutation_receipts")
+        cursor.execute(
+            "CREATE TABLE write_admissions (run_id TEXT PRIMARY KEY, receipt_id TEXT NOT NULL UNIQUE, operation TEXT NOT NULL, "
+            "FOREIGN KEY (run_id) REFERENCES product_runs(run_id), "
+            "FOREIGN KEY (receipt_id) REFERENCES mutation_receipts(receipt_id))"
+        )
+        cursor.execute(
+            "INSERT INTO write_admissions SELECT run_id, receipt_id, operation FROM mutation_receipts_migration"
+        )
+        cursor.execute("DROP TABLE mutation_receipts_migration")
 
     def _configuration_binding_constraint_exists(self, cursor: _Cursor) -> bool:
         """Check for the binding safeguard by name instead of attempting and hoping.
@@ -864,7 +922,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.execute(
                     self._sql(
                         "SELECT receipt_id, actor, key_digest, operation, target_run_id, request_fingerprint, "
-                        "reason, run_id, prefect_key, state, response_status, response_body, flow_run_id, "
+                        "reason, resource, run_id, prefect_key, state, response_status, response_body, flow_run_id, "
                         "created_at, updated_at FROM mutation_receipts WHERE receipt_id = ?"
                     ),
                     (receipt_id,),
@@ -1723,6 +1781,7 @@ def _receipt_values(receipt: MutationReceipt) -> tuple[Any, ...]:
         receipt.target_run_id,
         receipt.request_fingerprint,
         receipt.reason,
+        receipt.resource,
         receipt.run_id,
         receipt.prefect_key,
         receipt.state,
@@ -1744,14 +1803,15 @@ def _receipt_from_row(row: Sequence[Any]) -> MutationReceipt:
             "target_run_id": row[4],
             "request_fingerprint": row[5],
             "reason": row[6],
-            "run_id": row[7],
-            "prefect_key": row[8],
-            "state": row[9],
-            "response_status": row[10],
-            "response_body": None if row[11] is None else json.loads(row[11]),
-            "flow_run_id": row[12],
-            "created_at": row[13],
-            "updated_at": row[14],
+            "resource": row[7],
+            "run_id": row[8],
+            "prefect_key": row[9],
+            "state": row[10],
+            "response_status": row[11],
+            "response_body": None if row[12] is None else json.loads(row[12]),
+            "flow_run_id": row[13],
+            "created_at": row[14],
+            "updated_at": row[15],
         }
     )
 

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -833,9 +833,11 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     existing = self.lookup_mutation(receipt.actor, receipt.key_digest)
                     if existing.value is not None:
                         return existing.value, False
-                    if admit_write and self._write_admission_exists(receipt.run_id):
-                        msg = f"Sync run {receipt.run_id!r} already has a write-capable admission"
-                        raise WriteAdmissionConflictError(msg) from exc
+                    if admit_write:
+                        assert receipt.run_id is not None
+                        if self._write_admission_exists(receipt.run_id):
+                            msg = f"Sync run {receipt.run_id!r} already has a write-capable admission"
+                            raise WriteAdmissionConflictError(msg) from exc
                     if run is not None and self.exists(run.run_id):
                         msg = f"Sync run ID {run.run_id!r} already exists"
                         raise DuplicateRunError(msg) from exc
@@ -1519,7 +1521,7 @@ class ProductProjection:
         *,
         response_status: int,
         response_body: Mapping[str, Any],
-        flow_run_id: str,
+        flow_run_id: str | None,
         secrets: Sequence[str] = (),
     ) -> MutationReceipt:
         """Persist the exact accepted HTTP response and Prefect identity."""

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -58,10 +58,6 @@ CREATE TABLE IF NOT EXISTS mutation_receipts (
     reason TEXT NOT NULL, resource_kind TEXT NOT NULL DEFAULT 'run', resource_id TEXT NOT NULL, run_id TEXT, prefect_key TEXT,
     state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT,
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
-    CHECK (
-        (resource_kind = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL)
-        OR (resource_kind = 'configuration' AND run_id IS NULL AND prefect_key IS NULL AND target_run_id IS NULL AND flow_run_id IS NULL)
-    ),
     UNIQUE (actor, key_digest)
 );
 CREATE TABLE IF NOT EXISTS write_admissions (
@@ -105,6 +101,33 @@ _CONFIGURATION_BINDING_CONSTRAINT = "product_runs_configuration_binding_consiste
 _CONFIGURATION_BINDING_CHECK_EXPRESSION = (
     "(config_id IS NULL AND registry_version IS NULL AND package_checksum IS NULL) "
     "OR (config_id IS NOT NULL AND registry_version IS NOT NULL AND package_checksum IS NOT NULL)"
+)
+_SQLITE_MUTATION_RECEIPT_RESOURCE_TRIGGER_NAMES = (
+    "mutation_receipts_resource_consistent_insert",
+    "mutation_receipts_resource_consistent_update",
+)
+_SQLITE_MUTATION_RECEIPT_RESOURCE_CHECK = """NOT (
+    (NEW.resource_kind = 'run' AND NEW.run_id IS NOT NULL AND NEW.prefect_key IS NOT NULL)
+    OR (NEW.resource_kind IN ('configuration', 'configuration-registry') AND NEW.run_id IS NULL
+        AND NEW.prefect_key IS NULL AND NEW.target_run_id IS NULL AND NEW.flow_run_id IS NULL)
+)"""
+_SQLITE_MUTATION_RECEIPT_RESOURCE_INSERT_TRIGGER = f"""
+CREATE TRIGGER {_SQLITE_MUTATION_RECEIPT_RESOURCE_TRIGGER_NAMES[0]}
+BEFORE INSERT ON mutation_receipts
+FOR EACH ROW WHEN {_SQLITE_MUTATION_RECEIPT_RESOURCE_CHECK}
+BEGIN SELECT RAISE(ABORT, 'mutation receipt resource identity is inconsistent'); END;
+"""
+_SQLITE_MUTATION_RECEIPT_RESOURCE_UPDATE_TRIGGER = f"""
+CREATE TRIGGER {_SQLITE_MUTATION_RECEIPT_RESOURCE_TRIGGER_NAMES[1]}
+BEFORE UPDATE ON mutation_receipts
+FOR EACH ROW WHEN {_SQLITE_MUTATION_RECEIPT_RESOURCE_CHECK}
+BEGIN SELECT RAISE(ABORT, 'mutation receipt resource identity is inconsistent'); END;
+"""
+_MUTATION_RECEIPT_RESOURCE_CONSTRAINT = "mutation_receipts_resource_consistent"
+_MUTATION_RECEIPT_RESOURCE_CHECK = (
+    "(resource_kind = 'run' AND run_id IS NOT NULL AND prefect_key IS NOT NULL) OR "
+    "(resource_kind IN ('configuration', 'configuration-registry') AND run_id IS NULL "
+    "AND prefect_key IS NULL AND target_run_id IS NULL AND flow_run_id IS NULL)"
 )
 _SQLITE_CONFIGURATION_BINDING_INSERT_TRIGGER_NAME = "product_runs_configuration_binding_insert"
 _SQLITE_CONFIGURATION_BINDING_UPDATE_TRIGGER_NAME = "product_runs_configuration_binding_update"
@@ -297,6 +320,10 @@ class _RunStore(Protocol):  # pylint: disable=too-many-public-methods
         updated_at: datetime,
     ) -> MutationReceipt: ...
 
+    def claim_mutation(self, receipt_id: str, *, updated_at: datetime) -> bool: ...
+
+    def release_mutation(self, receipt_id: str, *, updated_at: datetime) -> None: ...
+
     def record_audit(self, event: AuditEvent) -> None: ...
 
     def audit_events(self, run_id: str | None = None) -> tuple[AuditEvent, ...]: ...
@@ -367,6 +394,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                             cursor.execute(statement)
                     self._migrate_product_runs_columns(cursor)
                     self._migrate_mutation_receipts(cursor)
+                    self._ensure_mutation_receipt_resource_constraint(cursor)
                     self._ensure_configuration_binding_constraint(cursor)
                     connection.commit()
                 except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -435,9 +463,10 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
             "WHERE resource_kind IS NULL OR resource_id IS NULL"
         )
         if self._dialect == "sqlite":
-            # SQLite has no ALTER COLUMN.  Editing only the table declaration preserves the
-            # table, rows, indexes, and foreign-key references while making legacy run-only
-            # columns nullable for configuration receipts.
+            # SQLite has no supported additive ALTER that removes NOT NULL. The table has a
+            # fixed, repository-owned legacy shape and a rebuild would also reconstruct the
+            # dependent write_admissions foreign key. Updating these two declarations is the
+            # only in-place migration that preserves rows, indexes, and references.
             cursor.execute("PRAGMA writable_schema = ON")
             cursor.execute(
                 "UPDATE sqlite_master SET sql = REPLACE(REPLACE(sql, 'run_id TEXT NOT NULL', 'run_id TEXT'), "
@@ -447,6 +476,35 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         else:
             cursor.execute("ALTER TABLE mutation_receipts ALTER COLUMN run_id DROP NOT NULL")
             cursor.execute("ALTER TABLE mutation_receipts ALTER COLUMN prefect_key DROP NOT NULL")
+
+    def _mutation_receipt_resource_constraint_exists(self, cursor: _Cursor) -> bool:
+        if self._dialect == "sqlite":
+            cursor.execute(
+                self._sql("SELECT name FROM sqlite_master WHERE type = 'trigger' AND name IN (?, ?)"),
+                _SQLITE_MUTATION_RECEIPT_RESOURCE_TRIGGER_NAMES,
+            )
+            return {str(row[0]) for row in cursor.fetchall()} >= set(_SQLITE_MUTATION_RECEIPT_RESOURCE_TRIGGER_NAMES)
+        cursor.execute(
+            self._sql(
+                "SELECT 1 FROM information_schema.table_constraints "
+                "WHERE table_name = ? AND constraint_name = ? AND table_schema = current_schema()"
+            ),
+            ("mutation_receipts", _MUTATION_RECEIPT_RESOURCE_CONSTRAINT),
+        )
+        return cursor.fetchone() is not None
+
+    def _ensure_mutation_receipt_resource_constraint(self, cursor: _Cursor) -> None:
+        """Give fresh and legacy receipts the same database-enforced resource shape."""
+        if self._mutation_receipt_resource_constraint_exists(cursor):
+            return
+        if self._dialect == "sqlite":
+            cursor.execute(_SQLITE_MUTATION_RECEIPT_RESOURCE_INSERT_TRIGGER)
+            cursor.execute(_SQLITE_MUTATION_RECEIPT_RESOURCE_UPDATE_TRIGGER)
+        else:
+            cursor.execute(
+                f"ALTER TABLE mutation_receipts ADD CONSTRAINT {_MUTATION_RECEIPT_RESOURCE_CONSTRAINT} "
+                f"CHECK ({_MUTATION_RECEIPT_RESOURCE_CHECK})"
+            )
 
     def _configuration_binding_constraint_exists(self, cursor: _Cursor) -> bool:
         """Check for the binding safeguard by name instead of attempting and hoping.
@@ -874,7 +932,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.execute(
                     self._sql(
                         "UPDATE mutation_receipts SET state = 'accepted', response_status = ?, response_body = ?, "
-                        "flow_run_id = ?, updated_at = ? WHERE receipt_id = ? AND state = 'reserved'"
+                        "flow_run_id = ?, updated_at = ? WHERE receipt_id = ? AND state IN ('reserved', 'processing')"
                     ),
                     (response_status, _json(response_body), flow_run_id, updated_at.isoformat(), receipt_id),
                 )
@@ -898,6 +956,52 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
             return receipt
         msg = f"Mutation receipt {receipt_id!r} is already complete with a different response"
         raise ValueError(msg)
+
+    def claim_mutation(self, receipt_id: str, *, updated_at: datetime) -> bool:
+        """Claim one retryable receipt before its service call begins."""
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(
+                        "UPDATE mutation_receipts SET state = 'processing', updated_at = ? "
+                        "WHERE receipt_id = ? AND state = 'reserved'"
+                    ),
+                    (updated_at.isoformat(), receipt_id),
+                )
+                claimed = cursor.rowcount == 1
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
+        return claimed
+
+    def release_mutation(self, receipt_id: str, *, updated_at: datetime) -> None:
+        """Return an unsuccessful in-flight receipt to retryable reservation state."""
+        connection = self._connect()
+        try:
+            cursor = connection.cursor()
+            try:
+                cursor.execute(
+                    self._sql(
+                        "UPDATE mutation_receipts SET state = 'reserved', updated_at = ? "
+                        "WHERE receipt_id = ? AND state = 'processing'"
+                    ),
+                    (updated_at.isoformat(), receipt_id),
+                )
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+        finally:
+            connection.close()
 
     def _lookup_mutation_by_id(self, receipt_id: str) -> MutationReceipt:
         connection = self._connect()
@@ -1421,7 +1525,7 @@ class S3ArtifactStore:
         return _validate_publication(reference, manifest, data)
 
 
-class ProductProjection:
+class ProductProjection:  # pylint: disable=too-many-public-methods
     """One product-record contract over interchangeable relational/object providers."""
 
     def __init__(self, records: _RunStore, artifacts: _ArtifactStore) -> None:
@@ -1516,6 +1620,14 @@ class ProductProjection:
             flow_run_id=None if flow_run_id is None else redact(flow_run_id, secrets),
             updated_at=datetime.now(timezone.utc),
         )
+
+    def claim_mutation(self, receipt_id: str, *, secrets: Sequence[str] = ()) -> bool:
+        """Atomically make one retryable receipt the sole in-flight service caller."""
+        return self._records.claim_mutation(redact(receipt_id, secrets), updated_at=datetime.now(timezone.utc))
+
+    def release_mutation(self, receipt_id: str, *, secrets: Sequence[str] = ()) -> None:
+        """Make a failed in-flight receipt available for a later retry."""
+        self._records.release_mutation(redact(receipt_id, secrets), updated_at=datetime.now(timezone.utc))
 
     def record_audit(self, event: AuditEvent, *, secrets: Sequence[str] = ()) -> None:
         """Append one immutable, secret-safe authorization or mutation event."""

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -293,7 +293,7 @@ class _RunStore(Protocol):  # pylint: disable=too-many-public-methods
         *,
         response_status: int,
         response_body: Mapping[str, Any],
-        flow_run_id: str,
+        flow_run_id: str | None,
         updated_at: datetime,
     ) -> MutationReceipt: ...
 
@@ -879,7 +879,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         *,
         response_status: int,
         response_body: Mapping[str, Any],
-        flow_run_id: str,
+        flow_run_id: str | None,
         updated_at: datetime,
     ) -> MutationReceipt:
         connection = self._connect()
@@ -1528,7 +1528,7 @@ class ProductProjection:
             redact(receipt_id, secrets),
             response_status=response_status,
             response_body=sanitized,
-            flow_run_id=redact(flow_run_id, secrets),
+            flow_run_id=None if flow_run_id is None else redact(flow_run_id, secrets),
             updated_at=datetime.now(timezone.utc),
         )
 

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from fastapi.testclient import TestClient
 
+from infrahub_sync.configuration.models import ValidationFinding
 from infrahub_sync.managed.app import create_app
 from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
 from infrahub_sync.managed.config_routes import ConfigurationAPIError, ConfigurationRoutes
@@ -19,6 +20,7 @@ from infrahub_sync.managed.serve import build_app
 from infrahub_sync.managed.service import ManagedRunService
 from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
+from infrahub_sync.product_store.configs import ValidationReport
 from tests.configuration.validation_packages import package_data
 
 if TYPE_CHECKING:
@@ -153,6 +155,131 @@ def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
     )
     assert projection.list_configurations() == ()
     assert [event.outcome for event in projection.audit_events()] == ["refused-authentication", "refused-authorization"]
+
+
+def test_configuration_route_grammar_refuses_hostile_values_before_service_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Path, page, and body grammar failures use the fixed request envelope without a service call."""
+    token = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def list_configs(self, **_kwargs: object) -> list[object]:
+            self.calls.append("list_configs")
+            return []
+
+        def list_versions(self, **_kwargs: object) -> list[object]:
+            self.calls.append("list_versions")
+            return []
+
+        def get_version(self, **_kwargs: object) -> object:
+            self.calls.append("get_version")
+            return {}
+
+        def validate(self, **_kwargs: object) -> object:
+            self.calls.append("validate")
+            return {}
+
+        def create_version(self, **_kwargs: object) -> object:
+            self.calls.append("create_version")
+            return {}
+
+        def register(self, **_kwargs: object) -> object:
+            self.calls.append("register")
+            return {}
+
+    service = Service()
+    client = TestClient(
+        create_app(
+            ManagedRunService(local_product_projection(tmp_path), _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, service=service, secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": "grammar-key"}
+    probes = [
+        ("post", "/configs", {"json": {"package": package_data(), "reason": "valid", "extra": True}}),
+        ("get", "/configs?offset=true", {}),
+        ("get", "/configs?limit=257", {}),
+        ("get", "/configs/not%20an%20id", {}),
+        ("get", "/configs/good/versions/true", {}),
+        ("get", "/configs/good/versions/0", {}),
+        ("post", "/configs/good/versions/1/validate?limit=true", {}),
+    ]
+    for method, path, kwargs in probes:
+        response = getattr(client, method)(path, headers=headers, **kwargs)
+        assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "request-invalid",
+                "message": "the request does not match the API schema",
+                "status": 422,
+                "run_id": None,
+                "mutation_id": None,
+            }
+        }
+    assert service.calls == []
+
+
+def test_validation_pages_are_bounded_and_concatenate_to_the_single_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pages slice one ordered validation report without changing its snapshot fields."""
+    token = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    findings = tuple(
+        ValidationFinding(code="synthetic", severity="error", location=f"/item{i}", message=f"finding {i}")
+        for i in range(600)
+    )
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def validate(**_kwargs: object) -> ValidationReport:
+            return ValidationReport("cfg", 1, "a" * 64, findings, "b" * 64)
+
+    client = TestClient(
+        create_app(
+            ManagedRunService(local_product_projection(tmp_path), _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, service=Service(), secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    pages = [
+        client.post(f"/configs/cfg/versions/1/validate?offset={offset}&limit=256", headers=headers).json()
+        for offset in range(0, 600, 256)
+    ]
+    assert all(len(page["findings"]) <= 256 for page in pages)
+    assert [page["findings"] for page in pages] == [
+        [finding.model_dump(mode="json") for finding in findings[:256]],
+        [finding.model_dump(mode="json") for finding in findings[256:512]],
+        [finding.model_dump(mode="json") for finding in findings[512:]],
+    ]
+    assert all(
+        {key: value for key, value in page.items() if key != "findings"}
+        == {"config_id": "cfg", "registry_version": 1, "package_checksum": "a" * 64, "destination_schema_fingerprint": "b" * 64}
+        for page in pages
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -374,9 +374,49 @@ def test_validation_pages_are_bounded_and_concatenate_to_the_single_snapshot(
             "registry_version": 1,
             "package_checksum": "a" * 64,
             "destination_schema_fingerprint": "b" * 64,
+            "offset": [0, 256, 512][pages.index(page)],
+            "limit": 256,
+            "total_findings": 600,
+            "next_offset": [256, 512, None][pages.index(page)],
         }
         for page in pages
     )
+
+
+def test_configuration_and_version_lists_return_every_service_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only validation findings paginate; registry lists keep all service records."""
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def list_configs(**_kwargs: object) -> list[dict[str, int]]:
+            return [{"position": position} for position in range(300)]
+
+        @staticmethod
+        def list_versions(**_kwargs: object) -> list[dict[str, int]]:
+            return [{"position": position} for position in range(300)]
+
+    client = TestClient(
+        create_app(
+            ManagedRunService(local_product_projection(tmp_path), _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, service=Service(), secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": f"Bearer {bearer}"}
+    assert len(client.get("/configs", headers=headers).json()) == 300
+    assert len(client.get("/configs/cfg/versions", headers=headers).json()) == 300
 
 
 @pytest.mark.parametrize(
@@ -573,6 +613,8 @@ def test_build_app_binds_one_cache_location_and_passes_configuration_dependency(
 
     monkeypatch.setenv(PRODUCT_CACHE_ENV, str(tmp_path))
     received: list[object] = []
+    route_locations: list[Path] = []
+    route_dependency = object()
 
     def projection(location: Path) -> object:
         received.append(location)
@@ -580,6 +622,11 @@ def test_build_app_binds_one_cache_location_and_passes_configuration_dependency(
 
     class Resolver:
         secret_values: tuple[str, ...] = ()
+
+    def route_factory(location: Path, *, secrets: tuple[str, ...]) -> object:
+        assert secrets == ()
+        route_locations.append(location)
+        return route_dependency
 
     def application(run: object, resolver: object, routes: object) -> object:
         received.extend((run, resolver, routes))
@@ -590,8 +637,11 @@ def test_build_app_binds_one_cache_location_and_passes_configuration_dependency(
             projection_factory=projection,
             resolver_factory=Resolver,
             run_service_factory=lambda *_args, **_kwargs: object(),
+            configuration_routes_factory=route_factory,
             app_factory=application,
         )
         is not None
     )
     assert received[0] == tmp_path
+    assert route_locations == [tmp_path]
+    assert received[-1] is route_dependency

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from infrahub_sync.managed.app import create_app
@@ -12,6 +14,7 @@ from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResol
 from infrahub_sync.managed.config_routes import ConfigurationRoutes
 from infrahub_sync.managed.orchestration import Observation, Submission
 from infrahub_sync.managed.service import ManagedRunService
+from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
 from tests.configuration.validation_packages import package_data
 
@@ -49,3 +52,87 @@ def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: ob
         client.get(f"/configs/{config_id}", headers={"Authorization": "Bearer admin-token-canary-0003"}).status_code
         == 200
     )
+
+
+@pytest.mark.parametrize(
+    ("failure", "status", "family", "reason"),
+    [
+        (configs_service.ConfigsRequestError("hostile"), 400, "request", None),
+        (configs_service.ConfigsValidationError("hostile"), 422, "validation", None),
+        (
+            configs_service.ConfigsNotFoundError("hostile", reason="configuration-not-found"),
+            404,
+            "not-found",
+            "configuration-not-found",
+        ),
+        (
+            configs_service.ConfigsNotFoundError("hostile", reason="configuration-version-not-found"),
+            404,
+            "not-found",
+            "configuration-version-not-found",
+        ),
+        (configs_service.ConfigsStorageError("hostile"), 503, "storage", None),
+        (configs_service.ConfigsInternalError("hostile"), 503, "internal", None),
+        (configs_service.ConfigsError("hostile"), 503, "configs", None),
+        (AssertionError("hostile"), 503, "internal", None),
+    ],
+)
+def test_configuration_error_matrix_preserves_only_declared_fields(  # noqa: PLR0913, PLR0917
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+    status: int,
+    family: str,
+    reason: str | None,
+) -> None:
+    """Each shared-service failure maps to the fixed configuration envelope."""
+    monkeypatch.setenv(
+        PRINCIPALS_ENV, json.dumps({"admin": {"token": "admin-token-canary-0003", "administrator": True}})
+    )
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    runs = ManagedRunService(local_product_projection(tmp_path), _Orchestration(), secrets=resolver.secret_values)
+    routes = ConfigurationRoutes(tmp_path)
+
+    def fail(**_kwargs: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(configs_service, "list_configs", fail)
+    response = TestClient(create_app(runs, resolver, routes)).get(
+        "/configs", headers={"Authorization": "Bearer admin-token-canary-0003"}
+    )
+    assert response.status_code == status
+    assert response.json()["error"]["family"] == family
+    assert response.json()["error"].get("reason") == reason
+
+
+def test_configuration_routes_do_not_import_storage_or_validation_internals() -> None:
+    """The HTTP adapter depends only on the shared service facade."""
+    source = Path(__file__).parents[2] / "infrahub_sync" / "managed" / "config_routes.py"
+    imports = [
+        node.module or "" for node in ast.walk(ast.parse(source.read_text())) if isinstance(node, ast.ImportFrom)
+    ]
+    assert all("product_store.store" not in module and "configuration.validation" not in module for module in imports)
+
+
+def test_unknown_configs_subclass_uses_fixed_base_family(tmp_path: Path) -> None:
+    """An extension refusal cannot influence the public family or message."""
+
+    class Hostile(configs_service.ConfigsError):
+        family = property(lambda _self: (_ for _ in ()).throw(AssertionError("metadata read")))
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def list_configs(**_kwargs: object) -> None:
+            message = "do not disclose"
+            raise Hostile(message)
+
+    with pytest.raises(Exception) as raised:
+        ConfigurationRoutes(tmp_path, service=Service()).list_configs()
+    assert raised.value.family == "configs"

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -98,8 +98,8 @@ def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Every mutation decision is durable evidence and contains no bearer secret."""
-    token = "admin-token-canary-0003"
-    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
     resolver = EnvironmentPrincipalResolver.from_environment()
     projection = local_product_projection(tmp_path)
     client = TestClient(
@@ -109,7 +109,7 @@ def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency
             ConfigurationRoutes(tmp_path, secrets=resolver.secret_values),
         )
     )
-    headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": "audit-once"}
+    headers = {"Authorization": f"Bearer {bearer}", "Idempotency-Key": "audit-once"}
     body = {"package": package_data(), "reason": "register audit proof"}
 
     assert client.post("/configs", headers=headers, json=body).status_code == 201
@@ -118,7 +118,7 @@ def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency
 
     events = projection.audit_events()
     assert [event.outcome for event in events] == ["accepted", "replayed", "refused-idempotency"]
-    assert all(token not in event.model_dump_json() for event in events)
+    assert all(bearer not in event.model_dump_json() for event in events)
 
 
 def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
@@ -161,8 +161,8 @@ def test_configuration_route_grammar_refuses_hostile_values_before_service_class
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Path, page, and body grammar failures use the fixed request envelope without a service call."""
-    token = "admin-token-canary-0003"
-    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
     resolver = EnvironmentPrincipalResolver.from_environment()
 
     class Service:
@@ -208,7 +208,7 @@ def test_configuration_route_grammar_refuses_hostile_values_before_service_class
             ConfigurationRoutes(tmp_path, service=service, secrets=resolver.secret_values),
         )
     )
-    headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": "grammar-key"}
+    headers = {"Authorization": f"Bearer {bearer}", "Idempotency-Key": "grammar-key"}
     probes = [
         ("post", "/configs", {"json": {"package": package_data(), "reason": "valid", "extra": True}}),
         ("get", "/configs?offset=true", {}),
@@ -237,8 +237,8 @@ def test_validation_pages_are_bounded_and_concatenate_to_the_single_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Pages slice one ordered validation report without changing its snapshot fields."""
-    token = "admin-token-canary-0003"
-    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
     resolver = EnvironmentPrincipalResolver.from_environment()
     findings = tuple(
         ValidationFinding(code="synthetic", severity="error", location=f"/item{i}", message=f"finding {i}")
@@ -264,7 +264,7 @@ def test_validation_pages_are_bounded_and_concatenate_to_the_single_snapshot(
             ConfigurationRoutes(tmp_path, service=Service(), secrets=resolver.secret_values),
         )
     )
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {"Authorization": f"Bearer {bearer}"}
     pages = [
         client.post(f"/configs/cfg/versions/1/validate?offset={offset}&limit=256", headers=headers).json()
         for offset in range(0, 600, 256)
@@ -277,7 +277,12 @@ def test_validation_pages_are_bounded_and_concatenate_to_the_single_snapshot(
     ]
     assert all(
         {key: value for key, value in page.items() if key != "findings"}
-        == {"config_id": "cfg", "registry_version": 1, "package_checksum": "a" * 64, "destination_schema_fingerprint": "b" * 64}
+        == {
+            "config_id": "cfg",
+            "registry_version": 1,
+            "package_checksum": "a" * 64,
+            "destination_schema_fingerprint": "b" * 64,
+        }
         for page in pages
     )
 

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -157,6 +157,54 @@ def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency
     assert all(bearer not in event.model_dump_json() for event in events)
 
 
+def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configuration service outage leaves no unaudited reservation behind."""
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def register(self, **_kwargs: object) -> dict[str, object]:
+            self.calls += 1
+            if self.calls == 1:
+                raise self.ConfigsStorageError("transient service failure")
+            return {"configuration": {"config_id": "cfg"}, "version": {"registry_version": 1}}
+
+    projection = local_product_projection(tmp_path)
+    service = Service()
+    client = TestClient(
+        create_app(
+            ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, service=service, secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": f"Bearer {bearer}", "Idempotency-Key": "retry-after-service-failure"}
+    body = {"package": package_data(), "reason": "retry after outage"}
+
+    refused = client.post("/configs", headers=headers, json=body)
+    reserved = projection.lookup_mutation("admin", sha256(headers["Idempotency-Key"].encode()).hexdigest()).value
+    retried = client.post("/configs", headers=headers, json=body)
+
+    assert refused.status_code == 503
+    assert reserved is not None and reserved.state == "reserved"
+    assert retried.status_code == 201
+    assert service.calls == 2
+    assert [event.outcome for event in projection.audit_events()] == ["unavailable", "accepted"]
+
+
 def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -302,9 +302,11 @@ def test_configuration_route_grammar_refuses_hostile_values_before_service_class
         ("post", "/configs", {"content": '{"package":{"nested":[NaN]},"reason":"valid"}'}),
         ("post", "/configs", {"json": {"package": package_data(), "reason": "invalid\nreason"}}),
         ("get", "/configs?offset=true", {}),
+        ("get", "/configs?offset=1.0", {}),
         ("get", "/configs?limit=257", {}),
         ("get", "/configs/not%20an%20id", {}),
         ("get", "/configs/good/versions/true", {}),
+        ("get", "/configs/good/versions/1.0", {}),
         ("get", "/configs/good/versions/0", {}),
         ("post", "/configs/good/versions/1/validate?limit=true", {}),
     ]

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -92,6 +92,33 @@ def test_configuration_mutation_replays_exact_response_and_rejects_changed_conte
     assert receipt.value.state == "accepted"
 
 
+def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency_without_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every mutation decision is durable evidence and contains no bearer secret."""
+    token = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": token, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path)
+    client = TestClient(
+        create_app(
+            ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": "audit-once"}
+    body = {"package": package_data(), "reason": "register audit proof"}
+
+    assert client.post("/configs", headers=headers, json=body).status_code == 201
+    assert client.post("/configs", headers=headers, json=body).status_code == 201
+    assert client.post("/configs", headers=headers, json={**body, "reason": "changed audit proof"}).status_code == 409
+
+    events = projection.audit_events()
+    assert [event.outcome for event in events] == ["accepted", "replayed", "refused-idempotency"]
+    assert all(token not in event.model_dump_json() for event in events)
+
+
 def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import json
+from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -86,8 +87,9 @@ def test_configuration_mutation_replays_exact_response_and_rejects_changed_conte
     assert replay.json() == first.json()
     assert changed.status_code == 409
     assert len(projection.list_configurations()) == 1
-    receipt = projection.lookup_mutation("admin", __import__("hashlib").sha256(b"register-once").hexdigest())
-    assert receipt.value is not None and receipt.value.state == "accepted"
+    receipt = projection.lookup_mutation("admin", sha256(b"register-once").hexdigest())
+    assert receipt.value is not None
+    assert receipt.value.state == "accepted"
 
 
 def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -179,7 +179,7 @@ def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_r
         def register(self, **_kwargs: object) -> dict[str, object]:
             self.calls += 1
             if self.calls == 1:
-                raise self.ConfigsStorageError("transient service failure")
+                raise self.ConfigsStorageError("transient service failure")  # noqa: EM101, TRY003
             return {"configuration": {"config_id": "cfg"}, "version": {"registry_version": 1}}
 
     projection = local_product_projection(tmp_path)
@@ -199,7 +199,8 @@ def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_r
     retried = client.post("/configs", headers=headers, json=body)
 
     assert refused.status_code == 503
-    assert reserved is not None and reserved.state == "reserved"
+    assert reserved is not None
+    assert reserved.state == "reserved"
     assert retried.status_code == 201
     assert service.calls == 2
     assert [event.outcome for event in projection.audit_events()] == ["unavailable", "accepted"]
@@ -519,7 +520,7 @@ def test_configs_request_subclass_uses_base_fallback_without_reflecting_metadata
 
         @staticmethod
         def list_configs(**_kwargs: object) -> None:
-            raise Hostile("do not disclose")
+            raise Hostile("do not disclose")  # noqa: EM101, TRY003
 
     with pytest.raises(ConfigurationAPIError) as raised:
         ConfigurationRoutes(tmp_path, service=Service()).list_configs()
@@ -545,7 +546,7 @@ def test_configs_not_found_subclass_cannot_leak_reason(tmp_path: Path) -> None:
 
         @staticmethod
         def list_configs(**_kwargs: object) -> None:
-            raise Hostile("do not disclose", reason="secret-reason")
+            raise Hostile("do not disclose", reason="secret-reason")  # noqa: EM101, TRY003
 
     with pytest.raises(ConfigurationAPIError) as raised:
         ConfigurationRoutes(tmp_path, service=Service()).list_configs()

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -377,6 +377,57 @@ def test_unknown_configs_subclass_uses_fixed_base_family(tmp_path: Path) -> None
     assert raised.value.family == "configs"
 
 
+def test_configs_request_subclass_uses_base_fallback_without_reflecting_metadata(tmp_path: Path) -> None:
+    """Only the exact shared refusal classes receive a public family."""
+
+    class Hostile(configs_service.ConfigsRequestError):
+        message = property(lambda _self: (_ for _ in ()).throw(AssertionError("message read")))
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def list_configs(**_kwargs: object) -> None:
+            raise Hostile("do not disclose")
+
+    with pytest.raises(ConfigurationAPIError) as raised:
+        ConfigurationRoutes(tmp_path, service=Service()).list_configs()
+    assert raised.value.status == 503
+    assert raised.value.family == "configs"
+
+
+def test_configs_not_found_subclass_cannot_leak_reason(tmp_path: Path) -> None:
+    """A not-found extension gets the fixed base response without its reason property."""
+
+    class Hostile(configs_service.ConfigsNotFoundError):
+        reason = property(
+            lambda _self: (_ for _ in ()).throw(AssertionError("reason read")), lambda _self, _value: None
+        )
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def list_configs(**_kwargs: object) -> None:
+            raise Hostile("do not disclose", reason="secret-reason")
+
+    with pytest.raises(ConfigurationAPIError) as raised:
+        ConfigurationRoutes(tmp_path, service=Service()).list_configs()
+    assert raised.value.status == 503
+    assert raised.value.family == "configs"
+    assert raised.value.reason is None
+
+
 def test_create_app_keeps_run_and_configuration_dependencies_separate(tmp_path: Path) -> None:
     """One route from each family touches only its explicitly supplied dependency."""
 

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -90,6 +90,42 @@ def test_configuration_mutation_replays_exact_response_and_rejects_changed_conte
     assert receipt.value is not None and receipt.value.state == "accepted"
 
 
+def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Authorization refusal occurs before configuration reservation or service invocation."""
+    monkeypatch.setenv(
+        PRINCIPALS_ENV,
+        json.dumps(
+            {
+                "admin": {"token": "admin-token-canary-0003", "administrator": True},
+                "reader": {"token": "reader-token-canary-0002", "administrator": False},
+            }
+        ),
+    )
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path)
+    client = TestClient(
+        create_app(
+            ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, secrets=resolver.secret_values),
+        )
+    )
+    body = {"package": package_data(), "reason": "register this package"}
+    assert client.post("/configs", headers={"Idempotency-Key": "missing-key"}, json=body).status_code == 401
+    assert (
+        client.post(
+            "/configs",
+            headers={"Authorization": "Bearer reader-token-canary-0002", "Idempotency-Key": "reader-key"},
+            json=body,
+        ).status_code
+        == 403
+    )
+    assert projection.list_configurations() == ()
+    assert [event.outcome for event in projection.audit_events()] == ["refused-authentication", "refused-authorization"]
+
+
 @pytest.mark.parametrize(
     ("failure", "status", "family", "reason"),
     [

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -13,6 +13,7 @@ from infrahub_sync.managed.app import create_app
 from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
 from infrahub_sync.managed.config_routes import ConfigurationRoutes
 from infrahub_sync.managed.orchestration import Observation, Submission
+from infrahub_sync.managed.serve import build_app
 from infrahub_sync.managed.service import ManagedRunService
 from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
@@ -136,3 +137,80 @@ def test_unknown_configs_subclass_uses_fixed_base_family(tmp_path: Path) -> None
     with pytest.raises(Exception) as raised:
         ConfigurationRoutes(tmp_path, service=Service()).list_configs()
     assert raised.value.family == "configs"
+
+
+def test_create_app_keeps_run_and_configuration_dependencies_separate(tmp_path: Path) -> None:
+    """One route from each family touches only its explicitly supplied dependency."""
+
+    class Runs:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        @staticmethod
+        def record_authentication_refusal(_path: str, _reason: str) -> None:
+            return None
+
+        def get_artifact(self, run_id: str, artifact_id: str) -> tuple[bytes, str, str]:
+            self.calls.append(run_id)
+            return (artifact_id.encode(), "text/plain", "a" * 64)
+
+    class ConfigService:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def list_configs(self, **_kwargs: object) -> list[dict[str, str]]:
+            self.calls.append("list_configs")
+            return []
+
+    class Resolver:
+        @staticmethod
+        def resolve(_token: str) -> object:
+            return type("Principal", (), {"administrator": True})()
+
+    runs = Runs()
+    config_service = ConfigService()
+    client = TestClient(create_app(runs, Resolver(), ConfigurationRoutes(tmp_path, service=config_service)))
+    headers = {"Authorization": "Bearer accepted"}
+    assert client.get("/runs/run-a/artifacts/one", headers=headers).status_code == 200
+    assert client.get("/configs", headers=headers).status_code == 200
+    assert runs.calls == ["run-a"]
+    assert config_service.calls == ["list_configs"]
+
+
+def test_build_app_binds_one_cache_location_and_passes_configuration_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runtime construction supplies the one durable cache location to both families."""
+    from infrahub_sync.managed._settings import PRODUCT_CACHE_ENV  # noqa: PLC2701
+
+    monkeypatch.setenv(PRODUCT_CACHE_ENV, str(tmp_path))
+    received: list[object] = []
+
+    def projection(location: Path) -> object:
+        received.append(location)
+        return object()
+
+    class Resolver:
+        secret_values: tuple[str, ...] = ()
+
+    def application(run: object, resolver: object, routes: object) -> object:
+        received.extend((run, resolver, routes))
+        return object()
+
+    assert (
+        build_app(
+            projection_factory=projection,
+            resolver_factory=Resolver,
+            run_service_factory=lambda *_args, **_kwargs: object(),
+            app_factory=application,
+        )
+        is not None
+    )
+    assert received[0] == tmp_path

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -6,6 +6,7 @@ import ast
 import json
 from hashlib import sha256
 from pathlib import Path
+from threading import Event, Thread
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -17,7 +18,7 @@ from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResol
 from infrahub_sync.managed.config_routes import ConfigurationAPIError, ConfigurationRoutes
 from infrahub_sync.managed.orchestration import Observation, Submission
 from infrahub_sync.managed.serve import build_app
-from infrahub_sync.managed.service import ManagedRunService
+from infrahub_sync.managed.service import ManagedAPIError, ManagedRunService
 from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
 from infrahub_sync.product_store.configs import ValidationReport
@@ -204,6 +205,107 @@ def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_r
     assert retried.status_code == 201
     assert service.calls == 2
     assert [event.outcome for event in projection.audit_events()] == ["unavailable", "accepted"]
+
+
+def test_concurrent_configuration_mutation_does_not_invoke_service_twice(tmp_path: Path) -> None:
+    """An in-flight idempotency identity has one service owner, not two."""
+    started = Event()
+    release = Event()
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def register(self, **_kwargs: object) -> dict[str, object]:
+            self.calls += 1
+            started.set()
+            assert release.wait(timeout=5)
+            return {"configuration": {"config_id": "cfg"}, "version": {"registry_version": 1}}
+
+    service = Service()
+    routes = ConfigurationRoutes(tmp_path, service=service)
+
+    def mutate() -> tuple[int, dict[str, object]]:
+        return routes.mutate(
+            actor="admin",
+            idempotency_key="concurrent-key",
+            operation="register-config",
+            resource_kind="configuration-registry",
+            resource_id="configs",
+            package=package_data(),
+            reason="test concurrent receipt",
+        )
+
+    first = Thread(target=mutate)
+    first.start()
+    assert started.wait(timeout=5)
+    with pytest.raises(ManagedAPIError) as raised:
+        mutate()
+    release.set()
+    first.join(timeout=5)
+
+    assert not first.is_alive()
+    assert raised.value.status == 409
+    assert raised.value.code == "idempotency-in-progress"
+    assert service.calls == 1
+
+
+def test_configuration_receipts_use_semantic_resource_identities(tmp_path: Path) -> None:
+    """Registration and version receipts are keyed by domain resource, not HTTP path."""
+    routes = ConfigurationRoutes(tmp_path)
+    register = routes.mutate(
+        actor="admin",
+        idempotency_key="semantic-registration",
+        operation="register-config",
+        resource_kind="configuration-registry",
+        resource_id="configs",
+        package=package_data(),
+        reason="semantic registration",
+    )
+    config_id = register[1]["configuration"]["config_id"]
+    routes.mutate(
+        actor="admin",
+        idempotency_key="semantic-version",
+        operation="create-config-version",
+        resource_kind="configuration",
+        resource_id=config_id,
+        package=package_data(),
+        reason="semantic version",
+    )
+
+    projection = local_product_projection(tmp_path)
+    registration = projection.lookup_mutation("admin", sha256(b"semantic-registration").hexdigest()).value
+    version = projection.lookup_mutation("admin", sha256(b"semantic-version").hexdigest()).value
+    assert registration is not None
+    assert version is not None
+    assert (registration.resource_kind, registration.resource_id) == ("configuration-registry", "configs")
+    assert (version.resource_kind, version.resource_id) == ("configuration", config_id)
+
+
+def test_unrelated_service_assertion_is_not_reclassified_as_configuration_refusal(tmp_path: Path) -> None:
+    """Only the service boundary, rather than HTTP routing, classifies service failures."""
+
+    class Service:
+        ConfigsRequestError = configs_service.ConfigsRequestError
+        ConfigsValidationError = configs_service.ConfigsValidationError
+        ConfigsNotFoundError = configs_service.ConfigsNotFoundError
+        ConfigsStorageError = configs_service.ConfigsStorageError
+        ConfigsInternalError = configs_service.ConfigsInternalError
+        ConfigsError = configs_service.ConfigsError
+
+        @staticmethod
+        def list_configs(**_kwargs: object) -> None:
+            raise AssertionError("unrelated defect")  # noqa: EM101, TRY003 - the assertion is the transport boundary probe.
+
+    with pytest.raises(AssertionError, match="unrelated defect"):
+        ConfigurationRoutes(tmp_path, service=Service()).list_configs()
 
 
 def test_configuration_mutation_refuses_unauthenticated_and_non_admin_calls(
@@ -440,7 +542,6 @@ def test_configuration_and_version_lists_return_every_service_result(
         (configs_service.ConfigsStorageError("hostile"), 503, "storage", None),
         (configs_service.ConfigsInternalError("hostile"), 503, "internal", None),
         (configs_service.ConfigsError("hostile"), 503, "configs", None),
-        (AssertionError("hostile"), 503, "internal", None),
     ],
 )
 def test_configuration_error_matrix_preserves_only_declared_fields(  # noqa: PLR0913, PLR0917

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import ast
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from fastapi.testclient import TestClient
 
 from infrahub_sync.managed.app import create_app
 from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
-from infrahub_sync.managed.config_routes import ConfigurationRoutes
+from infrahub_sync.managed.config_routes import ConfigurationAPIError, ConfigurationRoutes
 from infrahub_sync.managed.orchestration import Observation, Submission
 from infrahub_sync.managed.serve import build_app
 from infrahub_sync.managed.service import ManagedRunService
@@ -19,19 +20,22 @@ from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
 from tests.configuration.validation_packages import package_data
 
+if TYPE_CHECKING:
+    from infrahub_sync.managed.auth import PrincipalResolver
+
 
 class _Orchestration:  # pylint: disable=too-few-public-methods
-    async def submit(self, _parameters: dict[str, object], *, _idempotency_key: str) -> Submission:  # noqa: PLR6301
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:  # noqa: ARG002, PLR6301
         return Submission(flow_run_id="test-flow", state="pending")
 
-    async def observe(self, _flow_run_id: str) -> Observation:  # noqa: PLR6301
+    async def observe(self, flow_run_id: str) -> Observation:  # noqa: ARG002, PLR6301
         return Observation(available=True, state="running")
 
-    async def cancel(self, _flow_run_id: str) -> Observation:  # noqa: PLR6301
+    async def cancel(self, flow_run_id: str) -> Observation:  # noqa: ARG002, PLR6301
         return Observation(available=True, state="cancelled")
 
 
-def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: object) -> None:
+def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A configuration resource delegates registration and its scoped reads."""
     monkeypatch.setenv(
         PRINCIPALS_ENV, json.dumps({"admin": {"token": "admin-token-canary-0003", "administrator": True}})
@@ -134,7 +138,7 @@ def test_unknown_configs_subclass_uses_fixed_base_family(tmp_path: Path) -> None
             message = "do not disclose"
             raise Hostile(message)
 
-    with pytest.raises(Exception) as raised:
+    with pytest.raises(ConfigurationAPIError) as raised:
         ConfigurationRoutes(tmp_path, service=Service()).list_configs()
     assert raised.value.family == "configs"
 
@@ -176,7 +180,13 @@ def test_create_app_keeps_run_and_configuration_dependencies_separate(tmp_path: 
 
     runs = Runs()
     config_service = ConfigService()
-    client = TestClient(create_app(runs, Resolver(), ConfigurationRoutes(tmp_path, service=config_service)))
+    client = TestClient(
+        create_app(
+            cast("ManagedRunService", runs),
+            cast("PrincipalResolver", Resolver()),
+            ConfigurationRoutes(tmp_path, service=config_service),
+        )
+    )
     headers = {"Authorization": "Bearer accepted"}
     assert client.get("/runs/run-a/artifacts/one", headers=headers).status_code == 200
     assert client.get("/configs", headers=headers).status_code == 200

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -1,0 +1,51 @@
+"""Focused transport checks for configuration HTTP resources."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from infrahub_sync.managed.app import create_app
+from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
+from infrahub_sync.managed.config_routes import ConfigurationRoutes
+from infrahub_sync.managed.orchestration import Observation, Submission
+from infrahub_sync.managed.service import ManagedRunService
+from infrahub_sync.product_store import local_product_projection
+from tests.configuration.validation_packages import package_data
+
+
+class _Orchestration:  # pylint: disable=too-few-public-methods
+    async def submit(self, _parameters: dict[str, object], *, _idempotency_key: str) -> Submission:  # noqa: PLR6301
+        return Submission(flow_run_id="test-flow", state="pending")
+
+    async def observe(self, _flow_run_id: str) -> Observation:  # noqa: PLR6301
+        return Observation(available=True, state="running")
+
+    async def cancel(self, _flow_run_id: str) -> Observation:  # noqa: PLR6301
+        return Observation(available=True, state="cancelled")
+
+
+def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: object) -> None:
+    """A configuration resource delegates registration and its scoped reads."""
+    monkeypatch.setenv(
+        PRINCIPALS_ENV, json.dumps({"admin": {"token": "admin-token-canary-0003", "administrator": True}})
+    )
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path)
+    runs = ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values)
+    routes = ConfigurationRoutes(tmp_path, secrets=resolver.secret_values)
+    client = TestClient(create_app(runs, resolver, routes))
+    response = client.post(
+        "/configs",
+        headers={"Authorization": "Bearer admin-token-canary-0003"},
+        json={"package": package_data(), "reason": "register"},
+    )
+    assert response.status_code == 201, response.text
+    config_id = response.json()["configuration"]["config_id"]
+    assert client.get("/configs", headers={"Authorization": "Bearer admin-token-canary-0003"}).status_code == 200
+    assert (
+        client.get(f"/configs/{config_id}", headers={"Authorization": "Bearer admin-token-canary-0003"}).status_code
+        == 200
+    )

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -25,7 +25,11 @@ from infrahub_sync.product_store.configs import ValidationReport
 from tests.configuration.validation_packages import package_data
 
 if TYPE_CHECKING:
+    from typing import NoReturn
+
+    from infrahub_sync.configuration.models import ConfigurationPackage
     from infrahub_sync.managed.auth import PrincipalResolver
+    from infrahub_sync.product_store.models import ConfigurationVersion
 
 
 class _Orchestration:  # pylint: disable=too-few-public-methods
@@ -37,6 +41,10 @@ class _Orchestration:  # pylint: disable=too-few-public-methods
 
     async def cancel(self, flow_run_id: str) -> Observation:  # noqa: ARG002, PLR6301
         return Observation(available=True, state="cancelled")
+
+
+class _UnknownConfigsError(configs_service.ConfigsError):
+    """An unrecognized service error remains conservatively non-retryable."""
 
 
 def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -158,10 +166,27 @@ def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency
     assert all(bearer not in event.model_dump_json() for event in events)
 
 
-def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_retry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("error_type", "status", "released"),
+    [
+        (configs_service.ConfigsRequestError, 400, True),
+        (configs_service.ConfigsValidationError, 422, True),
+        (configs_service.ConfigsNotFoundError, 404, True),
+        (configs_service.ConfigsStorageError, 503, False),
+        (configs_service.ConfigsInternalError, 503, False),
+        (configs_service.ConfigsError, 503, False),
+        (_UnknownConfigsError, 503, False),
+    ],
+)
+def test_configuration_mutation_releases_only_proven_pre_effect_error_families(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[configs_service.ConfigsError],
+    *,
+    status: int,
+    released: bool,
 ) -> None:
-    """A configuration service outage leaves no unaudited reservation behind."""
+    """Only declared pre-effect families make a configuration receipt retryable."""
     bearer = "admin-token-canary-0003"
     monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
     resolver = EnvironmentPrincipalResolver.from_environment()
@@ -179,9 +204,7 @@ def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_r
 
         def register(self, **_kwargs: object) -> dict[str, object]:
             self.calls += 1
-            if self.calls == 1:
-                raise self.ConfigsStorageError("transient service failure")  # noqa: EM101, TRY003
-            return {"configuration": {"config_id": "cfg"}, "version": {"registry_version": 1}}
+            raise error_type("service failure")  # noqa: EM101, TRY003
 
     projection = local_product_projection(tmp_path)
     service = Service()
@@ -197,14 +220,62 @@ def test_configuration_service_failure_is_audited_and_the_reserved_receipt_can_r
 
     refused = client.post("/configs", headers=headers, json=body)
     reserved = projection.lookup_mutation("admin", sha256(headers["Idempotency-Key"].encode()).hexdigest()).value
-    retried = client.post("/configs", headers=headers, json=body)
+    retry = client.post("/configs", headers=headers, json=body)
 
-    assert refused.status_code == 503
+    assert refused.status_code == status
     assert reserved is not None
-    assert reserved.state == "reserved"
-    assert retried.status_code == 201
-    assert service.calls == 2
-    assert [event.outcome for event in projection.audit_events()] == ["unavailable", "accepted"]
+    assert reserved.state == ("reserved" if released else "processing")
+    assert retry.status_code == (status if released else 409)
+    assert service.calls == (2 if released else 1)
+    assert [event.outcome for event in projection.audit_events()] == (
+        ["unavailable", "unavailable"] if released else ["unavailable", "refused-idempotency-in-progress"]
+    )
+    assert all(bearer not in event.model_dump_json() for event in projection.audit_events())
+
+
+def test_post_commit_readback_failure_blocks_same_key_retry_without_a_second_configuration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contain an unknown post-commit outcome; this is not crash recovery or exactly-once execution."""
+    projection = local_product_projection(tmp_path)
+    writes = 0
+
+    class PostCommitReadbackFailure:  # pylint: disable=too-few-public-methods,no-self-use
+        def create_configuration(self, package: ConfigurationPackage) -> ConfigurationVersion:  # noqa: PLR6301
+            nonlocal writes
+            writes += 1
+            return projection.create_configuration(package)
+
+        def lookup_configuration(self, _config_id: str) -> NoReturn:  # noqa: PLR6301
+            message = "read-back failed after configuration commit"
+            raise OSError(message)
+
+    monkeypatch.setattr(configs_service, "local_product_projection", lambda _location: PostCommitReadbackFailure())
+    routes = ConfigurationRoutes(tmp_path)
+    request = {
+        "actor": "admin",
+        "idempotency_key": "post-commit-readback-failure",
+        "operation": "register-config",
+        "resource_kind": "configuration-registry",
+        "resource_id": "configs",
+        "package": package_data(),
+        "reason": "prove conservative containment",
+    }
+
+    with pytest.raises(ConfigurationAPIError) as first:
+        routes.mutate(**request)
+    with pytest.raises(ManagedAPIError) as retry:
+        routes.mutate(**request)
+
+    receipt = projection.lookup_mutation("admin", sha256(b"post-commit-readback-failure").hexdigest()).value
+    assert first.value.status == 503
+    assert first.value.family == "storage"
+    assert retry.value.code == "idempotency-in-progress"
+    assert receipt is not None
+    assert receipt.state == "processing"
+    assert writes == 1
+    assert len(projection.list_configurations()) == 1
+    assert [event.outcome for event in projection.audit_events()] == ["unavailable", "refused-idempotency-in-progress"]
 
 
 def test_concurrent_configuration_mutation_does_not_invoke_service_twice(tmp_path: Path) -> None:

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -47,7 +47,7 @@ def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: py
     client = TestClient(create_app(runs, resolver, routes))
     response = client.post(
         "/configs",
-        headers={"Authorization": "Bearer admin-token-canary-0003"},
+        headers={"Authorization": "Bearer admin-token-canary-0003", "Idempotency-Key": "register-once"},
         json={"package": package_data(), "reason": "register"},
     )
     assert response.status_code == 201, response.text
@@ -57,6 +57,37 @@ def test_configuration_routes_register_then_read(tmp_path: Path, monkeypatch: py
         client.get(f"/configs/{config_id}", headers={"Authorization": "Bearer admin-token-canary-0003"}).status_code
         == 200
     )
+
+
+def test_configuration_mutation_replays_exact_response_and_rejects_changed_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A configuration mutation uses the one durable receipt rather than a second write."""
+    monkeypatch.setenv(
+        PRINCIPALS_ENV, json.dumps({"admin": {"token": "admin-token-canary-0003", "administrator": True}})
+    )
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path)
+    client = TestClient(
+        create_app(
+            ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, secrets=resolver.secret_values),
+        )
+    )
+    headers = {"Authorization": "Bearer admin-token-canary-0003", "Idempotency-Key": "register-once"}
+    body = {"package": package_data(), "reason": "register this package"}
+
+    first = client.post("/configs", headers=headers, json=body)
+    replay = client.post("/configs", headers=headers, json=body)
+    changed = client.post("/configs", headers=headers, json={**body, "reason": "different reason"})
+
+    assert first.status_code == replay.status_code == 201
+    assert replay.json() == first.json()
+    assert changed.status_code == 409
+    assert len(projection.list_configurations()) == 1
+    receipt = projection.lookup_mutation("admin", __import__("hashlib").sha256(b"register-once").hexdigest())
+    assert receipt.value is not None and receipt.value.state == "accepted"
 
 
 @pytest.mark.parametrize(

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -208,9 +208,15 @@ def test_configuration_route_grammar_refuses_hostile_values_before_service_class
             ConfigurationRoutes(tmp_path, service=service, secrets=resolver.secret_values),
         )
     )
-    headers = {"Authorization": f"Bearer {bearer}", "Idempotency-Key": "grammar-key"}
+    headers = {
+        "Authorization": f"Bearer {bearer}",
+        "Content-Type": "application/json",
+        "Idempotency-Key": "grammar-key",
+    }
     probes = [
         ("post", "/configs", {"json": {"package": package_data(), "reason": "valid", "extra": True}}),
+        ("post", "/configs", {"content": '{"package":{"nested":[NaN]},"reason":"valid"}'}),
+        ("post", "/configs", {"json": {"package": package_data(), "reason": "invalid\nreason"}}),
         ("get", "/configs?offset=true", {}),
         ("get", "/configs?limit=257", {}),
         ("get", "/configs/not%20an%20id", {}),

--- a/tests/managed/test_config_routes.py
+++ b/tests/managed/test_config_routes.py
@@ -94,6 +94,42 @@ def test_configuration_mutation_replays_exact_response_and_rejects_changed_conte
     assert receipt.value.state == "accepted"
 
 
+def test_duplicate_configuration_version_checksum_returns_existing_version_without_a_second_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A checksum already stored for a configuration is a 200 replay, not a new version."""
+    bearer = "admin-token-canary-0003"
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": bearer, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    projection = local_product_projection(tmp_path)
+    client = TestClient(
+        create_app(
+            ManagedRunService(projection, _Orchestration(), secrets=resolver.secret_values),
+            resolver,
+            ConfigurationRoutes(tmp_path, secrets=resolver.secret_values),
+        )
+    )
+    package = package_data()
+    registration = client.post(
+        "/configs",
+        headers={"Authorization": f"Bearer {bearer}", "Idempotency-Key": "register-config"},
+        json={"package": package, "reason": "register"},
+    )
+    config_id = registration.json()["configuration"]["config_id"]
+    before = projection.list_configuration_versions(config_id)
+
+    response = client.post(
+        f"/configs/{config_id}/versions",
+        headers={"Authorization": f"Bearer {bearer}", "Idempotency-Key": "duplicate-version"},
+        json={"package": package, "reason": "duplicate checksum"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["version"]["registry_version"] == before[0].registry_version
+    assert projection.list_configuration_versions(config_id) == before
+    assert len(projection.list_configurations()) == 1
+
+
 def test_configuration_mutation_audits_accepted_replayed_and_refused_idempotency_without_secrets(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -2440,6 +2440,8 @@ class _FakePostgreSQLCursor:
                 raise _FakeDriverError(sqlstate="42P01")  # relation "{table}" does not exist
             connection.pending_columns.setdefault(table, set()).add(column)
             return ()
+        if operation.startswith("UPDATE mutation_receipts SET resource_kind"):
+            return ()
         if "ALTER COLUMN" in operation and "DROP NOT NULL" in operation:
             return ()
         if "information_schema.table_constraints" in operation:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -116,6 +116,8 @@ class _CursorAdapter:
             except sqlite3.IntegrityError as exc:
                 raise _FakeDriverError(sqlstate="42710") from exc
             return self
+        if "ALTER COLUMN" in stripped and "DROP NOT NULL" in stripped:
+            return self
         self._cursor.execute(stripped.replace("%s", "?"), parameters)
         return self
 
@@ -610,6 +612,59 @@ def test_mutation_reservation_atomically_creates_one_run_and_replays_on_both_pro
     assert replay == first
     assert provider.lookup_run("run-001").value == _run()
     assert provider.lookup_run("run-never-created").reason == "run-not-found"
+
+
+@pytest.mark.parametrize("profile", ("sqlite", "postgresql"))
+def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receipts(
+    tmp_path: Path, profile: str
+) -> None:
+    """Receipt storage upgrades legacy run rows without inventing run identifiers for configs."""
+    database = tmp_path / f"{profile}.sqlite3"
+    legacy = sqlite3.connect(database)
+    try:
+        legacy.execute(
+            "CREATE TABLE mutation_receipts ("
+            "receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL, "
+            "operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL, "
+            "reason TEXT NOT NULL, run_id TEXT NOT NULL, prefect_key TEXT NOT NULL, "
+            "state TEXT NOT NULL, response_status INTEGER, response_body TEXT, flow_run_id TEXT, "
+            "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, UNIQUE (actor, key_digest))"
+        )
+        legacy_receipt = _receipt()
+        legacy_values = product_store_store._receipt_values(legacy_receipt)
+        legacy.execute(
+            "INSERT INTO mutation_receipts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            legacy_values[:7] + legacy_values[8:],
+        )
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    records = SQLiteRunStore(database) if profile == "sqlite" else PostgreSQLRunStore(_connect(database))
+    projection = ProductProjection(records, FileArtifactStore(tmp_path / f"{profile}-objects"))
+    restored = projection.lookup_mutation(legacy_receipt.actor, legacy_receipt.key_digest)
+    assert restored.value is not None
+    assert restored.value.resource == "run"
+    assert restored.value.run_id == legacy_receipt.run_id
+    assert restored.value.prefect_key == legacy_receipt.prefect_key
+
+    now = datetime(2026, 8, 10, 12, tzinfo=timezone.utc)
+    configuration_receipt = MutationReceipt(
+        receipt_id="configuration-mutation-001",
+        actor="operator@example.com",
+        key_digest=sha256(b"configuration-key").hexdigest(),
+        operation="register-config",
+        request_fingerprint=sha256(b"configuration-request").hexdigest(),
+        reason="operator registered a configuration",
+        resource="configuration",
+        created_at=now,
+        updated_at=now,
+    )
+    reserved, created = projection.reserve_mutation(configuration_receipt)
+    assert created is True
+    assert reserved.run_id is None
+    assert reserved.prefect_key is None
+    assert reserved.flow_run_id is None
 
 
 def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(tmp_path: Path) -> None:
@@ -2352,6 +2407,8 @@ class _FakePostgreSQLCursor:
             table = match.group(1)
             if table not in database.tables:
                 connection.pending_tables.add(table)
+            if table == "mutation_receipts":
+                connection.pending_columns.setdefault(table, set()).add("resource")
             return ()
         if operation.startswith(("CREATE UNIQUE INDEX IF NOT EXISTS", "CREATE INDEX IF NOT EXISTS")):
             return ()
@@ -2364,6 +2421,8 @@ class _FakePostgreSQLCursor:
             if table not in (database.tables | connection.pending_tables):
                 raise _FakeDriverError(sqlstate="42P01")  # relation "{table}" does not exist
             connection.pending_columns.setdefault(table, set()).add(column)
+            return ()
+        if "ALTER COLUMN" in operation and "DROP NOT NULL" in operation:
             return ()
         if "information_schema.table_constraints" in operation:
             name = parameters[-1]

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -96,7 +96,8 @@ class _CursorAdapter:
         self._fake_rows = None
         stripped = operation.strip()
         if "information_schema.columns" in stripped:
-            self._cursor.execute("PRAGMA table_info(product_runs)")
+            table_name = parameters[0] if parameters else "product_runs"
+            self._cursor.execute(f"PRAGMA table_info({table_name})")  # noqa: S608 - controlled test table name.
             self._fake_rows = tuple((str(row[1]),) for row in self._cursor.fetchall())
             return self
         if "information_schema.table_constraints" in stripped:
@@ -412,6 +413,7 @@ def _receipt(  # noqa: PLR0913 - receipt factory exposes contract dimensions.
         target_run_id=target_run_id,
         request_fingerprint=sha256(f"canonical-request:{operation}:{target_run_id}".encode()).hexdigest(),
         reason=reason,
+        resource_id=run_id,
         run_id=run_id,
         prefect_key=sha256(receipt_id.encode()).hexdigest(),
         created_at=now,
@@ -634,7 +636,7 @@ def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receip
         legacy_values = product_store_store._receipt_values(legacy_receipt)
         legacy.execute(
             "INSERT INTO mutation_receipts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            legacy_values[:7] + legacy_values[8:],
+            legacy_values[:7] + legacy_values[9:],
         )
         legacy.commit()
     finally:
@@ -644,9 +646,22 @@ def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receip
     projection = ProductProjection(records, FileArtifactStore(tmp_path / f"{profile[0]}-objects"))
     restored = projection.lookup_mutation(legacy_receipt.actor, legacy_receipt.key_digest)
     assert restored.value is not None
-    assert restored.value.resource == "run"
+    assert restored.value.resource_kind == "run"
+    assert restored.value.resource_id == legacy_receipt.run_id
     assert restored.value.run_id == legacy_receipt.run_id
     assert restored.value.prefect_key == legacy_receipt.prefect_key
+
+    restarted = ProductProjection(SQLiteRunStore(database), FileArtifactStore(tmp_path / "restarted-objects"))
+    after_restart = restarted.lookup_mutation(legacy_receipt.actor, legacy_receipt.key_digest)
+    assert after_restart.value is not None
+    assert after_restart.value.run_id == legacy_receipt.run_id
+    assert after_restart.value.prefect_key == legacy_receipt.prefect_key
+    schema = sqlite3.connect(database)
+    try:
+        columns = {row[1] for row in schema.execute("PRAGMA table_info(mutation_receipts)")}
+    finally:
+        schema.close()
+    assert {"resource_kind", "resource_id"} <= columns
 
     now = datetime(2026, 8, 10, 12, tzinfo=timezone.utc)
     configuration_receipt = MutationReceipt(
@@ -656,7 +671,8 @@ def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receip
         operation="register-config",
         request_fingerprint=sha256(b"configuration-request").hexdigest(),
         reason="operator registered a configuration",
-        resource="configuration",
+        resource_kind="configuration",
+        resource_id="configs",
         created_at=now,
         updated_at=now,
     )
@@ -2410,7 +2426,7 @@ class _FakePostgreSQLCursor:
             if table not in database.tables:
                 connection.pending_tables.add(table)
             if table == "mutation_receipts":
-                connection.pending_columns.setdefault(table, set()).add("resource")
+                connection.pending_columns.setdefault(table, set()).update({"resource_kind", "resource_id"})
             return ()
         if operation.startswith(("CREATE UNIQUE INDEX IF NOT EXISTS", "CREATE INDEX IF NOT EXISTS")):
             return ()

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -614,12 +614,12 @@ def test_mutation_reservation_atomically_creates_one_run_and_replays_on_both_pro
     assert provider.lookup_run("run-never-created").reason == "run-not-found"
 
 
-@pytest.mark.parametrize("profile", ("sqlite", "postgresql"))
+@pytest.mark.parametrize("profile", [("sqlite",), ("postgresql",)])
 def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receipts(
-    tmp_path: Path, profile: str
+    tmp_path: Path, profile: tuple[str]
 ) -> None:
     """Receipt storage upgrades legacy run rows without inventing run identifiers for configs."""
-    database = tmp_path / f"{profile}.sqlite3"
+    database = tmp_path / f"{profile[0]}.sqlite3"
     legacy = sqlite3.connect(database)
     try:
         legacy.execute(
@@ -640,8 +640,8 @@ def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receip
     finally:
         legacy.close()
 
-    records = SQLiteRunStore(database) if profile == "sqlite" else PostgreSQLRunStore(_connect(database))
-    projection = ProductProjection(records, FileArtifactStore(tmp_path / f"{profile}-objects"))
+    records = SQLiteRunStore(database) if profile[0] == "sqlite" else PostgreSQLRunStore(_connect(database))
+    projection = ProductProjection(records, FileArtifactStore(tmp_path / f"{profile[0]}-objects"))
     restored = projection.lookup_mutation(legacy_receipt.actor, legacy_receipt.key_digest)
     assert restored.value is not None
     assert restored.value.resource == "run"
@@ -680,7 +680,9 @@ def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(
     assert sum(created for _, created in results) == 1
     winning_run_ids = {receipt.run_id for receipt, _ in results}
     assert len(winning_run_ids) == 1
-    assert projection.lookup_run(winning_run_ids.pop()).available
+    winning_run_id = winning_run_ids.pop()
+    assert winning_run_id is not None
+    assert projection.lookup_run(winning_run_id).available
 
 
 def test_write_capable_mutation_admission_is_atomic_on_both_profiles(provider: ProductProjection) -> None:
@@ -2400,7 +2402,7 @@ class _FakePostgreSQLCursor:
             raise
         return self
 
-    def _dispatch(self, operation: str, parameters: Sequence[Any]) -> tuple[tuple[Any, ...], ...]:
+    def _dispatch(self, operation: str, parameters: Sequence[Any]) -> tuple[tuple[Any, ...], ...]:  # noqa: PLR0911
         connection = self._connection
         database = connection.database
         if match := _FAKE_CREATE_TABLE.match(operation):

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -97,7 +97,7 @@ class _CursorAdapter:
         stripped = operation.strip()
         if "information_schema.columns" in stripped:
             table_name = parameters[0] if parameters else "product_runs"
-            self._cursor.execute(f"PRAGMA table_info({table_name})")  # noqa: S608 - controlled test table name.
+            self._cursor.execute(f"PRAGMA table_info({table_name})")
             self._fake_rows = tuple((str(row[1]),) for row in self._cursor.fetchall())
             return self
         if "information_schema.table_constraints" in stripped:

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -681,6 +681,46 @@ def test_receipt_migration_backfills_legacy_runs_and_allows_configuration_receip
     assert reserved.run_id is None
     assert reserved.prefect_key is None
     assert reserved.flow_run_id is None
+    schema = sqlite3.connect(database)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            schema.execute(
+                "UPDATE mutation_receipts SET resource_kind = 'configuration' WHERE receipt_id = ?",
+                (legacy_receipt.receipt_id,),
+            )
+    finally:
+        schema.close()
+
+
+def test_fresh_sqlite_receipt_resource_invariant_rejects_mixed_direct_write(tmp_path: Path) -> None:
+    """The fresh schema enforces the same configuration/run shape as a migrated database."""
+    database = tmp_path / "fresh.sqlite3"
+    SQLiteRunStore(database)
+    connection = sqlite3.connect(database)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO mutation_receipts (receipt_id, actor, key_digest, operation, request_fingerprint, reason, "
+                "resource_kind, resource_id, run_id, prefect_key, state, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "mixed-receipt",
+                    "operator",
+                    "a" * 64,
+                    "register-config",
+                    "b" * 64,
+                    "test direct write",
+                    "configuration",
+                    "configs",
+                    "run-001",
+                    "c" * 64,
+                    "reserved",
+                    "2026-08-10T12:00:00+00:00",
+                    "2026-08-10T12:00:00+00:00",
+                ),
+            )
+    finally:
+        connection.close()
 
 
 def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The configuration application service introduced in #190 has no HTTP surface, so service-first V3 clients cannot register, inspect, version, or validate configurations through the managed API.

This stacked draft adds seven authenticated configuration routes as a transport over the existing application service. It preserves one implementation of configuration behavior and extends the existing mutation-receipt mechanism for configuration writes.

## Key Changes

- Authenticated clients can register, list, retrieve, version, and validate configurations.
- Configuration mutations require administrator access, operator intent, and an idempotency key.
- Configuration and run mutations share one resource-aware receipt mechanism and additive persistence migration.
- Exact error translation, strict request grammar, and bounded validation pages keep the HTTP boundary stable and safe.
- Concurrent duplicate requests invoke the service once.
- Unknown post-effect outcomes remain conservatively blocked rather than risking duplicate registration.

## Before / After

Before:

```python
create_app(run_service, principal_resolver)
# /runs* only
```

After:

```python
create_app(run_service, principal_resolver, configuration_routes)
# /runs* and /configs*
```

## Related Context

- Stacked on #190, which introduces the shared configuration application service.
- Part of CF-005 Service Boundary.
- Full crash recovery remains dependent on outcome-determinable registration identity; this unit provides conservative duplicate-effect containment.

## Documentation Updates

No public product documentation is added in this unit. The routes are an internal stacked server boundary; CLI/Python clients and their final user-facing documentation follow later in CF-005.

## Test Plan

- `uv run invoke format`
- `uv run invoke lint`
- `uv run pytest -q`
  - 2597 passed
  - 24 skipped
  - 1 xfailed
- Configuration-route focused suite: 32 passed
- Concurrent mutation probe: 8/8 repeated passes
- CLI `--help` and example listing sanity checks
