### PR TITLE
feat: bind managed runs to registered configurations

### DIFF
--- a/infrahub_sync/__init__.py
+++ b/infrahub_sync/__init__.py
@@ -147,6 +147,8 @@ class SyncConfig(pydantic.BaseModel):
 
 class SyncInstance(SyncConfig):
     directory: str
+    # Worker-only state, deliberately absent from serialized configuration data.
+    _configuration_binding: tuple[str, int, str] | None = pydantic.PrivateAttr(default=None)
 
 
 def resolve_effective_diffsync_flags(

--- a/infrahub_sync/adapters/aci.py
+++ b/infrahub_sync/adapters/aci.py
@@ -23,6 +23,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
+from infrahub_sync.configuration.credentials import select_runtime_credential
 
 from .utils import get_value
 
@@ -205,9 +206,9 @@ class AciAdapter(DiffSyncMixin, Adapter):
 
     def _create_aci_client(self, adapter: SyncAdapter) -> AciApiClient:
         settings = adapter.settings or {}
-        url = os.environ.get("CISCO_APIC_URL") or settings.get("url")
-        username = os.environ.get("CISCO_APIC_USERNAME") or settings.get("username")
-        password = os.environ.get("CISCO_APIC_PASSWORD") or settings.get("password")
+        url = select_runtime_credential(settings, "url", ("CISCO_APIC_URL",))
+        username = select_runtime_credential(settings, "username", ("CISCO_APIC_USERNAME",))
+        password = select_runtime_credential(settings, "password", ("CISCO_APIC_PASSWORD",))
         # Prefer explicit env var for verify; allow boolean or string values
         verify_raw = os.environ.get("CISCO_APIC_VERIFY")
         if verify_raw is None:

--- a/infrahub_sync/adapters/genericrestapi.py
+++ b/infrahub_sync/adapters/genericrestapi.py
@@ -14,6 +14,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
+from infrahub_sync.configuration.credentials import select_runtime_credential
 
 from .rest_api_client import RestApiClient
 from .utils import derive_identifier_key, get_value
@@ -57,26 +58,13 @@ class GenericrestapiAdapter(DiffSyncMixin, Adapter):
         """
         # Get URL from multiple possible sources
         url_env_vars = settings.get("url_env_vars", ["URL", "ADDRESS"])
-        url = None
-        for env_var in url_env_vars:
-            url = os.environ.get(env_var)
-            if url:
-                break
-
-        if not url:
-            url = settings.get("url")
+        url = select_runtime_credential(settings, "url", tuple(url_env_vars))
 
         # Get settings with defaults
         api_endpoint = settings.get("api_endpoint", "/api/v0")
         auth_method = settings.get("auth_method", "token")
         token_env_vars = settings.get("token_env_vars", ["TOKEN"])
-        api_token = None
-        for env_var in token_env_vars:
-            api_token = os.environ.get(env_var)
-            if api_token:
-                break
-        if not api_token:
-            api_token = settings.get("token")
+        api_token = select_runtime_credential(settings, "token", tuple(token_env_vars))
         username_env_vars = settings.get("username_env_vars", ["USERNAME"])
         username = None
         for env_var in username_env_vars:

--- a/infrahub_sync/adapters/genericrestapi.py
+++ b/infrahub_sync/adapters/genericrestapi.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 from diffsync import Adapter, DiffSyncModel
@@ -66,24 +65,9 @@ class GenericrestapiAdapter(DiffSyncMixin, Adapter):
         token_env_vars = settings.get("token_env_vars", ["TOKEN"])
         api_token = select_runtime_credential(settings, "token", tuple(token_env_vars))
         username_env_vars = settings.get("username_env_vars", ["USERNAME"])
-        username = None
-        for env_var in username_env_vars:
-            username = os.environ.get(env_var)
-            if username:
-                break
-
-        if not username:
-            username = settings.get("username")
-
+        username = select_runtime_credential(settings, "username", tuple(username_env_vars))
         password_env_vars = settings.get("password_env_vars", ["PASSWORD"])
-        password = None
-        for env_var in password_env_vars:
-            password = os.environ.get(env_var)
-            if password:
-                break
-
-        if not password:
-            password = settings.get("password")
+        password = select_runtime_credential(settings, "password", tuple(password_env_vars))
 
         # Other configuration
         timeout = settings.get("timeout", 30)

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import ipaddress
 import logging
-import os
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +27,7 @@ from infrahub_sync import (
     SyncConfig,
 )
 from infrahub_sync.cache.cursors import CursorState, CursorTier
+from infrahub_sync.configuration.credentials import select_runtime_credential
 from infrahub_sync.generator import has_field
 from infrahub_sync.plan.canonical import canonical_json_bytes
 from infrahub_sync.plan.errors import (
@@ -53,7 +53,7 @@ def resolved_endpoint(settings: Mapping[str, Any], branch: str | None) -> tuple[
     the parsed YAML only, and the repo's own guidance keeps credentials and addresses in
     environment variables, exactly where that digest is blind.
     """
-    url = os.environ.get("INFRAHUB_ADDRESS") or os.environ.get("INFRAHUB_URL") or settings.get("url")
+    url = select_runtime_credential(settings, "url", ("INFRAHUB_ADDRESS", "INFRAHUB_URL"))
     return url, settings.get("branch") or branch
 
 
@@ -800,7 +800,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
 
         settings = adapter.settings or {}
         infrahub_url, infrahub_branch = resolved_endpoint(settings, branch)
-        infrahub_token = os.environ.get("INFRAHUB_API_TOKEN") or settings.get("token")
+        infrahub_token = select_runtime_credential(settings, "token", ("INFRAHUB_API_TOKEN",))
         verify_ssl = settings.get("verify_ssl")
 
         if not infrahub_url or not infrahub_token:

--- a/infrahub_sync/adapters/nautobot.py
+++ b/infrahub_sync/adapters/nautobot.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 # pylint: disable=R0801
 import logging
-import os
 from typing import TYPE_CHECKING, Any
 
 import pynautobot  # ty: ignore[unresolved-import]  # optional dep, see pyproject extras
@@ -19,6 +18,7 @@ from infrahub_sync import (
     SyncConfig,
 )
 from infrahub_sync.cache.cursors import CursorState, CursorTier
+from infrahub_sync.configuration.credentials import select_runtime_credential
 
 from .utils import get_value
 
@@ -65,8 +65,8 @@ class NautobotAdapter(DiffSyncMixin, Adapter):
 
     def _create_nautobot_client(self, adapter: SyncAdapter) -> pynautobot.api:
         settings = adapter.settings or {}
-        url = os.environ.get("NAUTOBOT_ADDRESS") or os.environ.get("NAUTOBOT_URL") or settings.get("url")
-        token = os.environ.get("NAUTOBOT_TOKEN") or settings.get("token")
+        url = select_runtime_credential(settings, "url", ("NAUTOBOT_ADDRESS", "NAUTOBOT_URL"))
+        token = select_runtime_credential(settings, "token", ("NAUTOBOT_TOKEN",))
         verify_ssl = settings.get("verify_ssl", True)
 
         if not url or not token:

--- a/infrahub_sync/adapters/netbox.py
+++ b/infrahub_sync/adapters/netbox.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 # pylint: disable=R0801
 import logging
-import os
 from typing import TYPE_CHECKING, Any
 
 import pynetbox  # ty: ignore[unresolved-import]  # optional dep, see pyproject extras
@@ -18,6 +17,7 @@ from infrahub_sync import (
     SyncConfig,
 )
 from infrahub_sync.cache.cursors import CursorState, CursorTier
+from infrahub_sync.configuration.credentials import select_runtime_credential
 
 from .utils import get_value
 
@@ -39,8 +39,8 @@ class NetboxAdapter(DiffSyncMixin, Adapter):
 
     def _create_netbox_client(self, adapter: SyncAdapter) -> pynetbox.api:
         settings = adapter.settings or {}
-        url = os.environ.get("NETBOX_ADDRESS") or os.environ.get("NETBOX_URL") or settings.get("url")
-        token = os.environ.get("NETBOX_TOKEN") or settings.get("token")
+        url = select_runtime_credential(settings, "url", ("NETBOX_ADDRESS", "NETBOX_URL"))
+        token = select_runtime_credential(settings, "token", ("NETBOX_TOKEN",))
         verify_ssl = settings.get("verify_ssl", True)
 
         if not url or not token:

--- a/infrahub_sync/adapters/prometheus.py
+++ b/infrahub_sync/adapters/prometheus.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 from typing import Any
 
@@ -19,6 +18,7 @@ from infrahub_sync import (
     SyncAdapter,
     SyncConfig,
 )
+from infrahub_sync.configuration.credentials import select_runtime_credential
 
 logger = logging.getLogger(__name__)
 
@@ -379,13 +379,13 @@ class PrometheusAdapter(DiffSyncMixin, Adapter):
 
         # Auth (both modes)
         self.auth_method = settings.get("auth_method", "none")
-        self.username = os.environ.get("PROM_USERNAME") or settings.get("username")
-        self.password = os.environ.get("PROM_PASSWORD") or settings.get("password")
-        self.api_token = os.environ.get("PROM_TOKEN") or settings.get("token")
+        self.username = select_runtime_credential(settings, "username", ("PROM_USERNAME",))
+        self.password = select_runtime_credential(settings, "password", ("PROM_PASSWORD",))
+        self.api_token = select_runtime_credential(settings, "token", ("PROM_TOKEN",))
         self.headers = settings.get("headers", {})
 
         # URL/endpoint
-        self.url = os.environ.get("PROM_URL") or os.environ.get("PROM_ADDRESS") or settings.get("url")
+        self.url = select_runtime_credential(settings, "url", ("PROM_URL", "PROM_ADDRESS"))
         if not self.url:
             msg = "Prometheus 'url' must be specified in settings.url (or PROM_URL)."
             raise ValueError(msg)

--- a/infrahub_sync/adapters/prometheus.py
+++ b/infrahub_sync/adapters/prometheus.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import requests
 from diffsync import Adapter, DiffSyncModel
-from prometheus_client.parser import (  # ty: ignore[unresolved-import]  # optional dep, see pyproject extras
+from prometheus_client.parser import (
     text_string_to_metric_families,
 )
 from typing_extensions import Self

--- a/infrahub_sync/configuration/credentials.py
+++ b/infrahub_sync/configuration/credentials.py
@@ -23,6 +23,20 @@ if TYPE_CHECKING:
     from .models import ConfigurationPackage, CredentialReference
 
 _ENV_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_REGISTERED_CONTEXT = "_infrahub_sync_registered_context"
+
+
+def select_runtime_credential(
+    settings: Mapping[str, object], setting_name: str, environment_names: tuple[str, ...]
+) -> object:
+    """Select a credential without ambient reads for a registered runtime package."""
+    if settings.get(_REGISTERED_CONTEXT) is True:
+        return settings.get(setting_name)
+    for environment_name in environment_names:
+        value = os.environ.get(environment_name)
+        if value:
+            return value
+    return settings.get(setting_name)
 
 
 @dataclass(frozen=True, slots=True)

--- a/infrahub_sync/configuration/credentials.py
+++ b/infrahub_sync/configuration/credentials.py
@@ -28,15 +28,17 @@ _REGISTERED_CONTEXT = "_infrahub_sync_registered_context"
 
 def select_runtime_credential(
     settings: Mapping[str, object], setting_name: str, environment_names: tuple[str, ...]
-) -> object:
+) -> str | None:
     """Select a credential without ambient reads for a registered runtime package."""
     if settings.get(_REGISTERED_CONTEXT) is True:
-        return settings.get(setting_name)
+        value = settings.get(setting_name)
+        return value if isinstance(value, str) else None
     for environment_name in environment_names:
         value = os.environ.get(environment_name)
         if value:
             return value
-    return settings.get(setting_name)
+    value = settings.get(setting_name)
+    return value if isinstance(value, str) else None
 
 
 @dataclass(frozen=True, slots=True)

--- a/infrahub_sync/configuration/runtime.py
+++ b/infrahub_sync/configuration/runtime.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from infrahub_sync import SyncInstance
 
-from .credentials import resolve_reference
+from .credentials import _REGISTERED_CONTEXT, resolve_reference
 
 if TYPE_CHECKING:
     from .models import ConfigurationPackage
@@ -26,4 +26,9 @@ def resolve_runtime_instance(package: ConfigurationPackage, *, directory: str) -
         return value
 
     resolved = resolve(package.configuration.model_dump(mode="json", by_alias=True))
-    return SyncInstance(**cast("dict[str, Any]", resolved), directory=directory)
+    runtime = cast("dict[str, Any]", resolved)
+    for side in ("source", "destination"):
+        adapter = runtime[side]
+        if type(adapter) is dict and type(adapter.get("settings")) is dict:
+            adapter["settings"][_REGISTERED_CONTEXT] = True
+    return SyncInstance(**runtime, directory=directory)

--- a/infrahub_sync/configuration/runtime.py
+++ b/infrahub_sync/configuration/runtime.py
@@ -1,0 +1,29 @@
+"""Construct worker-local runtime instances from verified registered packages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from infrahub_sync import SyncInstance
+
+from .credentials import resolve_reference
+
+if TYPE_CHECKING:
+    from .models import ConfigurationPackage
+
+
+def resolve_runtime_instance(package: ConfigurationPackage, *, directory: str) -> SyncInstance:
+    """Resolve declared credential references without adapter ambient lookup."""
+
+    def resolve(value: object) -> object:
+        if type(value) is dict:
+            mapping = cast("dict[str, object]", value)
+            if set(mapping) == {"$credential"} and type(mapping["$credential"]) is str:
+                return resolve_reference(package, cast("str", mapping["$credential"]))
+            return {key: resolve(child) for key, child in mapping.items()}
+        if type(value) is list:
+            return [resolve(child) for child in cast("list[object]", value)]
+        return value
+
+    resolved = resolve(package.configuration.model_dump(mode="json", by_alias=True))
+    return SyncInstance(**cast("dict[str, Any]", resolved), directory=directory)

--- a/infrahub_sync/configuration/runtime.py
+++ b/infrahub_sync/configuration/runtime.py
@@ -19,7 +19,7 @@ def resolve_runtime_instance(package: ConfigurationPackage, *, directory: str) -
         if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
             mapping = cast("dict[str, object]", value)
             if set(mapping) == {"$credential"} and type(mapping["$credential"]) is str:  # pylint: disable=unidiomatic-typecheck
-                return resolve_reference(package, cast("str", mapping["$credential"]))
+                return resolve_reference(package, mapping["$credential"])
             return {key: resolve(child) for key, child in mapping.items()}
         if type(value) is list:  # pylint: disable=unidiomatic-typecheck
             return [resolve(child) for child in cast("list[object]", value)]
@@ -29,6 +29,10 @@ def resolve_runtime_instance(package: ConfigurationPackage, *, directory: str) -
     runtime = cast("dict[str, object]", resolved)
     for side in ("source", "destination"):
         adapter = runtime[side]
-        if type(adapter) is dict and type(adapter.get("settings")) is dict:  # pylint: disable=unidiomatic-typecheck
-            adapter["settings"][_REGISTERED_CONTEXT] = True
-    return SyncInstance(**runtime, directory=directory)
+        if type(adapter) is dict:  # pylint: disable=unidiomatic-typecheck
+            adapter_mapping = cast("dict[str, object]", adapter)
+            settings = adapter_mapping.get("settings")
+            if type(settings) is dict:  # pylint: disable=unidiomatic-typecheck
+                cast("dict[str, object]", settings)[_REGISTERED_CONTEXT] = True
+    runtime["directory"] = directory
+    return SyncInstance.model_validate(runtime)

--- a/infrahub_sync/configuration/runtime.py
+++ b/infrahub_sync/configuration/runtime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from infrahub_sync import SyncInstance
 
@@ -16,19 +16,19 @@ def resolve_runtime_instance(package: ConfigurationPackage, *, directory: str) -
     """Resolve declared credential references without adapter ambient lookup."""
 
     def resolve(value: object) -> object:
-        if type(value) is dict:
+        if type(value) is dict:  # pylint: disable=unidiomatic-typecheck
             mapping = cast("dict[str, object]", value)
-            if set(mapping) == {"$credential"} and type(mapping["$credential"]) is str:
+            if set(mapping) == {"$credential"} and type(mapping["$credential"]) is str:  # pylint: disable=unidiomatic-typecheck
                 return resolve_reference(package, cast("str", mapping["$credential"]))
             return {key: resolve(child) for key, child in mapping.items()}
-        if type(value) is list:
+        if type(value) is list:  # pylint: disable=unidiomatic-typecheck
             return [resolve(child) for child in cast("list[object]", value)]
         return value
 
     resolved = resolve(package.configuration.model_dump(mode="json", by_alias=True))
-    runtime = cast("dict[str, Any]", resolved)
+    runtime = cast("dict[str, object]", resolved)
     for side in ("source", "destination"):
         adapter = runtime[side]
-        if type(adapter) is dict and type(adapter.get("settings")) is dict:
+        if type(adapter) is dict and type(adapter.get("settings")) is dict:  # pylint: disable=unidiomatic-typecheck
             adapter["settings"][_REGISTERED_CONTEXT] = True
     return SyncInstance(**runtime, directory=directory)

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -15,6 +15,8 @@ from typing import Any, Literal
 from prefect import flow, get_run_logger
 from prefect.exceptions import MissingContextError
 
+from infrahub_sync.configuration import ConfigurationPackageParseError, parse_configuration_package
+from infrahub_sync.configuration.runtime import resolve_runtime_instance
 from infrahub_sync.execution import (
     ACTION_KEYS,
     RunResult,
@@ -22,7 +24,6 @@ from infrahub_sync.execution import (
     collect_secret_values,
     execute_run,
     redact,
-    resolve_sync_instance,
     sanitize_exception_chain,
 )
 from infrahub_sync.orchestration.flow import (
@@ -44,6 +45,9 @@ from .service import PLAN_ARTIFACT_ID
 CONFIG_DIR_ENV = "INFRAHUB_SYNC_CONFIG_DIRECTORY"
 RUN_CACHE_ENV = "INFRAHUB_SYNC_CACHE_DIR"
 logger = logging.getLogger(__name__)
+_REGISTERED_VERSION_UNAVAILABLE = "registered configuration version is unavailable"
+_REGISTERED_VERSION_INVALID = "registered configuration version is invalid"
+_REGISTERED_CHECKSUM_MISMATCH = "registered configuration checksum does not match run binding"
 
 
 def _run_logger() -> tuple[RunLogger, bool]:
@@ -155,9 +159,10 @@ def _plan(
 
 def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
     run_id: str,
-    sync_name: str,
     stage: Literal["plan", "verify", "apply", "sync"],
-    configuration_reference: str,
+    config_id: str,
+    registry_version: int,
+    package_checksum: str,
     branch: str | None,
     expected_checksum: str | None,
     confirm_writes: bool,
@@ -170,12 +175,8 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
     if stored.value is None:
         msg = f"API-created Sync run {run_id!r} is unavailable"
         raise RuntimeError(msg)
-    if stored.value.configuration_reference != configuration_reference:
-        msg = f"configuration_reference does not match Sync run {run_id!r}"
-        raise ValueError(msg)
-    recorded_sync_name = stored.value.summary.get("sync_name")
-    if recorded_sync_name is not None and recorded_sync_name != sync_name:
-        msg = f"sync_name does not match Sync run {run_id!r}"
+    if stored.value.configuration_binding != (config_id, registry_version, package_checksum):
+        msg = "managed run binding does not match worker parameters"
         raise ValueError(msg)
     if stage in ("apply", "sync") and not confirm_writes:
         msg = f"confirm_writes=true is required for managed stage={stage}"
@@ -184,7 +185,17 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         msg = "expected_checksum is required for managed stage=apply"
         raise ValueError(msg)
 
-    instance = resolve_sync_instance(sync_name, directory=config_directory)
+    registered = projection.lookup_configuration_version(config_id, registry_version).value
+    if registered is None:
+        raise ValueError(_REGISTERED_VERSION_UNAVAILABLE)
+    try:
+        package = parse_configuration_package(registered.declared_content)
+    except ConfigurationPackageParseError:
+        raise ValueError(_REGISTERED_VERSION_INVALID) from None
+    if registered.package_checksum != package_checksum or package.checksum() != package_checksum:
+        raise ValueError(_REGISTERED_CHECKSUM_MISMATCH)
+    sync_name = package.configuration.name
+    instance = resolve_runtime_instance(package, directory=config_directory)
     secrets[:] = collect_secret_values(instance)
     result: dict[str, Any]
     if stage == "plan":
@@ -338,9 +349,10 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
 @flow(name=MANAGED_FLOW_NAME)
 def managed_sync_run(  # pylint: disable=too-many-positional-arguments
     run_id: str,
-    sync_name: str,
     stage: Literal["plan", "verify", "apply", "sync"],
-    configuration_reference: str,
+    config_id: str,
+    registry_version: int,
+    package_checksum: str,
     branch: str | None = None,
     expected_checksum: str | None = None,
     confirm_writes: bool = False,
@@ -353,9 +365,10 @@ def managed_sync_run(  # pylint: disable=too-many-positional-arguments
         with _remote_log_bridge(run_logger, prefect_context=prefect_context, secrets=secrets):
             return _execute_stage(
                 run_id,
-                sync_name,
                 stage,
-                configuration_reference,
+                config_id,
+                registry_version,
+                package_checksum,
                 branch,
                 expected_checksum,
                 confirm_writes,

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -24,6 +24,7 @@ from infrahub_sync.execution import (
     collect_secret_values,
     execute_run,
     redact,
+    resolve_sync_instance,
     sanitize_exception_chain,
 )
 from infrahub_sync.orchestration.flow import (
@@ -53,6 +54,9 @@ _REGISTERED_VERSION_INVALID = "registered configuration version is invalid"
 _REGISTERED_CHECKSUM_MISMATCH = "registered configuration checksum does not match run binding"
 _REGISTERED_PLAN_BINDING_MISMATCH = "registered saved plan binding does not match run binding"
 _REGISTERED_PLAN_VERIFICATION_FAILED = "registered saved plan verification failed"
+_WORKER_BINDING_PARAMETERS_INVALID = "managed worker configuration binding parameters must be all absent or all present"
+_LEGACY_RUN_IDENTITY_UNAVAILABLE = "legacy managed run identity is unavailable"
+_LEGACY_RUN_CONFIGURATION_MISMATCH = "legacy managed run configuration version does not match durable run"
 
 
 def _run_logger() -> tuple[RunLogger, bool]:
@@ -162,43 +166,50 @@ def _plan(
     return saved
 
 
-def _verify_registered_apply(*, instance: Any, run_id: str, binding: tuple[str, int, str]) -> None:
-    """Verify a bound artifact before the apply path can construct a destination."""
+def _verify_registered_apply(*, instance: Any, run_id: str, binding: tuple[str, int, str] | None) -> None:
+    """Verify an artifact before the apply path can construct a destination."""
     artifact = read_plan_artifact_bytes(resolve_run_directory(instance.name, run_id))
     if verify_plan(artifact=artifact, run_id=run_id, config_version=resolve_config_version(instance)):
         raise ValueError(_REGISTERED_PLAN_VERIFICATION_FAILED)
-    if parse_plan_artifact(artifact, run_id=run_id).manifest.configuration_binding != binding:
+    if binding is not None and parse_plan_artifact(artifact, run_id=run_id).manifest.configuration_binding != binding:
         raise ValueError(_REGISTERED_PLAN_BINDING_MISMATCH)
 
 
-def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
-    run_id: str,
-    stage: Literal["plan", "verify", "apply", "sync"],
-    config_id: str,
-    registry_version: int,
-    package_checksum: str,
-    branch: str | None,
-    expected_checksum: str | None,
-    confirm_writes: bool,
-    run_logger: RunLogger,
-    secrets: list[str],
-) -> dict[str, Any]:
-    """Resolve and execute one managed stage within the sanitized worker boundary."""
+def _worker_binding(
+    config_id: str | None, registry_version: int | None, package_checksum: str | None
+) -> tuple[str, int, str] | None:
+    """Return the closed Prefect tuple carrier or refuse a partial carrier."""
+    values = (config_id, registry_version, package_checksum)
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ValueError(_WORKER_BINDING_PARAMETERS_INVALID)
+    assert config_id is not None
+    assert registry_version is not None
+    assert package_checksum is not None
+    return config_id, registry_version, package_checksum
+
+
+def _worker_execution_context(run_id: str, binding: tuple[str, int, str] | None) -> tuple[ProductProjection, Any, str]:
+    """Load the durable run and resolve its registered or legacy runtime."""
     config_directory, projection = _runtime()
     stored = projection.lookup_run(run_id)
     if stored.value is None:
         msg = f"API-created Sync run {run_id!r} is unavailable"
         raise RuntimeError(msg)
-    if stored.value.configuration_binding != (config_id, registry_version, package_checksum):
+    if stored.value.configuration_binding != binding:
         msg = "managed run binding does not match worker parameters"
         raise ValueError(msg)
-    if stage in ("apply", "sync") and not confirm_writes:
-        msg = f"confirm_writes=true is required for managed stage={stage}"
-        raise ValueError(msg)
-    if stage == "apply" and expected_checksum is None:
-        msg = "expected_checksum is required for managed stage=apply"
-        raise ValueError(msg)
+    if binding is None:
+        sync_name = stored.value.summary.get("sync_name")
+        if not isinstance(sync_name, str) or not sync_name:
+            raise ValueError(_LEGACY_RUN_IDENTITY_UNAVAILABLE)
+        instance = resolve_sync_instance(sync_name, directory=config_directory)
+        if resolve_config_version(instance) != stored.value.configuration_reference:
+            raise ValueError(_LEGACY_RUN_CONFIGURATION_MISMATCH)
+        return projection, instance, sync_name
 
+    config_id, registry_version, package_checksum = binding
     registered = projection.lookup_configuration_version(config_id, registry_version).value
     if registered is None:
         raise ValueError(_REGISTERED_VERSION_UNAVAILABLE)
@@ -208,9 +219,33 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         raise ValueError(_REGISTERED_VERSION_INVALID) from None
     if registered.package_checksum != package_checksum or package.checksum() != package_checksum:
         raise ValueError(_REGISTERED_CHECKSUM_MISMATCH)
-    sync_name = package.configuration.name
     instance = resolve_runtime_instance(package, directory=config_directory)
-    instance._configuration_binding = (config_id, registry_version, package_checksum)
+    instance._configuration_binding = binding
+    return projection, instance, package.configuration.name
+
+
+def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
+    run_id: str,
+    stage: Literal["plan", "verify", "apply", "sync"],
+    config_id: str | None,
+    registry_version: int | None,
+    package_checksum: str | None,
+    branch: str | None,
+    expected_checksum: str | None,
+    confirm_writes: bool,
+    run_logger: RunLogger,
+    secrets: list[str],
+) -> dict[str, Any]:
+    """Resolve and execute one managed stage within the sanitized worker boundary."""
+    parameter_binding = _worker_binding(config_id, registry_version, package_checksum)
+    projection, instance, sync_name = _worker_execution_context(run_id, parameter_binding)
+    if stage in ("apply", "sync") and not confirm_writes:
+        msg = f"confirm_writes=true is required for managed stage={stage}"
+        raise ValueError(msg)
+    if stage == "apply" and expected_checksum is None:
+        msg = "expected_checksum is required for managed stage=apply"
+        raise ValueError(msg)
+
     secrets[:] = collect_secret_values(instance)
     result: dict[str, Any]
     if stage == "plan":
@@ -247,7 +282,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         _verify_registered_apply(
             instance=instance,
             run_id=run_id,
-            binding=(config_id, registry_version, package_checksum),
+            binding=parameter_binding,
         )
         applied = execute_run(
             instance,
@@ -283,7 +318,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
             _verify_registered_apply(
                 instance=instance,
                 run_id=run_id,
-                binding=(config_id, registry_version, package_checksum),
+                binding=parameter_binding,
             )
             applied = execute_run(
                 instance,
@@ -375,9 +410,9 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
 def managed_sync_run(  # pylint: disable=too-many-positional-arguments
     run_id: str,
     stage: Literal["plan", "verify", "apply", "sync"],
-    config_id: str,
-    registry_version: int,
-    package_checksum: str,
+    config_id: str | None = None,
+    registry_version: int | None = None,
+    package_checksum: str | None = None,
     branch: str | None = None,
     expected_checksum: str | None = None,
     confirm_writes: bool = False,

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -171,7 +171,8 @@ def _verify_registered_apply(*, instance: Any, run_id: str, binding: tuple[str, 
     artifact = read_plan_artifact_bytes(resolve_run_directory(instance.name, run_id))
     if verify_plan(artifact=artifact, run_id=run_id, config_version=resolve_config_version(instance)):
         raise ValueError(_REGISTERED_PLAN_VERIFICATION_FAILED)
-    if binding is not None and parse_plan_artifact(artifact, run_id=run_id).manifest.configuration_binding != binding:
+    manifest_binding = parse_plan_artifact(artifact, run_id=run_id).manifest.configuration_binding
+    if manifest_binding != binding:
         raise ValueError(_REGISTERED_PLAN_BINDING_MISMATCH)
 
 

--- a/infrahub_sync/managed/flow.py
+++ b/infrahub_sync/managed/flow.py
@@ -33,8 +33,11 @@ from infrahub_sync.orchestration.flow import (
     RunLogger,
     RunLoggerBridge,
 )
+from infrahub_sync.plan.config_version import resolve_config_version
 from infrahub_sync.plan.models import ApplyRecord
-from infrahub_sync.plan.review import SavedPlan
+from infrahub_sync.plan.reader import parse_plan_artifact, read_plan_artifact_bytes
+from infrahub_sync.plan.review import SavedPlan, resolve_run_directory
+from infrahub_sync.plan.verify import verify_plan
 from infrahub_sync.product_store import ProductProjection, local_product_projection
 
 from ._settings import PRODUCT_CACHE_ENV
@@ -48,6 +51,8 @@ logger = logging.getLogger(__name__)
 _REGISTERED_VERSION_UNAVAILABLE = "registered configuration version is unavailable"
 _REGISTERED_VERSION_INVALID = "registered configuration version is invalid"
 _REGISTERED_CHECKSUM_MISMATCH = "registered configuration checksum does not match run binding"
+_REGISTERED_PLAN_BINDING_MISMATCH = "registered saved plan binding does not match run binding"
+_REGISTERED_PLAN_VERIFICATION_FAILED = "registered saved plan verification failed"
 
 
 def _run_logger() -> tuple[RunLogger, bool]:
@@ -157,6 +162,15 @@ def _plan(
     return saved
 
 
+def _verify_registered_apply(*, instance: Any, run_id: str, binding: tuple[str, int, str]) -> None:
+    """Verify a bound artifact before the apply path can construct a destination."""
+    artifact = read_plan_artifact_bytes(resolve_run_directory(instance.name, run_id))
+    if verify_plan(artifact=artifact, run_id=run_id, config_version=resolve_config_version(instance)):
+        raise ValueError(_REGISTERED_PLAN_VERIFICATION_FAILED)
+    if parse_plan_artifact(artifact, run_id=run_id).manifest.configuration_binding != binding:
+        raise ValueError(_REGISTERED_PLAN_BINDING_MISMATCH)
+
+
 def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
     run_id: str,
     stage: Literal["plan", "verify", "apply", "sync"],
@@ -196,6 +210,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         raise ValueError(_REGISTERED_CHECKSUM_MISMATCH)
     sync_name = package.configuration.name
     instance = resolve_runtime_instance(package, directory=config_directory)
+    instance._configuration_binding = (config_id, registry_version, package_checksum)
     secrets[:] = collect_secret_values(instance)
     result: dict[str, Any]
     if stage == "plan":
@@ -229,6 +244,11 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
             secrets=secrets,
         )
     elif stage == "apply":
+        _verify_registered_apply(
+            instance=instance,
+            run_id=run_id,
+            binding=(config_id, registry_version, package_checksum),
+        )
         applied = execute_run(
             instance,
             operation="apply",
@@ -260,6 +280,11 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 _require_verified=True,
             )
             assert isinstance(verified, SavedPlan)
+            _verify_registered_apply(
+                instance=instance,
+                run_id=run_id,
+                binding=(config_id, registry_version, package_checksum),
+            )
             applied = execute_run(
                 instance,
                 operation="apply",

--- a/infrahub_sync/managed/models.py
+++ b/infrahub_sync/managed/models.py
@@ -12,6 +12,8 @@ from infrahub_sync.product_store import ArtifactReference, ProductRun  # noqa: T
 ManagedStage = Literal["plan", "verify", "apply", "sync"]
 _REASON_GRAMMAR_MESSAGE = "reason must be printable and trimmed"
 _JSON_NATIVE_PACKAGE_MESSAGE = "package must be recursively exact JSON-native"
+_REGISTRY_VERSION_TYPE_MESSAGE = "registry_version must be int"
+_REGISTRY_VERSION_RANGE_MESSAGE = "registry_version must be in the registry allocatable range"
 
 
 class _StrictModel(BaseModel):
@@ -21,12 +23,21 @@ class _StrictModel(BaseModel):
 class CreateRunRequest(_StrictModel):
     """Create one managed plan or confirmed composed sync."""
 
-    sync_name: str = Field(min_length=1)
     operation: Literal["plan", "sync"] = "plan"
-    configuration_reference: str = Field(min_length=1)
+    config_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+    registry_version: int
     branch: str | None = None
     confirm_writes: bool = False
     reason: str = Field(min_length=1)
+
+    @field_validator("registry_version", mode="before")
+    @classmethod
+    def _require_exact_registry_version(cls, value: object) -> int:
+        if type(value) is not int:  # pylint: disable=unidiomatic-typecheck  # bool is not a registry version.
+            raise ValueError(_REGISTRY_VERSION_TYPE_MESSAGE)
+        if not 1 <= value <= 2**63 - 1:
+            raise ValueError(_REGISTRY_VERSION_RANGE_MESSAGE)
+        return value
 
 
 class VerifyRunRequest(_StrictModel):

--- a/infrahub_sync/managed/service.py
+++ b/infrahub_sync/managed/service.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from pydantic import ValidationError
 
 from infrahub_sync.cache.paths import generate_run_id
+from infrahub_sync.configuration import ConfigurationPackageParseError, parse_configuration_package
 from infrahub_sync.execution import collect_secret_values, redact, sanitize_exception_chain
 from infrahub_sync.plan.canonical import canonical_json_bytes
 from infrahub_sync.product_store import (
@@ -85,10 +86,10 @@ class ManagedRunService:
             principal.actor,
             request.operation,
             request.reason,
-            sync_name=request.sync_name,
-            configuration_reference=request.configuration_reference,
+            config_id=request.config_id,
             branch=request.branch,
         )
+        sync_name, package_checksum = self._registered_configuration(request)
         if request.operation == "sync" and not request.confirm_writes:
             self._audit(
                 None,
@@ -114,11 +115,14 @@ class ManagedRunService:
         run = ProductRun(
             run_id=run_id,
             operation=request.operation,
-            configuration_reference=request.configuration_reference,
+            configuration_reference=f"{request.config_id}@{request.registry_version}",
+            config_id=request.config_id,
+            registry_version=request.registry_version,
+            package_checksum=package_checksum,
             actor=principal.actor,
             started_at=now,
             phase="accepted",
-            summary={"sync_name": request.sync_name},
+            summary={"sync_name": sync_name},
         )
         reserved, _ = self._projection.reserve_mutation(
             receipt,
@@ -138,14 +142,32 @@ class ManagedRunService:
             return self._stored_response(reserved)
         parameters: dict[str, object] = {
             "run_id": reserved.run_id,
-            "sync_name": request.sync_name,
             "stage": request.operation,
-            "configuration_reference": request.configuration_reference,
+            "config_id": request.config_id,
+            "registry_version": request.registry_version,
+            "package_checksum": package_checksum,
             "branch": request.branch,
             "expected_checksum": None,
             "confirm_writes": request.confirm_writes,
         }
         return await self._submit(reserved, parameters, principal, request.reason)
+
+    def _registered_configuration(self, request: CreateRunRequest) -> tuple[str, str]:
+        """Read the immutable registered package before allocating any run-side state."""
+        stored = self._projection.lookup_configuration_version(request.config_id, request.registry_version).value
+        if stored is None:
+            raise self._error(
+                404, "configuration-version-not-found", "the requested configuration version does not exist"
+            )
+        try:
+            package = parse_configuration_package(stored.declared_content)
+        except ConfigurationPackageParseError:
+            raise self._error(
+                503, "configuration-version-invalid", "the registered configuration version is invalid"
+            ) from None
+        if package.checksum() != stored.package_checksum:
+            raise self._error(503, "configuration-version-invalid", "the registered configuration version is invalid")
+        return package.configuration.name, stored.package_checksum
 
     async def verify_run(
         self, run_id: str, request: VerifyRunRequest, principal: Principal, idempotency_key: str
@@ -658,15 +680,17 @@ class ManagedRunService:
         expected_checksum: str | None = None,
         confirm_writes: bool = False,
     ) -> dict[str, object]:
-        return {
+        parameters: dict[str, object] = {
             "run_id": run.run_id,
-            "sync_name": str(run.summary.get("sync_name", run.configuration_reference)),
             "stage": stage,
-            "configuration_reference": run.configuration_reference,
             "branch": branch,
             "expected_checksum": expected_checksum,
             "confirm_writes": confirm_writes,
         }
+        binding = run.configuration_binding
+        if binding is not None:
+            parameters.update(config_id=binding[0], registry_version=binding[1], package_checksum=binding[2])
+        return parameters
 
     @staticmethod
     def _stored_response(receipt: MutationReceipt) -> tuple[int, dict[str, Any]]:

--- a/infrahub_sync/plan/models.py
+++ b/infrahub_sync/plan/models.py
@@ -322,9 +322,41 @@ class PlanManifest(BaseModel):
     operations_count: int = Field(ge=0)
     delete_operations_computed: bool
     plan_checksum: str
+    # Registered plans bind the exact configuration package the worker verified.  The
+    # three values are deliberately separate artifact fields so they participate in the
+    # canonical checksum alongside every other manifest fact.
+    config_id: str | None = Field(default=None, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+    registry_version: int | None = Field(default=None, ge=1, le=2**63 - 1)
+    package_checksum: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     # Additive: manifests written before this field exists carry no
     # binding, and the apply-time destination comparison skips them.
     destination_binding: DestinationBindingRecord | None = None
+
+    @field_validator("registry_version", mode="before")
+    @classmethod
+    def _require_exact_registry_version(cls, value: object) -> object:
+        """Refuse coercible values; a binding is an exact registry identity."""
+        if value is not None and type(value) is not int:
+            msg = "registry_version must be int"
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _require_complete_configuration_binding(self) -> PlanManifest:
+        binding = (self.config_id, self.registry_version, self.package_checksum)
+        if any(value is None for value in binding) and any(value is not None for value in binding):
+            msg = "configuration binding must be all absent or all present"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def configuration_binding(self) -> tuple[str, int, str] | None:
+        """Return the complete registered package identity, never a partial tuple."""
+        if self.config_id is None:
+            return None
+        assert self.registry_version is not None
+        assert self.package_checksum is not None
+        return self.config_id, self.registry_version, self.package_checksum
 
     @model_serializer(mode="wrap")
     def _serialize_without_absent_binding(self, handler: Any) -> dict[str, Any]:
@@ -337,6 +369,10 @@ class PlanManifest(BaseModel):
         data: dict[str, Any] = handler(self)
         if data.get("destination_binding") is None:
             data.pop("destination_binding", None)
+        if self.configuration_binding is None:
+            data.pop("config_id", None)
+            data.pop("registry_version", None)
+            data.pop("package_checksum", None)
         return data
 
 

--- a/infrahub_sync/plan/models.py
+++ b/infrahub_sync/plan/models.py
@@ -336,7 +336,8 @@ class PlanManifest(BaseModel):
     @classmethod
     def _require_exact_registry_version(cls, value: object) -> object:
         """Refuse coercible values; a binding is an exact registry identity."""
-        if value is not None and type(value) is not int:
+        if value is not None and type(value) is not int:  # pylint: disable=unidiomatic-typecheck
+            # Exact identity excludes bool and int subclasses.
             msg = "registry_version must be int"
             raise ValueError(msg)
         return value

--- a/infrahub_sync/plan/writer.py
+++ b/infrahub_sync/plan/writer.py
@@ -177,6 +177,7 @@ def write_plan_artifact(
     deletes_computed: bool,
     operations: Sequence[PlannedOperation],
     destination_binding: DestinationBindingRecord | None = None,
+    configuration_binding: tuple[str, int, str] | None = None,
 ) -> PlanManifest:
     """Write `<run_dir>/plan/` and return the manifest that was written.
 
@@ -216,6 +217,12 @@ def write_plan_artifact(
     if destination_binding is not None:
         # Before the checksum below, so the recorded binding is covered by it.
         body["destination_binding"] = destination_binding.model_dump()
+    if configuration_binding is not None:
+        body.update(
+            config_id=configuration_binding[0],
+            registry_version=configuration_binding[1],
+            package_checksum=configuration_binding[2],
+        )
     body["plan_checksum"] = compute_plan_checksum(body, operations_bytes)
     manifest = PlanManifest.model_validate(body)
 

--- a/infrahub_sync/potenda/__init__.py
+++ b/infrahub_sync/potenda/__init__.py
@@ -158,6 +158,7 @@ class Potenda:
         self._counts: dict[str, int] = {}
         self._last_plan_action_counts: dict[str, int] | None = None
         self._last_applied_plan_action_counts: dict[str, int] | None = None
+        self.configuration_binding = getattr(config, "_configuration_binding", None)
         self._did_full_extract: bool = False
         # Per-side extraction mode, recorded alongside the OR-accumulated
         # `_did_full_extract` rather than in place of it. FR-015 derives deletes only
@@ -556,6 +557,7 @@ class Potenda:
             # The resolved destination identity, when the adapter captured one; `None`
             # writes the manifest shape older plans carry.
             destination_binding=getattr(self.destination, "destination_binding", None),
+            configuration_binding=self.configuration_binding,
         )
         logger.info(
             "Plan artifact: wrote %d operation(s) to %s (deletes computed: %s)",

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -79,6 +79,9 @@ class ProductRun(BaseModel):
     run_id: str = Field(pattern=_IDENTIFIER_PATTERN)
     operation: Operation
     configuration_reference: str = Field(min_length=1)
+    config_id: str | None = Field(default=None, pattern=_IDENTIFIER_PATTERN)
+    registry_version: int | None = Field(default=None, ge=1, le=2**63 - 1)
+    package_checksum: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     actor: str | None = None
     audit_links: tuple[str, ...] = ()
     started_at: datetime
@@ -100,6 +103,10 @@ class ProductRun(BaseModel):
 
     @model_validator(mode="after")
     def _require_consistent_children(self) -> ProductRun:
+        binding = (self.config_id, self.registry_version, self.package_checksum)
+        if any(value is None for value in binding) and any(value is not None for value in binding):
+            msg = "configuration binding must be all absent or all present"
+            raise ValueError(msg)
         if self.finished_at is not None and self.outcome is None:
             msg = "a finished product record requires an outcome"
             raise ValueError(msg)
@@ -115,6 +122,15 @@ class ProductRun(BaseModel):
             msg = "Prefect flow-run IDs must be unique within a product record"
             raise ValueError(msg)
         return self
+
+    @property
+    def configuration_binding(self) -> tuple[str, int, str] | None:
+        """Return the complete registered package identity, never a partial tuple."""
+        if self.config_id is None:
+            return None
+        assert self.registry_version is not None
+        assert self.package_checksum is not None
+        return self.config_id, self.registry_version, self.package_checksum
 
 
 class MutationReceipt(BaseModel):

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -192,10 +192,12 @@ _SELECT_NEXT_CONFIGURATION_VERSION = (
     "SELECT COALESCE(MAX(registry_version) + 1, 1) FROM configuration_versions WHERE config_id = ?"
 )
 
-_INSERT_PRODUCT_RUN = """INSERT INTO product_runs (run_id, operation, configuration_reference, actor, audit_links,
-started_at, finished_at, phase, outcome, summary, results) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+_INSERT_PRODUCT_RUN = """INSERT INTO product_runs (run_id, operation, configuration_reference, config_id,
+registry_version, package_checksum, actor, audit_links, started_at, finished_at, phase, outcome, summary, results)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _SELECT_PRODUCT_RUN = """SELECT run_id, operation, configuration_reference, actor, audit_links, started_at,
-finished_at, phase, outcome, summary, results FROM product_runs WHERE run_id = ?"""
+finished_at, phase, outcome, summary, results, config_id, registry_version, package_checksum
+FROM product_runs WHERE run_id = ?"""
 _SELECT_RUN_ARTIFACT_REFERENCES = """SELECT run_id, artifact_id, kind, media_type, digest, size, object_key,
 manifest_key, created_at, expires_at, published FROM artifact_refs WHERE run_id = ? AND published = 1 ORDER BY artifact_id"""
 _SELECT_ARTIFACT_REFERENCE = """SELECT run_id, artifact_id, kind, media_type, digest, size, object_key,
@@ -596,6 +598,9 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 run.run_id,
                 run.operation,
                 run.configuration_reference,
+                run.config_id,
+                run.registry_version,
+                run.package_checksum,
                 run.actor,
                 _json(run.audit_links),
                 run.started_at.isoformat(),
@@ -1853,6 +1858,9 @@ def _run_from_rows(
             "outcome": row[8],
             "summary": json.loads(row[9]),
             "results": json.loads(row[10]),
+            "config_id": row[11],
+            "registry_version": row[12],
+            "package_checksum": row[13],
             "artifact_refs": [_reference_from_row(item).model_dump() for item in references],
             "prefect_executions": [
                 {

--- a/tests/configuration/test_adapter_setting_conformance.py
+++ b/tests/configuration/test_adapter_setting_conformance.py
@@ -65,6 +65,17 @@ def _literal_setting_method_access(node: ast.AST) -> str | None:
     return _literal_string(node.args[0])
 
 
+def _registered_credential_access(node: ast.AST) -> str | None:
+    """Return the setting consumed through the shared credential boundary."""
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+        return None
+    if node.func.id != "select_runtime_credential" or len(node.args) < 2:
+        return None
+    if not _is_settings_reference(node.args[0]):
+        return None
+    return _literal_string(node.args[1])
+
+
 def _literal_setting_accesses(module_name: str) -> frozenset[str]:
     tree = ast.parse((_ADAPTERS_DIRECTORY / f"{module_name}.py").read_text(encoding="utf-8"))
     setting_names: set[str] = set()
@@ -86,6 +97,12 @@ def _literal_setting_accesses(module_name: str) -> frozenset[str]:
                 setting_names.update(
                     setting_name for operand in operands if (setting_name := _literal_string(operand)) is not None
                 )
+
+        # Credential selection is a shared authority boundary.  Its setting name is
+        # still a real adapter consumer, even though the helper (rather than the
+        # adapter) performs the Mapping lookup.
+        if (setting_name := _registered_credential_access(node)) is not None:
+            setting_names.add(setting_name)
 
     return frozenset(setting_names)
 

--- a/tests/configuration/test_registered_adapter_authority.py
+++ b/tests/configuration/test_registered_adapter_authority.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any, cast
 
 import pytest
 
@@ -111,15 +113,15 @@ ROWS = (
 
 def _install_optional_sdk_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make optional imports deterministic before each dynamic adapter import."""
-    pynetbox = types.ModuleType("pynetbox")
-    pynetbox.api = lambda *_args, **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
-    pynautobot = types.ModuleType("pynautobot")
-    pynautobot.api = lambda **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
+    pynetbox = cast("Any", types.ModuleType("pynetbox"))
+    pynetbox.api = lambda *_args, **_kwargs: types.SimpleNamespace()
+    pynautobot = cast("Any", types.ModuleType("pynautobot"))
+    pynautobot.api = lambda **_kwargs: types.SimpleNamespace()
     core = types.ModuleType("pynautobot.core")
-    query = types.ModuleType("pynautobot.core.query")
-    query.RequestError = RuntimeError  # type: ignore[attr-defined]
-    ipfabric = types.ModuleType("ipfabric")
-    ipfabric.IPFClient = lambda **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
+    query = cast("Any", types.ModuleType("pynautobot.core.query"))
+    query.RequestError = RuntimeError
+    ipfabric = cast("Any", types.ModuleType("ipfabric"))
+    ipfabric.IPFClient = lambda **_kwargs: types.SimpleNamespace()
     for name, module in {
         "pynetbox": pynetbox,
         "pynautobot": pynautobot,
@@ -141,12 +143,12 @@ def _class_name(row: AdapterRow) -> str:
     return "".join(part.title() for part in row.name.split("_")) + "Adapter"
 
 
-def _instance(row: AdapterRow, settings: dict[str, str]) -> SyncInstance:
+def _instance(row: AdapterRow, settings: Mapping[str, object]) -> SyncInstance:
     return SyncInstance(
         name=f"ar5-{row.name}",
         directory="/registered-runtime",
-        source=SyncAdapter(name=row.name, settings=settings.copy()),
-        destination=SyncAdapter(name=row.name, settings=settings.copy()),
+        source=SyncAdapter(name=row.name, settings=dict(settings)),
+        destination=SyncAdapter(name=row.name, settings=dict(settings)),
     )
 
 
@@ -154,6 +156,7 @@ def _capture_client(
     monkeypatch: pytest.MonkeyPatch, row: AdapterRow, module: types.ModuleType
 ) -> list[dict[str, object]]:
     observed: list[dict[str, object]] = []
+    dynamic_module = cast("Any", module)
 
     def capture(**kwargs: object) -> object:
         observed.append(kwargs)
@@ -165,37 +168,37 @@ def _capture_client(
         return types.SimpleNamespace(get=lambda *_args, **_kwargs: types.SimpleNamespace(json=lambda: {"imdata": []}))
 
     if row.name == "aci":
-        monkeypatch.setattr(module, "AciApiClient", capture)
+        monkeypatch.setattr(dynamic_module, "AciApiClient", capture)
     elif row.name == "infrahub":
 
         class MissingNodeError(Exception):
             pass
 
-        monkeypatch.setattr(module, "NodeNotFoundError", MissingNodeError)
-        monkeypatch.setattr(module, "Config", lambda **kwargs: kwargs)
-        monkeypatch.setattr(module, "InfrahubClientSync", capture)
+        monkeypatch.setattr(dynamic_module, "NodeNotFoundError", MissingNodeError)
+        monkeypatch.setattr(dynamic_module, "Config", lambda **kwargs: kwargs)
+        monkeypatch.setattr(dynamic_module, "InfrahubClientSync", capture)
     elif row.name == "netbox":
-        monkeypatch.setattr(module.pynetbox, "api", lambda url, token: capture(url=url, token=token))
+        monkeypatch.setattr(dynamic_module.pynetbox, "api", lambda url, token: capture(url=url, token=token))
     elif row.name == "nautobot":
-        monkeypatch.setattr(module.pynautobot, "api", capture)
+        monkeypatch.setattr(dynamic_module.pynautobot, "api", capture)
     elif row.name == "prometheus":
-        monkeypatch.setattr(module, "PrometheusScrapeClient", capture)
+        monkeypatch.setattr(dynamic_module, "PrometheusScrapeClient", capture)
     elif row.name == "ipfabricsync":
-        monkeypatch.setattr(module, "IPFClient", capture)
+        monkeypatch.setattr(dynamic_module, "IPFClient", capture)
     else:
         monkeypatch.setattr(importlib.import_module("infrahub_sync.adapters.genericrestapi"), "RestApiClient", capture)
     return observed
 
 
-def _observed(row: AdapterRow, kwargs: dict[str, object]) -> dict[str, object]:
+def _observed(row: AdapterRow, kwargs: dict[str, Any]) -> dict[str, object]:
     if row.name == "aci":
         return {
             "url": kwargs["base_url"].removesuffix("/api/"),
             "username": kwargs["username"],
             "password": kwargs["password"],
-        }  # type: ignore[union-attr]
+        }
     if row.name == "infrahub":
-        return {"url": kwargs["address"], "token": kwargs["config"]["api_token"]}  # type: ignore[index]
+        return {"url": kwargs["address"], "token": kwargs["config"]["api_token"]}
     if row.name in {"netbox", "nautobot"}:
         return {"url": kwargs["url"], "token": kwargs["token"]}
     if row.name == "prometheus":
@@ -265,7 +268,7 @@ def test_apply_constructs_only_registered_destination(
     calls: list[str] = []
 
     def adapter_factory(**kwargs: object) -> type[object]:
-        calls.append(kwargs["adapter"].name)  # type: ignore[index]
+        calls.append(cast("SyncAdapter", kwargs["adapter"]).name)
         return getattr(module, _class_name(row))
 
     monkeypatch.setattr("infrahub_sync.utils.import_adapter", adapter_factory)
@@ -288,7 +291,8 @@ def test_registered_writebacks_never_copy_ambient_credentials(
     monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: getattr(module, _class_name(row)))
     get_potenda_from_instance(instance, run_id="ar5-writeback")
     for adapter in (instance.source, instance.destination):
-        assert not any(value in row.ambient.values() for value in adapter.settings.values())  # type: ignore[union-attr]
+        assert adapter.settings is not None
+        assert not any(value in row.ambient.values() for value in adapter.settings.values())
 
 
 def test_peeringmanager_defaults_reach_genericrestapi_without_overriding_registered_values(
@@ -306,5 +310,6 @@ def test_peeringmanager_defaults_reach_genericrestapi_without_overriding_registe
     get_potenda_from_instance(instance, run_id="ar5-peering")
     assert [_observed(row, call) for call in observed] == [row.expected, row.expected]
     for adapter in (instance.source, instance.destination):
-        assert adapter.settings["url_env_vars"] == ["PEERING_MANAGER_ADDRESS", "PEERING_MANAGER_URL"]  # type: ignore[index]
-        assert adapter.settings["token_env_vars"] == ["PEERING_MANAGER_TOKEN"]  # type: ignore[index]
+        assert adapter.settings is not None
+        assert adapter.settings["url_env_vars"] == ["PEERING_MANAGER_ADDRESS", "PEERING_MANAGER_URL"]
+        assert adapter.settings["token_env_vars"] == ["PEERING_MANAGER_TOKEN"]

--- a/tests/configuration/test_registered_adapter_authority.py
+++ b/tests/configuration/test_registered_adapter_authority.py
@@ -1,0 +1,310 @@
+"""AR5: registered credentials win at the real adapter construction seams."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+from infrahub_sync import SyncAdapter, SyncInstance
+from infrahub_sync.utils import PlanApplier, get_potenda_from_instance
+
+
+@dataclass(frozen=True)
+class AdapterRow:
+    """One bundled adapter's observable credential paths."""
+
+    name: str
+    settings: dict[str, str]
+    ambient: dict[str, str]
+    expected: dict[str, str]
+    legacy: dict[str, str]
+
+
+ROWS = (
+    AdapterRow(
+        "aci",
+        {"url": "https://registered-aci", "username": "registered-user", "password": "registered-pass"},
+        {
+            "CISCO_APIC_URL": "https://ambient-aci",
+            "CISCO_APIC_USERNAME": "ambient-user",
+            "CISCO_APIC_PASSWORD": "ambient-pass",
+        },
+        {"url": "https://registered-aci", "username": "registered-user", "password": "registered-pass"},
+        {"url": "https://ambient-aci", "username": "ambient-user", "password": "ambient-pass"},
+    ),
+    AdapterRow(
+        "infrahub",
+        {"url": "https://registered-infrahub", "token": "registered-token"},
+        {"INFRAHUB_ADDRESS": "https://ambient-infrahub", "INFRAHUB_API_TOKEN": "ambient-token"},
+        {"url": "https://registered-infrahub", "token": "registered-token"},
+        {"url": "https://ambient-infrahub", "token": "ambient-token"},
+    ),
+    AdapterRow(
+        "netbox",
+        {"url": "https://registered-netbox", "token": "registered-token"},
+        {"NETBOX_ADDRESS": "https://ambient-netbox", "NETBOX_TOKEN": "ambient-token"},
+        {"url": "https://registered-netbox", "token": "registered-token"},
+        {"url": "https://ambient-netbox", "token": "ambient-token"},
+    ),
+    AdapterRow(
+        "nautobot",
+        {"url": "https://registered-nautobot", "token": "registered-token"},
+        {"NAUTOBOT_ADDRESS": "https://ambient-nautobot", "NAUTOBOT_TOKEN": "ambient-token"},
+        {"url": "https://registered-nautobot", "token": "registered-token"},
+        {"url": "https://ambient-nautobot", "token": "ambient-token"},
+    ),
+    AdapterRow(
+        "prometheus",
+        {
+            "url": "https://registered-prometheus",
+            "username": "registered-user",
+            "password": "registered-pass",
+            "token": "registered-token",
+            "auth_method": "bearer",
+        },
+        {
+            "PROM_URL": "https://ambient-prometheus",
+            "PROM_USERNAME": "ambient-user",
+            "PROM_PASSWORD": "ambient-pass",
+            "PROM_TOKEN": "ambient-token",
+        },
+        {
+            "url": "https://registered-prometheus",
+            "username": "registered-user",
+            "password": "registered-pass",
+            "token": "registered-token",
+        },
+        {
+            "url": "https://ambient-prometheus",
+            "username": "ambient-user",
+            "password": "ambient-pass",
+            "token": "ambient-token",
+        },
+    ),
+    AdapterRow(
+        "ipfabricsync",
+        {"base_url": "https://registered-ipfabric", "auth": "registered-token"},
+        {"IPF_URL": "https://ambient-ipfabric", "IPF_TOKEN": "ambient-token"},
+        {"url": "https://registered-ipfabric", "token": "registered-token"},
+        {"url": "https://registered-ipfabric", "token": "registered-token"},
+    ),
+    AdapterRow(
+        "peeringmanager",
+        {"url": "https://registered-peering", "token": "registered-token"},
+        {"PEERING_MANAGER_ADDRESS": "https://ambient-peering", "PEERING_MANAGER_TOKEN": "ambient-token"},
+        {"url": "https://registered-peering", "token": "registered-token"},
+        {"url": "https://ambient-peering", "token": "ambient-token"},
+    ),
+    AdapterRow(
+        "genericrestapi",
+        {"url": "https://registered-generic", "token": "registered-token"},
+        {"URL": "https://ambient-generic", "TOKEN": "ambient-token"},
+        {"url": "https://registered-generic", "token": "registered-token"},
+        {"url": "https://ambient-generic", "token": "ambient-token"},
+    ),
+)
+
+
+def _install_optional_sdk_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make optional imports deterministic before each dynamic adapter import."""
+    pynetbox = types.ModuleType("pynetbox")
+    pynetbox.api = lambda *_args, **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
+    pynautobot = types.ModuleType("pynautobot")
+    pynautobot.api = lambda **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
+    core = types.ModuleType("pynautobot.core")
+    query = types.ModuleType("pynautobot.core.query")
+    query.RequestError = RuntimeError  # type: ignore[attr-defined]
+    ipfabric = types.ModuleType("ipfabric")
+    ipfabric.IPFClient = lambda **_kwargs: types.SimpleNamespace()  # type: ignore[attr-defined]
+    for name, module in {
+        "pynetbox": pynetbox,
+        "pynautobot": pynautobot,
+        "pynautobot.core": core,
+        "pynautobot.core.query": query,
+        "ipfabric": ipfabric,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _adapter_module(monkeypatch: pytest.MonkeyPatch, row: AdapterRow) -> types.ModuleType:
+    _install_optional_sdk_stubs(monkeypatch)
+    module_name = f"infrahub_sync.adapters.{row.name}"
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def _class_name(row: AdapterRow) -> str:
+    return "".join(part.title() for part in row.name.split("_")) + "Adapter"
+
+
+def _instance(row: AdapterRow, settings: dict[str, str]) -> SyncInstance:
+    return SyncInstance(
+        name=f"ar5-{row.name}",
+        directory="/registered-runtime",
+        source=SyncAdapter(name=row.name, settings=settings.copy()),
+        destination=SyncAdapter(name=row.name, settings=settings.copy()),
+    )
+
+
+def _capture_client(
+    monkeypatch: pytest.MonkeyPatch, row: AdapterRow, module: types.ModuleType
+) -> list[dict[str, object]]:
+    observed: list[dict[str, object]] = []
+
+    def capture(**kwargs: object) -> object:
+        observed.append(kwargs)
+        if row.name == "infrahub":
+            return types.SimpleNamespace(
+                get=lambda *_args, **_kwargs: None,
+                schema=types.SimpleNamespace(all=lambda **_kwargs: {}),
+            )
+        return types.SimpleNamespace(get=lambda *_args, **_kwargs: types.SimpleNamespace(json=lambda: {"imdata": []}))
+
+    if row.name == "aci":
+        monkeypatch.setattr(module, "AciApiClient", capture)
+    elif row.name == "infrahub":
+
+        class MissingNodeError(Exception):
+            pass
+
+        monkeypatch.setattr(module, "NodeNotFoundError", MissingNodeError)
+        monkeypatch.setattr(module, "Config", lambda **kwargs: kwargs)
+        monkeypatch.setattr(module, "InfrahubClientSync", capture)
+    elif row.name == "netbox":
+        monkeypatch.setattr(module.pynetbox, "api", lambda url, token: capture(url=url, token=token))
+    elif row.name == "nautobot":
+        monkeypatch.setattr(module.pynautobot, "api", capture)
+    elif row.name == "prometheus":
+        monkeypatch.setattr(module, "PrometheusScrapeClient", capture)
+    elif row.name == "ipfabricsync":
+        monkeypatch.setattr(module, "IPFClient", capture)
+    else:
+        monkeypatch.setattr(importlib.import_module("infrahub_sync.adapters.genericrestapi"), "RestApiClient", capture)
+    return observed
+
+
+def _observed(row: AdapterRow, kwargs: dict[str, object]) -> dict[str, object]:
+    if row.name == "aci":
+        return {
+            "url": kwargs["base_url"].removesuffix("/api/"),
+            "username": kwargs["username"],
+            "password": kwargs["password"],
+        }  # type: ignore[union-attr]
+    if row.name == "infrahub":
+        return {"url": kwargs["address"], "token": kwargs["config"]["api_token"]}  # type: ignore[index]
+    if row.name in {"netbox", "nautobot"}:
+        return {"url": kwargs["url"], "token": kwargs["token"]}
+    if row.name == "prometheus":
+        return {
+            "url": kwargs["base_url"],
+            "username": kwargs["username"],
+            "password": kwargs["password"],
+            "token": kwargs["api_token"],
+        }
+    if row.name == "ipfabricsync":
+        return {"url": kwargs["base_url"], "token": kwargs["auth"]}
+    return {"url": str(kwargs["base_url"]).removesuffix("/api/v0").removesuffix("/api"), "token": kwargs["api_token"]}
+
+
+def _patch_engine(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    class Engine:
+        def __init__(self, **kwargs: object) -> None:
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr("infrahub_sync.utils.Potenda", Engine)
+    monkeypatch.setattr("infrahub_sync.utils.stored_run_dir", lambda *_args: tmp_path)
+
+
+@pytest.mark.parametrize("row", ROWS, ids=lambda row: row.name)
+def test_registered_values_win_over_ambient_through_get_potenda(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object, row: AdapterRow
+) -> None:
+    """Both source and destination construction observe worker-resolved values."""
+    module = _adapter_module(monkeypatch, row)
+    observed = _capture_client(monkeypatch, row, module)
+    instance = _instance(row, {**row.settings, "_infrahub_sync_registered_context": True})
+    for name, value in row.ambient.items():
+        monkeypatch.setenv(name, value)
+    _patch_engine(monkeypatch, tmp_path)
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: getattr(module, _class_name(row)))
+    get_potenda_from_instance(instance, run_id="ar5-registered")
+    assert [_observed(row, call) for call in observed] == [row.expected, row.expected]
+
+
+@pytest.mark.parametrize("row", ROWS, ids=lambda row: row.name)
+def test_legacy_values_keep_committed_precedence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object, row: AdapterRow
+) -> None:
+    """No marker preserves every accepted legacy lookup order."""
+    module = _adapter_module(monkeypatch, row)
+    observed = _capture_client(monkeypatch, row, module)
+    instance = _instance(row, row.settings)
+    for name, value in row.ambient.items():
+        monkeypatch.setenv(name, value)
+    _patch_engine(monkeypatch, tmp_path)
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: getattr(module, _class_name(row)))
+    get_potenda_from_instance(instance, run_id="ar5-legacy")
+    assert [_observed(row, call) for call in observed] == [row.legacy, row.legacy]
+
+
+@pytest.mark.parametrize("row", ROWS, ids=lambda row: row.name)
+def test_apply_constructs_only_registered_destination(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object, row: AdapterRow
+) -> None:
+    """Plan apply constructs no source and its destination sees registered values."""
+    module = _adapter_module(monkeypatch, row)
+    observed = _capture_client(monkeypatch, row, module)
+    instance = _instance(row, {**row.settings, "_infrahub_sync_registered_context": True})
+    for name, value in row.ambient.items():
+        monkeypatch.setenv(name, value)
+    _patch_engine(monkeypatch, tmp_path)
+    calls: list[str] = []
+
+    def adapter_factory(**kwargs: object) -> type[object]:
+        calls.append(kwargs["adapter"].name)  # type: ignore[index]
+        return getattr(module, _class_name(row))
+
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", adapter_factory)
+    PlanApplier.open_existing(instance, run_id="ar5-apply")
+    assert calls == [row.name]
+    assert [_observed(row, call) for call in observed] == [row.expected]
+
+
+@pytest.mark.parametrize("row", [ROWS[5], ROWS[6]], ids=lambda row: row.name)
+def test_registered_writebacks_never_copy_ambient_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object, row: AdapterRow
+) -> None:
+    """The two settings write-back paths cannot preserve ambient credentials."""
+    module = _adapter_module(monkeypatch, row)
+    _capture_client(monkeypatch, row, module)
+    instance = _instance(row, {**row.settings, "_infrahub_sync_registered_context": True})
+    for name, value in row.ambient.items():
+        monkeypatch.setenv(name, value)
+    _patch_engine(monkeypatch, tmp_path)
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: getattr(module, _class_name(row)))
+    get_potenda_from_instance(instance, run_id="ar5-writeback")
+    for adapter in (instance.source, instance.destination):
+        assert not any(value in row.ambient.values() for value in adapter.settings.values())  # type: ignore[union-attr]
+
+
+def test_peeringmanager_defaults_reach_genericrestapi_without_overriding_registered_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    """Delegated custom env-variable defaults cannot trump the registered URL/token."""
+    row = ROWS[6]
+    module = _adapter_module(monkeypatch, row)
+    observed = _capture_client(monkeypatch, row, module)
+    instance = _instance(row, {**row.settings, "_infrahub_sync_registered_context": True})
+    for name, value in row.ambient.items():
+        monkeypatch.setenv(name, value)
+    _patch_engine(monkeypatch, tmp_path)
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: module.PeeringmanagerAdapter)
+    get_potenda_from_instance(instance, run_id="ar5-peering")
+    assert [_observed(row, call) for call in observed] == [row.expected, row.expected]
+    for adapter in (instance.source, instance.destination):
+        assert adapter.settings["url_env_vars"] == ["PEERING_MANAGER_ADDRESS", "PEERING_MANAGER_URL"]  # type: ignore[index]
+        assert adapter.settings["token_env_vars"] == ["PEERING_MANAGER_TOKEN"]  # type: ignore[index]

--- a/tests/configuration/test_registered_adapter_authority.py
+++ b/tests/configuration/test_registered_adapter_authority.py
@@ -213,6 +213,15 @@ def _observed(row: AdapterRow, kwargs: dict[str, Any]) -> dict[str, object]:
     return {"url": str(kwargs["base_url"]).removesuffix("/api/v0").removesuffix("/api"), "token": kwargs["api_token"]}
 
 
+def _basic_observed(kwargs: dict[str, object]) -> dict[str, object]:
+    """Return the Generic REST client's complete basic-auth input."""
+    return {
+        "url": str(kwargs["base_url"]).removesuffix("/api/v0").removesuffix("/api"),
+        "username": kwargs["username"],
+        "password": kwargs["password"],
+    }
+
+
 def _patch_engine(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
     class Engine:
         def __init__(self, **kwargs: object) -> None:
@@ -313,3 +322,45 @@ def test_peeringmanager_defaults_reach_genericrestapi_without_overriding_registe
         assert adapter.settings is not None
         assert adapter.settings["url_env_vars"] == ["PEERING_MANAGER_ADDRESS", "PEERING_MANAGER_URL"]
         assert adapter.settings["token_env_vars"] == ["PEERING_MANAGER_TOKEN"]
+
+
+@pytest.mark.parametrize("adapter_name", ["genericrestapi", "peeringmanager"])
+@pytest.mark.parametrize("construction", ["normal", "apply"])
+def test_registered_basic_auth_wins_over_ambient_at_every_genericrestapi_seam(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+    adapter_name: str,
+    construction: str,
+) -> None:
+    """Delegated Generic REST basic auth must not recover ambient credentials."""
+    row = next(candidate for candidate in ROWS if candidate.name == adapter_name)
+    module = _adapter_module(monkeypatch, row)
+    observed = _capture_client(monkeypatch, row, module)
+    instance = _instance(
+        row,
+        {
+            "url": f"https://registered-{adapter_name}",
+            "auth_method": "basic",
+            "username": "registered-basic-user",
+            "password": "registered-basic-password",
+            "_infrahub_sync_registered_context": True,
+        },
+    )
+    monkeypatch.setenv("USERNAME", "ambient-basic-user")
+    monkeypatch.setenv("PASSWORD", "ambient-basic-password")
+    _patch_engine(monkeypatch, tmp_path)
+    monkeypatch.setattr("infrahub_sync.utils.import_adapter", lambda **_kwargs: getattr(module, _class_name(row)))
+
+    if construction == "normal":
+        get_potenda_from_instance(instance, run_id="ar5-basic-normal")
+    else:
+        PlanApplier.open_existing(instance, run_id="ar5-basic-apply")
+
+    expected = {
+        "url": f"https://registered-{adapter_name}",
+        "username": "registered-basic-user",
+        "password": "registered-basic-password",
+    }
+    assert [_basic_observed(call) for call in observed] == (
+        [expected, expected] if construction == "normal" else [expected]
+    )

--- a/tests/configuration/test_runtime.py
+++ b/tests/configuration/test_runtime.py
@@ -35,5 +35,7 @@ def test_runtime_instance_resolves_declared_credentials_without_ambient_lookup(m
     )
 
     instance = resolve_runtime_instance(package, directory="/registered")
+    assert instance.source.settings is not None
+    assert instance.destination.settings is not None
     assert instance.source.settings["token"] == registered
     assert instance.destination.settings["token"] == registered

--- a/tests/configuration/test_runtime.py
+++ b/tests/configuration/test_runtime.py
@@ -1,0 +1,39 @@
+"""Worker runtime construction from declared configuration packages."""
+
+from __future__ import annotations
+
+from infrahub_sync.configuration import ConfigurationPackage
+
+
+def test_runtime_instance_resolves_declared_credentials_without_ambient_lookup(monkeypatch) -> None:
+    """A registered package is executable from its declared identity alone."""
+    from infrahub_sync.configuration.runtime import resolve_runtime_instance
+
+    registered = "registered-canary"
+    monkeypatch.setenv("TOKEN", registered)
+    monkeypatch.setenv("NETBOX_TOKEN", "ambient-canary")
+    package = ConfigurationPackage.model_validate(
+        {
+            "format_version": 1,
+            "configuration": {
+                "name": "registered",
+                "source": {
+                    "name": "netbox",
+                    "settings": {"url": "https://netbox.example", "token": {"$credential": "token"}},
+                },
+                "destination": {
+                    "name": "infrahub",
+                    "settings": {"url": "https://infrahub.example", "token": {"$credential": "token"}},
+                },
+                "order": [],
+                "schema_mapping": [],
+                "diffsync_flags": [],
+                "incremental": None,
+            },
+            "credentials": {"token": {"provider": "env", "identifier": "TOKEN"}},
+        }
+    )
+
+    instance = resolve_runtime_instance(package, directory="/registered")
+    assert instance.source.settings["token"] == registered
+    assert instance.destination.settings["token"] == registered

--- a/tests/conformance/test_interface_matrix.py
+++ b/tests/conformance/test_interface_matrix.py
@@ -40,6 +40,7 @@ from infrahub_sync.plan.review import SavedPlan, read_saved_plan, resolve_run_di
 from infrahub_sync.plan.writer import write_plan_artifact
 from infrahub_sync.product_store import ProductProjection, ProductRun, local_product_projection
 from infrahub_sync.product_store.standalone import execute_standalone
+from tests.configuration.validation_packages import package, package_data
 from tests.conformance.interface_adapters import (
     cli_product_envelope,
     managed_product_envelope,
@@ -96,7 +97,7 @@ def _instance(tmp_path: Path) -> SyncInstance:
     )
 
 
-def _saved(run_id: str, instance: SyncInstance) -> SavedPlan:
+def _saved(run_id: str, instance: SyncInstance, binding: tuple[str, int, str] | None = None) -> SavedPlan:
     identity = {"name": "edge-1"}
     operation = PlannedOperation(
         operation_id=operation_id("create", "DcimDevice", identity),
@@ -116,11 +117,21 @@ def _saved(run_id: str, instance: SyncInstance) -> SavedPlan:
             operations_count=1,
             delete_operations_computed=True,
             plan_checksum="a" * 64,
+            config_id=None if binding is None else binding[0],
+            registry_version=None if binding is None else binding[1],
+            package_checksum=None if binding is None else binding[2],
         ),
         operations=[operation],
         checksum_ok=True,
         verification_notes=[],
     )
+
+
+def _register_inventory(projection: ProductProjection) -> tuple[str, int, str]:
+    declared = package_data()
+    declared["configuration"]["name"] = "inventory"
+    registered = projection.create_configuration(package(declared))
+    return registered.config_id, registered.registry_version, registered.package_checksum
 
 
 def _result(run_id: str, operation: Operation, tmp_path: Path) -> RunResult:
@@ -281,11 +292,16 @@ def _run_managed_worker(
     root = (tmp_path / "managed-products").resolve()
     destination = _DestinationProbe()
     projection = local_product_projection(root)
+    binding = _register_inventory(projection)
+    saved = _saved(run_id, instance, binding)
     projection.create_run(
         ProductRun(
             run_id=run_id,
             operation="plan" if operation == "apply" else operation,
-            configuration_reference=resolve_config_version(instance),
+            configuration_reference=f"{binding[0]}@{binding[1]}",
+            config_id=binding[0],
+            registry_version=binding[1],
+            package_checksum=binding[2],
             started_at=datetime.now(timezone.utc),
             phase="accepted",
             summary={"sync_name": "inventory"},
@@ -293,10 +309,11 @@ def _run_managed_worker(
     )
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("db006-matrix"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", lambda *_args, **_kwargs: instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(managed_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(managed_flow, "_plan", lambda *_args, **_kwargs: saved)
+    monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
     def core(_instance: object, *, operation: Operation, **_kwargs: object) -> SavedPlan | RunResult:
         if operation == "verify":
@@ -307,21 +324,19 @@ def _run_managed_worker(
 
     monkeypatch.setattr(managed_flow, "execute_run", core)
     if operation == "apply":
-        managed_sync_run.fn(run_id, "inventory", "plan", resolve_config_version(instance))
+        managed_sync_run.fn(run_id, "plan", *binding)
         worker_result = managed_sync_run.fn(
             run_id,
-            "inventory",
             "apply",
-            resolve_config_version(instance),
+            *binding,
             expected_checksum=saved.manifest.plan_checksum,
             confirm_writes=True,
         )
     else:
         worker_result = managed_sync_run.fn(
             run_id,
-            "inventory",
             operation,
-            resolve_config_version(instance),
+            *binding,
             confirm_writes=operation == "sync",
         )
     record, artifact = _product_parts(projection, run_id)
@@ -347,6 +362,13 @@ def test_executed_three_interface_product_envelopes_are_equal(
         python = _run_python(scoped, tmp_path / "python", operation, run_id)
     with monkeypatch.context() as scoped:
         managed = _run_managed_worker(scoped, tmp_path / "managed", operation, run_id)
+    managed_record = cast("dict[str, object]", managed.product_record)
+    assert all(managed_record[key] is not None for key in ("config_id", "registry_version", "package_checksum"))
+    # Standalone interfaces remain legacy by contract. Compare their common product
+    # semantics after separately proving the managed-only durable binding.
+    managed_record["configuration_reference"] = cli.product_record["configuration_reference"]
+    for key in ("config_id", "registry_version", "package_checksum"):
+        managed_record[key] = None
     observations = [cli, python, managed]
     assert_equivalent(observations)
 
@@ -438,9 +460,9 @@ def test_python_and_managed_verify_common_fields_and_cli_review_consume_the_same
         instance = _instance(root)
         saved = _saved(run_id, instance)
         projection = local_product_projection(root / "products")
-        _seed_plan(instance, saved, root / "products")
         with monkeypatch.context() as scoped:
             if surface == "python":
+                _seed_plan(instance, saved, root / "products")
                 scoped.setattr(
                     api_operations,
                     "resolve_sync_instance",
@@ -465,6 +487,22 @@ def test_python_and_managed_verify_common_fields_and_cli_review_consume_the_same
                     )
                 )
             else:
+                binding = _register_inventory(projection)
+                saved = _saved(run_id, instance, binding)
+                projection.create_run(
+                    ProductRun(
+                        run_id=run_id,
+                        operation="plan",
+                        configuration_reference=f"{binding[0]}@{binding[1]}",
+                        config_id=binding[0],
+                        registry_version=binding[1],
+                        package_checksum=binding[2],
+                        started_at=datetime.now(timezone.utc),
+                        phase="accepted",
+                        summary={"sync_name": "inventory"},
+                    )
+                )
+                managed_flow._publish_plan(projection, run_id, saved, ())
                 scoped.setattr(
                     managed_flow,
                     "_runtime",
@@ -473,7 +511,7 @@ def test_python_and_managed_verify_common_fields_and_cli_review_consume_the_same
                 scoped.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("db006-matrix"), False))
                 scoped.setattr(
                     managed_flow,
-                    "resolve_sync_instance",
+                    "resolve_runtime_instance",
                     lambda *_args, _instance=instance, **_kwargs: _instance,
                 )
                 scoped.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
@@ -484,9 +522,8 @@ def test_python_and_managed_verify_common_fields_and_cli_review_consume_the_same
                 )
                 worker_result = managed_sync_run.fn(
                     run_id,
-                    "inventory",
                     "verify",
-                    resolve_config_version(instance),
+                    *binding,
                 )
         record, artifact = _product_parts(projection, run_id)
         if surface == "python":
@@ -627,9 +664,10 @@ class _Orchestration:
 def _execute_submission(parameters: Mapping[str, object]) -> dict[str, object]:
     return managed_sync_run.fn(
         run_id=cast("str", parameters["run_id"]),
-        sync_name=cast("str", parameters["sync_name"]),
         stage=cast('Literal["plan", "verify", "apply", "sync"]', parameters["stage"]),
-        configuration_reference=cast("str", parameters["configuration_reference"]),
+        config_id=cast("str", parameters["config_id"]),
+        registry_version=cast("int", parameters["registry_version"]),
+        package_checksum=cast("str", parameters["package_checksum"]),
         branch=cast("str | None", parameters["branch"]),
         expected_checksum=cast("str | None", parameters["expected_checksum"]),
         confirm_writes=cast("bool", parameters["confirm_writes"]),
@@ -644,6 +682,7 @@ def test_managed_http_prefect_parameters_and_all_worker_operations_are_executed_
     monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"owner": {"token": AUTH_TOKEN}}))
     resolver = EnvironmentPrincipalResolver.from_environment()
     projection = local_product_projection((tmp_path / "products").resolve())
+    binding = _register_inventory(projection)
     orchestration = _Orchestration()
     client = TestClient(
         create_app(ManagedRunService(projection, orchestration, secrets=resolver.secret_values), resolver)
@@ -651,7 +690,6 @@ def test_managed_http_prefect_parameters_and_all_worker_operations_are_executed_
     instance = _instance(tmp_path)
     plan_destination = _DestinationProbe()
     sync_destination = _DestinationProbe()
-    configuration_reference = resolve_config_version(instance)
     headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
 
     with caplog.at_level(logging.INFO):
@@ -659,21 +697,22 @@ def test_managed_http_prefect_parameters_and_all_worker_operations_are_executed_
             "/runs",
             headers={**headers, "Idempotency-Key": "matrix-plan"},
             json={
-                "sync_name": "inventory",
                 "operation": "plan",
-                "configuration_reference": configuration_reference,
+                "config_id": binding[0],
+                "registry_version": binding[1],
                 "reason": "matrix plan",
             },
         )
         assert planned.status_code == 202
         plan_parameters = orchestration.submissions[-1]
         plan_run_id = str(plan_parameters["run_id"])
-        saved = _saved(plan_run_id, instance)
+        saved = _saved(plan_run_id, instance, binding)
         monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
         monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("db006-http-matrix"), False))
-        monkeypatch.setattr(managed_flow, "resolve_sync_instance", lambda *_args, **_kwargs: instance)
+        monkeypatch.setattr(managed_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: instance)
         monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: (SENTINEL,))
         monkeypatch.setattr(managed_flow, "_plan", lambda *_args, **_kwargs: saved)
+        monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
         def plan_core(*_args: object, operation: Operation, **_kwargs: object) -> SavedPlan | RunResult:
             if operation == "verify":
@@ -721,9 +760,9 @@ def test_managed_http_prefect_parameters_and_all_worker_operations_are_executed_
             "/runs",
             headers={**headers, "Idempotency-Key": "matrix-sync"},
             json={
-                "sync_name": "inventory",
                 "operation": "sync",
-                "configuration_reference": configuration_reference,
+                "config_id": binding[0],
+                "registry_version": binding[1],
                 "reason": "matrix sync",
                 "confirm_writes": True,
             },
@@ -731,7 +770,7 @@ def test_managed_http_prefect_parameters_and_all_worker_operations_are_executed_
         assert synced.status_code == 202
         sync_parameters = orchestration.submissions[-1]
         sync_run_id = str(sync_parameters["run_id"])
-        sync_saved = _saved(sync_run_id, instance)
+        sync_saved = _saved(sync_run_id, instance, binding)
         monkeypatch.setattr(managed_flow, "_plan", lambda *_args, **_kwargs: sync_saved)
 
         def sync_core(*_args: object, operation: Operation, **_kwargs: object) -> SavedPlan | RunResult:

--- a/tests/conformance/test_managed_equivalence.py
+++ b/tests/conformance/test_managed_equivalence.py
@@ -17,8 +17,16 @@ from infrahub_sync.managed import flow as managed_flow
 from infrahub_sync.plan.config_version import resolve_config_version
 from infrahub_sync.plan.models import PlanManifest
 from infrahub_sync.plan.review import SavedPlan
-from infrahub_sync.product_store import ProductRun, local_product_projection
+from infrahub_sync.product_store import ProductProjection, ProductRun, local_product_projection
 from infrahub_sync.product_store.standalone import execute_standalone
+from tests.configuration.validation_packages import package, package_data
+
+
+def _register_inventory(projection: ProductProjection) -> tuple[str, int, str]:
+    declared = package_data()
+    declared["configuration"]["name"] = "inventory"
+    registered = projection.create_configuration(package(declared))
+    return registered.config_id, registered.registry_version, registered.package_checksum
 
 
 def test_managed_and_standalone_plan_product_projection_seams_match(
@@ -51,11 +59,15 @@ def test_managed_and_standalone_plan_product_projection_seams_match(
     standalone_cache = (tmp_path / "standalone").resolve()
     managed_cache = (tmp_path / "managed").resolve()
     managed_projection = local_product_projection(managed_cache)
+    binding = _register_inventory(managed_projection)
     managed_projection.create_run(
         ProductRun(
             run_id=run_id,
             operation="plan",
-            configuration_reference=configuration_reference,
+            configuration_reference=f"{binding[0]}@{binding[1]}",
+            config_id=binding[0],
+            registry_version=binding[1],
+            package_checksum=binding[2],
             started_at=datetime.now(timezone.utc),
             phase="accepted",
             summary={"sync_name": "inventory"},
@@ -73,10 +85,10 @@ def test_managed_and_standalone_plan_product_projection_seams_match(
 
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), managed_projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-conformance"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", lambda *_args, **_kwargs: instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(managed_flow, "_plan", lambda *_args, **_kwargs: saved)
-    managed_flow.managed_sync_run.fn(run_id, "inventory", "plan", configuration_reference)
+    managed_flow.managed_sync_run.fn(run_id, "plan", *binding)
 
     standalone_projection = local_product_projection(standalone_cache)
     standalone_record = standalone_projection.lookup_run(run_id).value
@@ -97,5 +109,11 @@ def test_managed_and_standalone_plan_product_projection_seams_match(
             reference["created_at"] = "<generated>"
         return data
 
-    assert stable_product_record(standalone_record) == stable_product_record(managed_record)
+    standalone_data = stable_product_record(standalone_record)
+    managed_data = stable_product_record(managed_record)
+    for key in ("config_id", "registry_version", "package_checksum"):
+        assert managed_data[key] is not None
+        managed_data[key] = None
+    managed_data["configuration_reference"] = configuration_reference
+    assert standalone_data == managed_data
     assert standalone_artifact == managed_artifact

--- a/tests/integration/test_managed_prefect_idempotency.py
+++ b/tests/integration/test_managed_prefect_idempotency.py
@@ -37,9 +37,10 @@ def isolated_prefect_server(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
 async def test_same_opaque_key_creates_one_prefect_flow_run(isolated_prefect_server: None) -> None:  # noqa: ARG001
     parameters: dict[str, object] = {
         "run_id": "run-server-idempotency",
-        "sync_name": "inventory",
         "stage": "plan",
-        "configuration_reference": "sha256:configuration",
+        "config_id": "config-001",
+        "registry_version": 1,
+        "package_checksum": "a" * 64,
         "branch": None,
         "expected_checksum": None,
         "confirm_writes": False,

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -33,6 +33,7 @@ from infrahub_sync.plan.errors import OperationApplyFailedError
 from infrahub_sync.plan.models import ApplyRecord, PlanManifest
 from infrahub_sync.plan.review import SavedPlan
 from infrahub_sync.product_store import ProductRun, local_product_projection
+from tests.configuration.validation_packages import package
 
 if TYPE_CHECKING:
     from prefect.client.schemas.actions import DeploymentUpdate
@@ -53,8 +54,8 @@ def _saved(run_id: str) -> SavedPlan:
     return SavedPlan(manifest=manifest, operations=[], checksum_ok=True, verification_notes=[])
 
 
-def _instance(sync_name: str, *, directory: str) -> SimpleNamespace:  # noqa: ARG001 - resolver protocol fake.
-    return SimpleNamespace(name=sync_name)
+def _instance(configuration: object, *, directory: str) -> SimpleNamespace:  # noqa: ARG001 - resolver protocol fake.
+    return SimpleNamespace(name=configuration.configuration.name)
 
 
 class _RecordingRunLogger:
@@ -112,11 +113,15 @@ def _create_product_run(
     operation: Literal["plan", "sync", "verify", "apply"] = "plan",
 ):
     projection = local_product_projection(cache)
+    version = projection.create_configuration(package())
     projection.create_run(
         ProductRun(
             run_id=run_id,
             operation=operation,
-            configuration_reference="sha256:configuration",
+            configuration_reference=f"{version.config_id}@{version.registry_version}",
+            config_id=version.config_id,
+            registry_version=version.registry_version,
+            package_checksum=version.package_checksum,
             actor="owner",
             started_at=datetime.now(timezone.utc),
             phase="accepted",
@@ -124,6 +129,13 @@ def _create_product_run(
         )
     )
     return projection
+
+
+def _binding(projection, run_id: str) -> tuple[str, int, str]:
+    run = projection.lookup_run(run_id).value
+    assert run is not None
+    assert run.configuration_binding is not None
+    return run.configuration_binding
 
 
 def test_worker_rejects_missing_registered_package_before_runtime_construction(
@@ -388,11 +400,11 @@ def test_managed_flow_redacts_worker_logs_exception_chain_and_failed_state(
         failure_message = f"adapter rejected {configuration_canary}"
         raise ValueError(failure_message) from ConnectionError(cause_message)
 
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", resolve)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", resolve)
     monkeypatch.setattr(managed_flow, "_plan", fail_plan)
 
     with pytest.raises(RuntimeError) as exc_info:
-        managed_sync_run.fn(run_id, "inventory", "plan", "sha256:configuration")
+        managed_sync_run.fn(run_id, "plan", *_binding(projection, run_id))
 
     failure = exc_info.value
     failed_state = Failed(message=str(failure), data=failure)
@@ -428,8 +440,9 @@ def test_managed_apply_failure_retains_partial_write_evidence(
     partial = ApplyRecord(applied_operations=("op-applied",), failed_operation="op-failed")
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+    monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
     def fail_apply(*_args: object, **_kwargs: object) -> NoReturn:
         msg = "destination rejected operation"
@@ -440,9 +453,8 @@ def test_managed_apply_failure_retains_partial_write_evidence(
     with pytest.raises(RuntimeError):
         managed_sync_run.fn(
             run_id,
-            "inventory",
             "apply",
-            "sha256:configuration",
+            *_binding(projection, run_id),
             expected_checksum="a" * 64,
             confirm_writes=True,
         )
@@ -469,9 +481,10 @@ def test_managed_confirmed_sync_retains_the_semantic_sync_operation(
     saved = _saved(run_id)
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(managed_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
     def core(_instance: object, *, operation: str, **_kwargs: object) -> SavedPlan | RunResult:
         if operation in {"plan", "verify"}:
@@ -490,9 +503,8 @@ def test_managed_confirmed_sync_retains_the_semantic_sync_operation(
 
     result = managed_sync_run.fn(
         run_id,
-        "inventory",
         "sync",
-        "sha256:configuration",
+        *_binding(projection, run_id),
         confirm_writes=True,
     )
 
@@ -512,8 +524,9 @@ def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(
     seen: list[str] = []
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+    monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
     def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
         seen.append(run_id)
@@ -524,9 +537,8 @@ def test_managed_plan_worker_updates_the_api_created_run_and_publishes_review(
 
     result = managed_sync_run.fn(
         run_id,
-        "inventory",
         "plan",
-        "sha256:configuration",
+        *_binding(projection, run_id),
     )
 
     assert seen == [run_id]
@@ -544,15 +556,14 @@ def test_managed_verify_is_read_only_for_product_lifecycle(monkeypatch: pytest.M
     saved = _saved(run_id)
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(managed_flow, "execute_run", lambda *_args, **_kwargs: saved)
 
     result = managed_sync_run.fn(
         run_id,
-        "inventory",
         "verify",
-        "sha256:configuration",
+        *_binding(projection, run_id),
     )
 
     assert result == {
@@ -580,8 +591,9 @@ def test_confirmed_managed_sync_calls_plan_verify_apply_in_order_on_one_run(
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
     monkeypatch.setattr(managed_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
-    monkeypatch.setattr(managed_flow, "resolve_sync_instance", _instance)
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+    monkeypatch.setattr(managed_flow, "_verify_registered_apply", lambda **_kwargs: None)
 
     def plan(_instance, *, run_id: str, branch: str | None, composed_sync: bool):  # noqa: ARG001
         calls.append(("plan", run_id))
@@ -610,9 +622,8 @@ def test_confirmed_managed_sync_calls_plan_verify_apply_in_order_on_one_run(
 
     managed_sync_run.fn(
         run_id,
-        "inventory",
         "sync",
-        "sha256:configuration",
+        *_binding(projection, run_id),
         confirm_writes=True,
     )
 
@@ -666,9 +677,10 @@ async def test_prefect_extras_executor_receives_opaque_key_unchanged() -> None:
     gateway = PrefectOrchestration(client)  # type: ignore[arg-type] - offline fake implements the protocol.
     parameters: dict[str, object] = {
         "run_id": "run-001",
-        "sync_name": "inventory",
         "stage": "plan",
-        "configuration_reference": "sha256:configuration",
+        "config_id": "config-001",
+        "registry_version": 1,
+        "package_checksum": "a" * 64,
         "branch": None,
         "expected_checksum": None,
         "confirm_writes": False,

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -126,12 +126,42 @@ def _create_product_run(
     return projection
 
 
+def test_worker_rejects_missing_registered_package_before_runtime_construction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A bound worker cannot fall back to caller-local configuration files."""
+    run_id = "run-missing-registered-package"
+    projection = local_product_projection(tmp_path)
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation="plan",
+            configuration_reference="config-001@1",
+            config_id="config-001",
+            registry_version=1,
+            package_checksum="a" * 64,
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="accepted",
+        )
+    )
+    constructed = []
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: constructed.append(True))
+
+    with pytest.raises(RuntimeError, match="registered configuration version is unavailable"):
+        managed_sync_run.fn(run_id, "plan", "config-001", 1, "a" * 64)
+    assert constructed == []
+
+
 def test_managed_and_direct_prefect_flow_schemas_are_separate_and_exact() -> None:
     assert tuple(inspect.signature(managed_sync_run.fn).parameters) == (
         "run_id",
-        "sync_name",
         "stage",
-        "configuration_reference",
+        "config_id",
+        "registry_version",
+        "package_checksum",
         "branch",
         "expected_checksum",
         "confirm_writes",

--- a/tests/managed/test_flow_and_prefect.py
+++ b/tests/managed/test_flow_and_prefect.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from prefect.client.schemas.actions import DeploymentUpdate
     from prefect.client.schemas.objects import State
 
+    from infrahub_sync.configuration import ConfigurationPackage
+
 
 def _saved(run_id: str) -> SavedPlan:
     manifest = PlanManifest(
@@ -54,7 +56,8 @@ def _saved(run_id: str) -> SavedPlan:
     return SavedPlan(manifest=manifest, operations=[], checksum_ok=True, verification_notes=[])
 
 
-def _instance(configuration: object, *, directory: str) -> SimpleNamespace:  # noqa: ARG001 - resolver protocol fake.
+def _instance(configuration: ConfigurationPackage, *, directory: str) -> SimpleNamespace:  # noqa: ARG001
+    """Build the flow's minimal runtime fake from a registered package."""
     return SimpleNamespace(name=configuration.configuration.name)
 
 

--- a/tests/managed/test_http_api.py
+++ b/tests/managed/test_http_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -17,11 +18,12 @@ pytest.importorskip("fastapi")
 
 from fastapi.testclient import TestClient
 
+from infrahub_sync.configuration import ConfigurationPackage
 from infrahub_sync.managed.app import create_app
 from infrahub_sync.managed.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
-from infrahub_sync.managed.models import PlanResource
+from infrahub_sync.managed.models import CreateRunRequest, PlanResource
 from infrahub_sync.managed.orchestration import Observation, Submission
-from infrahub_sync.managed.service import PLAN_ARTIFACT_ID, ManagedRunService
+from infrahub_sync.managed.service import PLAN_ARTIFACT_ID, ManagedAPIError, ManagedRunService
 from infrahub_sync.product_store import ProductProjection, local_product_projection
 
 OWNER_TOKEN = "owner-token-canary-0001"  # noqa: S105 - deliberate non-secret boundary canary.
@@ -29,6 +31,30 @@ OTHER_TOKEN = "other-token-canary-0002"  # noqa: S105 - deliberate non-secret bo
 ADMIN_TOKEN = "admin-token-canary-0003"  # noqa: S105 - deliberate non-secret boundary canary.
 RAW_KEY = "client-idempotency-key-canary"
 AUTH = {"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": RAW_KEY}
+
+
+def _registered_package() -> ConfigurationPackage:
+    return ConfigurationPackage.model_validate(
+        {
+            "format_version": 1,
+            "configuration": {
+                "name": "registered-inventory",
+                "source": {
+                    "name": "netbox",
+                    "settings": {"url": "https://netbox.example", "token": {"$credential": "token"}},
+                },
+                "destination": {
+                    "name": "infrahub",
+                    "settings": {"url": "https://infrahub.example", "token": {"$credential": "token"}},
+                },
+                "order": [],
+                "schema_mapping": [],
+                "diffsync_flags": [],
+                "incremental": None,
+            },
+            "credentials": {"token": {"provider": "env", "identifier": "TOKEN"}},
+        }
+    )
 
 
 class _FakeOrchestration:
@@ -90,8 +116,11 @@ def managed(
     resolver = EnvironmentPrincipalResolver.from_environment()
     projection = local_product_projection(tmp_path.resolve())
     orchestration = _FakeOrchestration()
+    version = projection.create_configuration(_registered_package())
     service = ManagedRunService(projection, orchestration, secrets=resolver.secret_values)
-    return TestClient(create_app(service, resolver)), projection, orchestration
+    client = TestClient(create_app(service, resolver))
+    client.app.state.run_binding = version
+    return client, projection, orchestration
 
 
 def _create(
@@ -101,16 +130,57 @@ def _create(
     reason: str = "review inventory changes",
     authorization: str = f"Bearer {OWNER_TOKEN}",
 ):
+    version = client.app.state.run_binding
     return client.post(
         "/runs",
         headers={"Authorization": authorization, "Idempotency-Key": key},
         json={
-            "sync_name": "inventory",
             "operation": "plan",
-            "configuration_reference": "sha256:configuration",
+            "config_id": version.config_id,
+            "registry_version": version.registry_version,
             "reason": reason,
         },
     )
+
+
+def test_admission_reads_registered_binding_before_allocating_run(
+    managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    """Admission takes package identity and display name from the immutable registry row."""
+    _client, projection, orchestration = managed
+    version = projection.create_configuration(_registered_package())
+    request = CreateRunRequest(
+        operation="plan",
+        config_id=version.config_id,
+        registry_version=version.registry_version,
+        reason="plan registered package",
+    )
+    service = ManagedRunService(projection, orchestration)
+    principal = EnvironmentPrincipalResolver.from_environment().resolve(OWNER_TOKEN)
+    assert principal is not None
+
+    _status, body = asyncio.run(service.create_run(request, principal, "registered-key"))
+    run = projection.lookup_run(body["run"]["run_id"]).value
+    assert run is not None
+    assert run.configuration_binding == (version.config_id, version.registry_version, version.package_checksum)
+    assert run.summary["sync_name"] == "registered-inventory"
+    assert set(orchestration.submissions[0][0]) == {
+        "run_id",
+        "stage",
+        "config_id",
+        "registry_version",
+        "package_checksum",
+        "branch",
+        "expected_checksum",
+        "confirm_writes",
+    }
+
+    missing = CreateRunRequest(
+        operation="plan", config_id="missing-config", registry_version=1, reason="refuse before allocation"
+    )
+    with pytest.raises(ManagedAPIError, match="requested configuration version does not exist"):
+        asyncio.run(service.create_run(missing, principal, "missing-key"))
+    assert len(orchestration.submissions) == 1
 
 
 def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str = "a" * 64) -> PlanResource:
@@ -172,9 +242,10 @@ def test_authentication_idempotency_and_secret_boundaries(
     parameters, opaque_key = orchestration.submissions[0]
     assert set(parameters) == {
         "run_id",
-        "sync_name",
         "stage",
-        "configuration_reference",
+        "config_id",
+        "registry_version",
+        "package_checksum",
         "branch",
         "expected_checksum",
         "confirm_writes",
@@ -192,9 +263,9 @@ def test_authentication_idempotency_and_secret_boundaries(
         "/runs",
         headers={"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": "secret-parameter-key"},
         json={
-            "sync_name": "inventory",
             "operation": "plan",
-            "configuration_reference": OWNER_TOKEN,
+            "config_id": OWNER_TOKEN,
+            "registry_version": 1,
             "reason": "reject credential-bearing parameter",
         },
     )
@@ -557,10 +628,11 @@ def test_confirmed_sync_reserves_its_write_admission_and_replays(
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:
     client, projection, orchestration = managed
+    version = client.app.state.run_binding
     body = {
-        "sync_name": "inventory",
         "operation": "sync",
-        "configuration_reference": "sha256:configuration",
+        "config_id": version.config_id,
+        "registry_version": version.registry_version,
         "confirm_writes": True,
         "reason": "approved composed sync",
     }
@@ -712,14 +784,15 @@ def test_confirmation_schema_errors_and_openapi_contract(
     managed: tuple[TestClient, ProductProjection, _FakeOrchestration],
 ) -> None:
     client, _projection, orchestration = managed
+    version = client.app.state.run_binding
     headers = {"Authorization": f"Bearer {OWNER_TOKEN}", "Idempotency-Key": "sync-key"}
     unconfirmed = client.post(
         "/runs",
         headers=headers,
         json={
-            "sync_name": "inventory",
             "operation": "sync",
-            "configuration_reference": "sha256:configuration",
+            "config_id": version.config_id,
+            "registry_version": version.registry_version,
             "reason": "run now",
         },
     )
@@ -727,19 +800,19 @@ def test_confirmation_schema_errors_and_openapi_contract(
         "/runs",
         headers={"Authorization": f"Bearer {OWNER_TOKEN}"},
         json={
-            "sync_name": "inventory",
-            "configuration_reference": "sha256:configuration",
+            "config_id": version.config_id,
+            "registry_version": version.registry_version,
             "reason": "plan now",
         },
     )
-    invalid = client.post("/runs", headers=headers, json={"sync_name": "inventory"})
+    invalid = client.post("/runs", headers=headers, json={"config_id": version.config_id})
     invalid_operation = client.post(
         "/runs",
         headers=headers,
         json={
-            "sync_name": "inventory",
             "operation": "delete",
-            "configuration_reference": "sha256:configuration",
+            "config_id": version.config_id,
+            "registry_version": version.registry_version,
             "reason": "unsupported operation",
         },
     )

--- a/tests/managed/test_legacy_run_binding.py
+++ b/tests/managed/test_legacy_run_binding.py
@@ -1,0 +1,197 @@
+"""Durable legacy runs keep their existing worker and plan-verification path."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+
+from infrahub_sync.execution import RunResult
+from infrahub_sync.managed import flow as managed_flow
+from infrahub_sync.managed.flow import managed_sync_run
+from infrahub_sync.plan.models import PlanManifest
+from infrahub_sync.plan.review import SavedPlan
+from infrahub_sync.product_store import ProductRun, local_product_projection
+
+
+def _legacy_run(cache: Path, run_id: str, operation: Literal["plan", "verify", "apply"]) -> object:
+    """Persist a pre-binding run with only its durable legacy identity fields."""
+    projection = local_product_projection(cache)
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation=operation,
+            configuration_reference="legacy-config-version",
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="accepted",
+            summary={"sync_name": "legacy-inventory"},
+        )
+    )
+    return projection
+
+
+def _legacy_saved(run_id: str) -> SavedPlan:
+    """Return an unchanged all-absent legacy manifest."""
+    return SavedPlan(
+        manifest=PlanManifest(
+            format_version=2,
+            run_id=run_id,
+            created_at="2026-08-10T12:00:00+00:00",
+            config_version="legacy-config-version",
+            source_snapshot=[],
+            operations_count=0,
+            delete_operations_computed=True,
+            plan_checksum="a" * 64,
+        ),
+        operations=[],
+        checksum_ok=True,
+        verification_notes=[],
+    )
+
+
+@pytest.mark.parametrize("stage", ["plan", "verify", "apply"])
+def test_all_absent_legacy_run_reaches_existing_local_worker_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stage: Literal["plan", "verify", "apply"]
+) -> None:
+    """No durable legacy run is rejected merely because it predates tuple binding."""
+    run_id = f"legacy-{stage}"
+    projection = _legacy_run(tmp_path / "product", run_id, stage)
+    saved = _legacy_saved(run_id)
+    resolved: list[tuple[str, str]] = []
+    verified: list[tuple[str, object]] = []
+    instance = SimpleNamespace(name="legacy-inventory")
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(
+        managed_flow,
+        "resolve_sync_instance",
+        lambda name, *, directory: (resolved.append((name, directory)), instance)[1],
+        raising=False,
+    )
+    monkeypatch.setattr(managed_flow, "resolve_config_version", lambda _instance: "legacy-config-version")
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+    monkeypatch.setattr(managed_flow, "_plan", lambda *_args, **_kwargs: saved)
+    monkeypatch.setattr(managed_flow, "_publish_plan", lambda *_args, **_kwargs: None)
+    if stage == "apply":
+        artifact = object()
+        monkeypatch.setattr(managed_flow, "resolve_run_directory", lambda *_args: tmp_path)
+        monkeypatch.setattr(managed_flow, "read_plan_artifact_bytes", lambda _path: artifact)
+
+        def verify(**kwargs: object) -> list[object]:
+            verified.append((str(kwargs["run_id"]), kwargs["config_version"]))
+            return []
+
+        monkeypatch.setattr(managed_flow, "verify_plan", verify)
+        monkeypatch.setattr(
+            managed_flow,
+            "parse_plan_artifact",
+            lambda *_args, **_kwargs: pytest.fail("legacy verification must not parse a registered binding"),
+        )
+
+    def execute(*_args: object, operation: str, **_kwargs: object) -> SavedPlan | RunResult:
+        if operation == "verify":
+            return saved
+        return RunResult(
+            sync_name="legacy-inventory",
+            operation="apply",
+            run_id=run_id,
+            status="no-change",
+            changed=False,
+            summary={"create": 0, "update": 0, "delete": 0},
+            artifact_path=str(tmp_path / run_id),
+        )
+
+    monkeypatch.setattr(managed_flow, "execute_run", execute)
+    if stage == "apply":
+        managed_sync_run.fn(run_id, stage, expected_checksum="a" * 64, confirm_writes=True)
+    else:
+        managed_sync_run.fn(run_id, stage)
+
+    assert resolved == [("legacy-inventory", str(tmp_path))]
+    assert verified == ([(run_id, "legacy-config-version")] if stage == "apply" else [])
+
+
+def test_prefect_binding_carrier_is_optional_only_as_one_closed_group() -> None:
+    """Legacy submissions omit all three carrier keys; validation remains in the worker."""
+    parameters = inspect.signature(managed_sync_run.fn).parameters
+    assert tuple(parameters)[:5] == ("run_id", "stage", "config_id", "registry_version", "package_checksum")
+    assert tuple(parameters[name].default for name in ("config_id", "registry_version", "package_checksum")) == (
+        None,
+        None,
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("durable_binding", "carrier", "error"),
+    [
+        pytest.param(
+            None, ("config-001", 1, "a" * 64), "managed run binding does not match worker parameters", id="legacy-bound"
+        ),
+        pytest.param(
+            ("config-001", 1, "a" * 64),
+            (None, None, None),
+            "managed run binding does not match worker parameters",
+            id="bound-legacy",
+        ),
+        pytest.param(
+            ("config-001", 1, "a" * 64),
+            ("config-001", None, None),
+            "managed worker configuration binding parameters must be all absent or all present",
+            id="partial",
+        ),
+    ],
+)
+def test_cross_product_and_partial_worker_carriers_refuse_before_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    durable_binding: tuple[str, int, str] | None,
+    carrier: tuple[str | None, int | None, str | None],
+    error: str,
+) -> None:
+    """Optional Prefect parameters remain a closed all-absent/all-present carrier."""
+    projection = local_product_projection(tmp_path / "product")
+    if durable_binding is None:
+        run = ProductRun(
+            run_id="carrier-refusal",
+            operation="plan",
+            configuration_reference="legacy-config-version",
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="accepted",
+            summary={"sync_name": "legacy-inventory"},
+        )
+    else:
+        run = ProductRun(
+            run_id="carrier-refusal",
+            operation="plan",
+            configuration_reference="legacy-config-version",
+            config_id=durable_binding[0],
+            registry_version=durable_binding[1],
+            package_checksum=durable_binding[2],
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="accepted",
+            summary={"sync_name": "legacy-inventory"},
+        )
+    projection.create_run(run)
+    constructed: list[object] = []
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(
+        managed_flow, "resolve_sync_instance", lambda *_args, **_kwargs: constructed.append(True), raising=False
+    )
+    monkeypatch.setattr(managed_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: constructed.append(True))
+
+    with pytest.raises(RuntimeError, match=error):
+        managed_sync_run.fn("carrier-refusal", "plan", *carrier)
+    assert constructed == []

--- a/tests/managed/test_legacy_run_binding.py
+++ b/tests/managed/test_legacy_run_binding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,8 +18,11 @@ pytest.importorskip("opsmill_prefect_extras")
 from infrahub_sync.execution import RunResult
 from infrahub_sync.managed import flow as managed_flow
 from infrahub_sync.managed.flow import managed_sync_run
+from infrahub_sync.plan.canonical import canonical_json_bytes
+from infrahub_sync.plan.checksum import compute_plan_checksum
 from infrahub_sync.plan.models import PlanManifest
 from infrahub_sync.plan.review import SavedPlan
+from infrahub_sync.plan.writer import MANIFEST_FILE_NAME, OPERATIONS_FILE_NAME, PLAN_DIR_NAME, write_plan_artifact
 from infrahub_sync.product_store import ProductRun, local_product_projection
 
 
@@ -68,6 +72,7 @@ def test_all_absent_legacy_run_reaches_existing_local_worker_path(
     saved = _legacy_saved(run_id)
     resolved: list[tuple[str, str]] = []
     verified: list[tuple[str, object]] = []
+    parsed: list[object] = []
     instance = SimpleNamespace(name="legacy-inventory")
     monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
@@ -94,7 +99,7 @@ def test_all_absent_legacy_run_reaches_existing_local_worker_path(
         monkeypatch.setattr(
             managed_flow,
             "parse_plan_artifact",
-            lambda *_args, **_kwargs: pytest.fail("legacy verification must not parse a registered binding"),
+            lambda *_args, **_kwargs: (parsed.append(True), SimpleNamespace(manifest=saved.manifest))[1],
         )
 
     def execute(*_args: object, operation: str, **_kwargs: object) -> SavedPlan | RunResult:
@@ -118,6 +123,67 @@ def test_all_absent_legacy_run_reaches_existing_local_worker_path(
 
     assert resolved == [("legacy-inventory", str(tmp_path))]
     assert verified == ([(run_id, "legacy-config-version")] if stage == "apply" else [])
+    assert parsed == ([True] if stage == "apply" else [])
+
+
+@pytest.mark.parametrize(
+    ("manifest_binding", "expected_error"),
+    [
+        pytest.param(("registered-config", 1, "a" * 64), "registered saved plan binding", id="registered"),
+        pytest.param({"config_id": "registered-config"}, "configuration binding must be all absent", id="partial"),
+    ],
+)
+def test_legacy_apply_refuses_checksum_valid_nonlegacy_manifest_before_destination(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    manifest_binding: tuple[str, int, str] | dict[str, str],
+    expected_error: str,
+) -> None:
+    """A legacy run accepts only a fully legacy manifest before destination construction."""
+    run_id = "legacy-nonlegacy-manifest"
+    projection = _legacy_run(tmp_path / "product", run_id, "apply")
+    instance = SimpleNamespace(name="legacy-inventory")
+    run_dir = tmp_path / "runs" / instance.name / run_id
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path / "runs"))
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (logging.getLogger("test-managed"), False))
+    monkeypatch.setattr(managed_flow, "resolve_sync_instance", lambda *_args, **_kwargs: instance, raising=False)
+    monkeypatch.setattr(managed_flow, "resolve_config_version", lambda _instance: "legacy-config-version")
+    monkeypatch.setattr(managed_flow, "collect_secret_values", lambda _instance=None: ())
+    if isinstance(manifest_binding, tuple):
+        write_plan_artifact(
+            run_dir=run_dir,
+            run_id=run_id,
+            config_version="legacy-config-version",
+            source_snapshot=[],
+            deletes_computed=True,
+            operations=[],
+            configuration_binding=manifest_binding,
+        )
+    else:
+        write_plan_artifact(
+            run_dir=run_dir,
+            run_id=run_id,
+            config_version="legacy-config-version",
+            source_snapshot=[],
+            deletes_computed=True,
+            operations=[],
+        )
+        plan_dir = run_dir / PLAN_DIR_NAME
+        manifest_path = plan_dir / MANIFEST_FILE_NAME
+        manifest = json.loads(manifest_path.read_bytes())
+        manifest.update(manifest_binding)
+        manifest["plan_checksum"] = compute_plan_checksum(manifest, (plan_dir / OPERATIONS_FILE_NAME).read_bytes())
+        manifest_path.write_bytes(canonical_json_bytes(manifest))
+
+    def destination_construction_sentinel(*_args: object, **_kwargs: object) -> RunResult:
+        msg = "destination construction sentinel reached"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(managed_flow, "execute_run", destination_construction_sentinel)
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        managed_sync_run.fn(run_id, "apply", expected_checksum="a" * 64, confirm_writes=True)
 
 
 def test_prefect_binding_carrier_is_optional_only_as_one_closed_group() -> None:

--- a/tests/managed/test_registered_plan_apply.py
+++ b/tests/managed/test_registered_plan_apply.py
@@ -1,0 +1,108 @@
+"""AR6-AR7: registered saved plans are admitted before destination construction."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+
+from infrahub_sync.configuration import ConfigurationPackage
+from infrahub_sync.configuration.runtime import resolve_runtime_instance
+from infrahub_sync.execution import RunResult
+from infrahub_sync.managed import flow as managed_flow
+from infrahub_sync.managed.flow import managed_sync_run
+from infrahub_sync.plan.config_version import resolve_config_version
+from infrahub_sync.plan.writer import write_plan_artifact
+from infrahub_sync.product_store import ProductRun, local_product_projection
+from tests.configuration.validation_packages import package
+
+
+def _registered_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, manifest_binding: tuple[str, int, str] | Literal["exact"] | None
+) -> tuple[str, tuple[str, int, str], list[str]]:
+    """Prepare one bound run and a manifest, with a destination-call sentinel."""
+    monkeypatch.setenv("NETBOX_TOKEN", "registered-netbox-canary")
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "registered-infrahub-canary")
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path / "runs"))
+    projection = local_product_projection(tmp_path / "product")
+    registered = projection.create_configuration(package())
+    binding = (registered.config_id, registered.registry_version, registered.package_checksum)
+    if manifest_binding == "exact":
+        manifest_binding = binding
+    run_id = "registered-plan-apply"
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation="apply",
+            configuration_reference=f"{binding[0]}@{binding[1]}",
+            config_id=binding[0],
+            registry_version=binding[1],
+            package_checksum=binding[2],
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="planned",
+        )
+    )
+    stored = projection.lookup_configuration_version(binding[0], binding[1]).value
+    assert stored is not None
+    runtime = resolve_runtime_instance(ConfigurationPackage.model_validate(stored.declared_content), directory=str(tmp_path))
+    write_plan_artifact(
+        run_dir=tmp_path / "runs" / runtime.name / run_id,
+        run_id=run_id,
+        config_version=resolve_config_version(runtime),
+        source_snapshot=[],
+        deletes_computed=True,
+        operations=[],
+        configuration_binding=manifest_binding,
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(managed_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(managed_flow, "_run_logger", lambda: (managed_flow.logger, False))
+
+    def destination_forbidden(*_args: object, **_kwargs: object) -> RunResult:
+        calls.append("execute-run")
+        return RunResult(
+            sync_name=runtime.name,
+            operation="apply",
+            run_id=run_id,
+            status="no-change",
+            changed=False,
+            summary={"create": 0, "update": 0, "delete": 0},
+            artifact_path=str(tmp_path / "runs" / runtime.name / run_id),
+        )
+
+    monkeypatch.setattr(managed_flow, "execute_run", destination_forbidden)
+    return run_id, binding, calls
+
+
+@pytest.mark.parametrize(
+    "manifest_binding",
+    [
+        pytest.param(None, id="legacy-manifest"),
+        pytest.param(("other-config", 1, "a" * 64), id="cross-product"),
+        pytest.param(("config-001", 2, "a" * 64), id="version-mutation"),
+        pytest.param(("config-001", 1, "b" * 64), id="checksum-mutation"),
+    ],
+)
+def test_bound_apply_refuses_nonmatching_manifest_before_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, manifest_binding: tuple[str, int, str] | None
+) -> None:
+    run_id, binding, calls = _registered_apply(tmp_path, monkeypatch, manifest_binding=manifest_binding)
+
+    with pytest.raises(RuntimeError, match="registered saved plan binding"):
+        managed_sync_run.fn(run_id, "apply", *binding, expected_checksum="a" * 64, confirm_writes=True)
+
+    assert calls == []
+
+
+def test_bound_apply_accepts_an_exact_manifest_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id, binding, calls = _registered_apply(tmp_path, monkeypatch, manifest_binding="exact")
+    managed_sync_run.fn(run_id, "apply", *binding, expected_checksum="a" * 64, confirm_writes=True)
+    assert calls == ["execute-run"]

--- a/tests/managed/test_registered_plan_apply.py
+++ b/tests/managed/test_registered_plan_apply.py
@@ -50,7 +50,9 @@ def _registered_apply(
     )
     stored = projection.lookup_configuration_version(binding[0], binding[1]).value
     assert stored is not None
-    runtime = resolve_runtime_instance(ConfigurationPackage.model_validate(stored.declared_content), directory=str(tmp_path))
+    runtime = resolve_runtime_instance(
+        ConfigurationPackage.model_validate(stored.declared_content), directory=str(tmp_path)
+    )
     write_plan_artifact(
         run_dir=tmp_path / "runs" / runtime.name / run_id,
         run_id=run_id,
@@ -100,9 +102,7 @@ def test_bound_apply_refuses_nonmatching_manifest_before_destination(
     assert calls == []
 
 
-def test_bound_apply_accepts_an_exact_manifest_binding(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_bound_apply_accepts_an_exact_manifest_binding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     run_id, binding, calls = _registered_apply(tmp_path, monkeypatch, manifest_binding="exact")
     managed_sync_run.fn(run_id, "apply", *binding, expected_checksum="a" * 64, confirm_writes=True)
     assert calls == ["execute-run"]

--- a/tests/plan/test_models.py
+++ b/tests/plan/test_models.py
@@ -103,6 +103,39 @@ def test_the_two_masks_are_deliberately_different() -> None:
     assert set(CHECKSUM_EXCLUDED_FIELDS) - set(SC006_MASKED_FIELDS) == {"plan_checksum"}
 
 
+@pytest.mark.parametrize(
+    "binding",
+    [
+        pytest.param(
+            {"config_id": "config-001", "registry_version": 1, "package_checksum": "a" * 64},
+            id="complete",
+        ),
+        pytest.param({}, id="absent"),
+    ],
+)
+def test_manifest_configuration_binding_is_all_absent_or_all_present(binding: dict[str, object]) -> None:
+    manifest = PlanManifest(**_manifest(**binding))
+    assert manifest.configuration_binding == (
+        ("config-001", 1, "a" * 64) if binding else None
+    )
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        pytest.param({"config_id": "config-001"}, id="id-only"),
+        pytest.param({"registry_version": 1}, id="version-only"),
+        pytest.param({"package_checksum": "a" * 64}, id="checksum-only"),
+        pytest.param({"config_id": "config-001", "registry_version": True, "package_checksum": "a" * 64}, id="bool"),
+        pytest.param({"config_id": "config-001", "registry_version": "1", "package_checksum": "a" * 64}, id="string"),
+        pytest.param({"config_id": "config-001", "registry_version": 1, "package_checksum": "not-a-digest"}, id="digest"),
+    ],
+)
+def test_manifest_configuration_binding_refuses_partial_or_hostile_values(binding: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        PlanManifest(**_manifest(**binding))
+
+
 # ======================================================================================
 # `payload` is None if and only if `action == "delete"`
 # ======================================================================================
@@ -635,6 +668,9 @@ PLAN_MANIFEST_FIELDS = {
     "operations_count",
     "delete_operations_computed",
     "plan_checksum",
+    "config_id",
+    "registry_version",
+    "package_checksum",
     # Additive: the effective destination the plan is bound to. An
     # identity to compare at apply time, not a grouping of operations into write units.
     "destination_binding",
@@ -736,7 +772,7 @@ def test_planned_operation_rejects_unknown_fields() -> None:
 
 def test_plan_manifest_still_requires_its_declared_fields() -> None:
     """`extra="allow"` does not make the declared fields optional."""
-    for missing in PLAN_MANIFEST_FIELDS - {"destination_binding"}:
+    for missing in PLAN_MANIFEST_FIELDS - {"destination_binding", "config_id", "registry_version", "package_checksum"}:
         record = _manifest()
         del record[missing]
         with pytest.raises(ValidationError):

--- a/tests/plan/test_models.py
+++ b/tests/plan/test_models.py
@@ -115,9 +115,7 @@ def test_the_two_masks_are_deliberately_different() -> None:
 )
 def test_manifest_configuration_binding_is_all_absent_or_all_present(binding: dict[str, object]) -> None:
     manifest = PlanManifest(**_manifest(**binding))
-    assert manifest.configuration_binding == (
-        ("config-001", 1, "a" * 64) if binding else None
-    )
+    assert manifest.configuration_binding == (("config-001", 1, "a" * 64) if binding else None)
 
 
 @pytest.mark.parametrize(
@@ -128,7 +126,9 @@ def test_manifest_configuration_binding_is_all_absent_or_all_present(binding: di
         pytest.param({"package_checksum": "a" * 64}, id="checksum-only"),
         pytest.param({"config_id": "config-001", "registry_version": True, "package_checksum": "a" * 64}, id="bool"),
         pytest.param({"config_id": "config-001", "registry_version": "1", "package_checksum": "a" * 64}, id="string"),
-        pytest.param({"config_id": "config-001", "registry_version": 1, "package_checksum": "not-a-digest"}, id="digest"),
+        pytest.param(
+            {"config_id": "config-001", "registry_version": 1, "package_checksum": "not-a-digest"}, id="digest"
+        ),
     ],
 )
 def test_manifest_configuration_binding_refuses_partial_or_hostile_values(binding: dict[str, object]) -> None:

--- a/tests/plan/test_writer.py
+++ b/tests/plan/test_writer.py
@@ -175,6 +175,28 @@ def _write(
     )
 
 
+def test_registered_configuration_binding_is_written_and_covered_by_checksum(tmp_path: Path) -> None:
+    binding = ("config-001", 1, "a" * 64)
+    manifest = write_plan_artifact(
+        run_dir=tmp_path / RUN_ID,
+        run_id=RUN_ID,
+        config_version=CONFIG_VERSION,
+        source_snapshot=_snapshot(),
+        deletes_computed=True,
+        operations=[_tag("registered")],
+        configuration_binding=binding,
+    )
+
+    assert manifest.configuration_binding == binding
+    raw = json.loads(_manifest_path(tmp_path / RUN_ID).read_text(encoding="utf-8"))
+    assert raw["config_id"] == binding[0]
+    assert raw["registry_version"] == binding[1]
+    assert raw["package_checksum"] == binding[2]
+    assert manifest.plan_checksum != compute_plan_checksum(
+        {**raw, "package_checksum": "b" * 64}, _operations_path(tmp_path / RUN_ID).read_bytes()
+    )
+
+
 def _plan_dir(run_dir: Path) -> Path:
     return run_dir / PLAN_DIR_NAME
 

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -373,6 +373,37 @@ def _run(run_id: str = "run-001", *, links: tuple[PrefectExecutionLink, ...] = (
     )
 
 
+def test_registered_run_binding_is_all_or_none_and_survives_restart(tmp_path: Path) -> None:
+    """A registered run retains its exact immutable package identity."""
+    started_at = datetime(2026, 8, 8, 12, tzinfo=timezone.utc)
+    bound = ProductRun(
+        run_id="bound-run-001",
+        operation="plan",
+        configuration_reference="config-001@1",
+        config_id="config-001",
+        registry_version=1,
+        package_checksum="a" * 64,
+        started_at=started_at,
+        phase="accepted",
+    )
+    assert bound.configuration_binding == ("config-001", 1, "a" * 64)
+    with pytest.raises(ValueError, match="configuration binding"):
+        ProductRun(
+            run_id="partial-run-001",
+            operation="plan",
+            configuration_reference="config-001@1",
+            config_id="config-001",
+            started_at=started_at,
+            phase="accepted",
+        )
+
+    projection = local_product_projection(tmp_path)
+    projection.create_run(bound)
+    restarted = local_product_projection(tmp_path).lookup_run("bound-run-001").value
+    assert restarted is not None
+    assert restarted.configuration_binding == bound.configuration_binding
+
+
 def _artifact_reference(
     data: bytes = b"{}",
     *,

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -2341,8 +2341,8 @@ def test_fresh_sqlite_database_gains_the_nullable_binding_columns(tmp_path: Path
     assert set(_CONFIGURATION_BINDING_COLUMN_NAMES) <= columns
 
 
-def test_product_run_model_declares_no_configuration_binding_fields() -> None:
-    assert not set(_CONFIGURATION_BINDING_COLUMN_NAMES) & set(ProductRun.model_fields)
+def test_product_run_model_declares_configuration_binding_fields() -> None:
+    assert set(_CONFIGURATION_BINDING_COLUMN_NAMES) <= set(ProductRun.model_fields)
 
 
 def test_preexisting_database_is_migrated_forward_and_keeps_its_legacy_row(tmp_path: Path) -> None:
@@ -2410,7 +2410,7 @@ def test_existing_run_lifecycle_is_unaffected_by_the_new_binding_columns(provide
     assert loaded is not None
     assert loaded.phase == "planned"
     assert loaded.outcome == "succeeded"
-    assert "config_id" not in ProductRun.model_fields
+    assert set(_CONFIGURATION_BINDING_COLUMN_NAMES) <= set(ProductRun.model_fields)
 
 
 class _FakePostgreSQLDatabase:


### PR DESCRIPTION
## Summary

The configuration routes in #191 can persist registered packages, but managed runs still need a durable proof of which exact package bytes they execute. Without that binding, worker parameters and saved plans could drift from registry-owned configuration identity.

This stacked draft binds each registered managed run to the exact configuration version and checksum, resolves the verified package and credentials inside the worker, and requires saved-plan apply to prove the same identity before destination construction.

## Key Changes

- Run admission resolves registry-owned configuration identity and persists the complete `(config_id, registry_version, package_checksum)` tuple.
- Prefect carries only the non-secret tuple; workers re-read and checksum the exact stored package before constructing adapters.
- Registered credential values are authoritative across all bundled adapter construction paths while legacy ambient precedence remains compatible.
- Saved-plan manifests bind to the same tuple and registered apply verifies run, manifest, registry row, and package content before destination construction or write.
- Legacy runs and legacy manifests remain compatible; every legacy/registered/partial or mismatched cross-product refuses before destination effects.
- Blake-authorized closure round 4/4 corrected the final legacy-manifest parsing gap without reopening Configuration Routes or another defect family.

## Related Context

- Stacked on #191, which exposes the configuration application service over HTTP.
- Part of CF-005 Service Boundary.
- Exact accepted base: `9a46c3516444fc0c281e7ffc1df03b778acfa2f5`.
- Exact source head: `8a69132a92f78a0daea431fd33f33cab6c962d4b`.
- Independent full-diff AR1-AR8 review returned READY with no actionable finding.

## Documentation Updates

No public product documentation is added in this internal stacked unit. Client conversion and final user-facing documentation remain later CF-005 work.

## Test Plan

- Focused legacy/registered/partial apply matrix: 14 passed
- Managed, plan, product-store, conformance, and adapter-setting suites: 984 passed, 1 skipped, 1 xfailed
- `uv run ty check .`: exit 0, zero errors; 3 existing warning-only unused ignores
- `uv run invoke format`: exit 0, unchanged
- `uv run invoke lint`: exit 0
- `uv run pytest -q`: 2655 passed, 24 skipped, 1 xfailed
- CLI `--help` and example listing: exit 0
- CLI `generate`: reached the real Infrahub dependency and stopped only because `localhost:8000` was unavailable
