### PR TITLE
Promote the preview rig to a non-mutating local developer stack with client smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ fixture is deterministic; the review still uses a live, writable Infrahub destin
 | **Configuration reference** | [Sync instance configuration](https://docs.infrahub.app/sync/reference/config) · [CLI reference](https://docs.infrahub.app/sync/reference/cli) |
 | **Custom CA certificates** | [Custom certificates guide](https://docs.infrahub.app/sync/custom-certificates) |
 | **Local custom adapters** | [Local adapters guide](https://docs.infrahub.app/sync/adapters/local-adapters) |
-| **Contribute** | [Contributing guide](https://docs.infrahub.app/sync/contributing) — development environment, tests, code standards |
+| **Contribute** | [Contributing guide](https://docs.infrahub.app/sync/contributing) — development environment, tests, code standards · [Local development stack](https://docs.infrahub.app/sync/development-stack) — the full stack on your machine |
 
 ---
 

--- a/development/README.md
+++ b/development/README.md
@@ -1,19 +1,20 @@
 # Preview environment
 
 One command from a fresh clone to a complete, testable Infrahub Sync v3 stack:
-a disposable Infrahub instance, a dedicated Prefect server, the Sync
-HTTP API, a Prefect worker running the service deployment, a loaded example
-schema, and a first saved plan — finished with an automatic smoke run across
-every preview surface so you never start from a broken environment.
+a disposable Infrahub instance, a dedicated Prefect server, the Sync HTTP API,
+and a Prefect worker running the service deployment.
 
-The smoke run writes its five example devices only to the `preview-smoke`
-Infrahub branch. `main` stays empty, so the custom-example CLI walkthrough
-starts with five creates; after applying that reviewed plan, the next plan has
-zero operations.
+`preview.up` starts that stack and stops there. It writes nothing to Infrahub
+and admits no Sync run, so repeating it against an environment somebody is
+already using changes none of their data.
 
-`preview.up` checks that pristine `main` state during startup. After completing
-the walkthrough, rerun `preview.smoke`, or reset volumes before running
-`preview.up` again.
+Two commands write, and each says what it will write before writing:
+
+- `preview.seed` loads the example schema, creates the `InfraDevice` named
+  `core01` on `main`, then forks the `preview-smoke` branch from it. Running it
+  again on an environment that already holds the branch changes nothing.
+- `preview.smoke` seeds, then runs the smoke suite. That suite mutates `core01`
+  on `main` and creates and applies real Sync runs against `preview-smoke`.
 
 ## Start
 
@@ -26,7 +27,7 @@ The final summary prints the Infrahub UI, Prefect UI, and Sync API
 addresses, the bearer principals, and where runtime state lives. Requires
 Docker and Python 3.11+.
 
-Other commands: `preview.status`, `preview.smoke`, `preview.logs`
+Other commands: `preview.status`, `preview.seed`, `preview.smoke`, `preview.logs`
 (`--name sync-api|prefect-worker`), `preview.down` (add `--volumes` to reset
 all data).
 

--- a/development/README.md
+++ b/development/README.md
@@ -16,6 +16,11 @@ Two commands write, and each says what it will write before writing:
 - `preview.smoke` seeds, then runs the smoke suite. That suite mutates `core01`
   on `main` and creates and applies real Sync runs against `preview-smoke`.
 
+The published page for this stack is
+[Local development stack](../docs/docs/development-stack.mdx). It covers the same
+commands plus the addresses, the development-only credentials, the startup refusal on
+retired state, and how to run the tests.
+
 ## Start
 
 ```bash

--- a/docs/docs/contributing.mdx
+++ b/docs/docs/contributing.mdx
@@ -70,6 +70,10 @@ uv run infrahub-sync runs plan --help
 uv run pytest -q
 ```
 
+### Running the full stack locally
+
+To run the Sync HTTP API, its Prefect worker, and a disposable Infrahub against your checkout, see the [local development stack](./development-stack.mdx).
+
 ## Code standards
 
 ### Python style

--- a/docs/docs/development-stack.mdx
+++ b/docs/docs/development-stack.mdx
@@ -89,10 +89,12 @@ different ones.
 
 ## The stack refuses to start on retired state
 
-`preview.up` reads Prefect and the host process list before starting anything, and
-refuses when it finds state left under the names this service used before its rename:
-the `infrahub-sync-managed` deployment, a work pool or worker whose name starts with it,
-or a host process running `infrahub_sync.managed.serve` or `infrahub_sync.managed.worker`.
+`preview.up` starts the containers and waits for Infrahub and Prefect to answer, then
+reads Prefect and the host process list before it starts the worker, the deployment, and
+the Sync API. It refuses at that point when it finds state left under the names this
+service used before its rename: the `infrahub-sync-managed` deployment, a work pool or
+worker whose name starts with it, or a host process running `infrahub_sync.managed.serve`
+or `infrahub_sync.managed.worker`.
 
 The refusal names its own fix:
 

--- a/docs/docs/development-stack.mdx
+++ b/docs/docs/development-stack.mdx
@@ -1,0 +1,134 @@
+---
+title: Local development stack
+---
+
+The repository ships a complete local stack for working on Infrahub Sync: a disposable
+Infrahub instance, PostgreSQL and MinIO for the service's own records and artifacts, a
+dedicated Prefect server, and the Sync HTTP API and its Prefect worker running from your
+checkout.
+
+Everything the stack creates is disposable, and every credential it uses is a published
+local default. Never point any value on this page at a shared or internet-facing
+instance.
+
+## Install
+
+The stack needs Docker, [uv](https://docs.astral.sh/uv/), and Python 3.11 to 3.13.
+
+```bash
+uv sync --extra dev --extra prefect --extra service
+```
+
+All three extras are required. Without `prefect` and `service` the Sync API and its
+worker cannot start, and the type checker cannot resolve their imports.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `uv run invoke preview.up` | Start the containers and the host processes. Writes nothing to Infrahub. |
+| `uv run invoke preview.seed` | Write the smoke dataset into Infrahub. |
+| `uv run invoke preview.smoke` | Seed, then run the smoke suite, which creates and applies real runs. |
+| `uv run invoke preview.status` | Show container, host process, and endpoint state. |
+| `uv run invoke preview.logs` | Print the tail of a host process log. |
+| `uv run invoke preview.down` | Stop the host processes and the containers, keeping the data. |
+| `uv run invoke preview.down --volumes` | Stop everything and delete every data volume. |
+
+`preview.logs` prints the Sync API log by default; pass `-n prefect-worker` for the
+worker's, and `--lines` for how much of it to print.
+
+### Starting the stack writes nothing
+
+`preview.up` brings the stack up and stops there. It loads no schema, creates no branch
+or node, and admits no run, so starting it again against an environment you are already
+using changes none of your data.
+
+Two commands write, and each says what it will write before writing:
+
+- `preview.seed` loads the example schema from
+  `examples/prefect_remote_run/schemas/infra_device.yml`, creates the `InfraDevice` named
+  `core01` on `main`, and then forks the `preview-smoke` branch from it. It changes
+  nothing on an environment that already holds that branch.
+- `preview.smoke` seeds, then runs the smoke suite. That suite mutates `core01` on `main`
+  and drives real plan and apply runs against `preview-smoke`.
+
+A clean `preview.up` followed by `preview.smoke` therefore works without a separate seed.
+
+## Addresses
+
+| Service | Address | Runs as |
+| --- | --- | --- |
+| Infrahub | `http://localhost:8080` | Container |
+| Prefect | `http://localhost:4210` | Container |
+| Sync HTTP API | `http://127.0.0.1:8010` | Host process |
+| PostgreSQL | `127.0.0.1:5439` | Container |
+| MinIO | `http://127.0.0.1:9010` | Container |
+
+The defaults avoid ports 8000 and 4200, so an Infrahub development stack or a Prefect
+server you already run keeps working alongside. To change any of them, put the override
+in `development/preview.local.env`, which the tasks read after the shipped
+`development/preview.env`. Git ignores that local file.
+
+Runtime state — process identifiers, logs, and caches — lives under `.preview/` at the
+repository root, which Git also ignores.
+
+## Every credential is a development default
+
+Nothing the stack uses is a secret, and none of it works anywhere else:
+
+- `development/preview.env` ships the MinIO access key and secret key, the Infrahub admin
+  token, and the Sync API bearer principal.
+- `development/docker-compose.infrahub.yml` is the official Infrahub Compose file,
+  downloaded unmodified from `https://infrahub.opsmill.io/<VERSION>` for the `VERSION`
+  pinned in `development/preview.env`. Its Infrahub admin token, agent token, and
+  security key defaults are that file's own published values.
+
+They reach only the disposable local containers this stack creates. Do not reuse them in
+a deployment, and mint your own tokens in `development/preview.local.env` if you need
+different ones.
+
+## The stack refuses to start on retired state
+
+`preview.up` reads Prefect and the host process list before starting anything, and
+refuses when it finds state left under the names this service used before its rename:
+the `infrahub-sync-managed` deployment, a work pool or worker whose name starts with it,
+or a host process running `infrahub_sync.managed.serve` or `infrahub_sync.managed.worker`.
+
+The refusal names its own fix:
+
+```bash
+uv run invoke preview.down --volumes
+```
+
+That reset is destructive. It deletes every data volume in the stack, so the Infrahub
+instance, the service records, and the artifacts all go. It also stops a retired host
+process it can identify without ambiguity; where more than one running process matches a
+retired name, it stops none of them and asks you to stop them by hand.
+
+`preview.down` without `--volumes` does neither. It leaves the data volumes and any
+retired process in place, so it does not clear the refusal.
+
+## Running the tests
+
+The smoke suite lives in `tests/preview/` and is opt-in:
+
+```bash
+uv run pytest -m preview tests/preview -q
+```
+
+Run it in a single process. Its modules share one Infrahub branch and one Prefect
+deployment, and a collection hook orders the run-creating modules ahead of the module
+that observes their Prefect flow runs. Under `pytest-xdist` that ordering would apply
+only within one worker, and the shared branch would take concurrent writes.
+
+Every test in the suite skips, rather than fails, when the stack is not reachable.
+
+The rest of the test suite needs no stack, and excludes the markers that write to one:
+
+```bash
+uv run pytest -m "not preview and not integration" -q
+```
+
+Run that form while the stack is up. A plain `pytest -q` would collect the smoke suite
+against your running environment, and the `integration` tests write to whatever Infrahub
+instance the ambient settings name.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -89,6 +89,7 @@ const sidebars: SidebarsConfig = {
         },
       ],
     },
+    'development-stack',
     'contributing',
   ]
 };

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -28,7 +28,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from invoke import Context, UnexpectedExit, task
+from invoke import Context, task
 
 from .utils import ESCAPED_REPO_PATH
 
@@ -223,6 +223,22 @@ def _wait_for_http(url: str, description: str, timeout: int = WAIT_TIMEOUT_SECON
         time.sleep(3)
     msg = f"{description} did not become ready within {timeout}s (last: {last_error})"
     raise PreviewError(msg)
+
+
+def _infrahub_reachable(infrahub_address: str) -> bool:
+    """Report whether Infrahub answers at all, on the endpoint `up` waits for.
+
+    A stopped stack is the one condition under which the smoke skips seeding: the suite
+    then reports the unreachable endpoint itself. Every other seed failure is a real
+    failure and belongs to the caller.
+    """
+    import httpx  # noqa: PLC0415 -- lazy so importing the tasks package never requires the service extras
+
+    try:
+        httpx.get(f"{infrahub_address}/api/config", timeout=5)
+    except httpx.HTTPError:
+        return False
+    return True
 
 
 def _prefect_call(method: str, url: str) -> httpx.Response:
@@ -490,18 +506,12 @@ def seed(context: Context) -> None:
 @task
 def smoke(context: Context) -> None:
     """Seed the smoke dataset, then run the smoke suite against the running environment."""
-    from infrahub_sdk.exceptions import (  # noqa: PLC0415 -- keep Invoke task imports lightweight
-        ServerNotReachableError,
-    )
-
     env = _runtime_env(load_preview_env())
-    print(f" - [{NAMESPACE}] The smoke suite writes, so it seeds first")
-    try:
+    if _infrahub_reachable(env["INFRAHUB_ADDRESS"]):
+        print(f" - [{NAMESPACE}] The smoke suite writes, so it seeds first")
         seed(context)
-    except (ServerNotReachableError, UnexpectedExit):
-        # Preserve the suite's polite stopped-environment behavior: its session
-        # fixture reports the unavailable endpoint and skips the preview tests.
-        print(f" - [{NAMESPACE}] The preview could not be seeded; smoke tests will report the environment state")
+    else:
+        print(f" - [{NAMESPACE}] Infrahub is not reachable; smoke tests will report the environment state")
     print(f" - [{NAMESPACE}] Running the preview smoke suite")
     with context.cd(ESCAPED_REPO_PATH):
         # Single-process deliberately: the suite's modules share one Infrahub branch and

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -504,6 +504,9 @@ def smoke(context: Context) -> None:
         print(f" - [{NAMESPACE}] The preview could not be seeded; smoke tests will report the environment state")
     print(f" - [{NAMESPACE}] Running the preview smoke suite")
     with context.cd(ESCAPED_REPO_PATH):
+        # Single-process deliberately: the suite's modules share one Infrahub branch and
+        # one Prefect deployment, and its collection hook orders them against each other.
+        # A distributed run would split that ordering across workers.
         context.run("uv run pytest -m preview tests/preview -q", env=env)
 
 

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -1,10 +1,14 @@
 """Preview environment: one command from a fresh clone to a testable v3 stack.
 
 `invoke preview.up` brings up a disposable Infrahub instance and a dedicated
-Prefect server (Docker), loads the example schema, starts the Sync HTTP
-API and a Prefect worker from this checkout, applies the service deployment,
-and finishes by running the preview smoke suite so a
-tester never receives an environment that has not just proven its own basics.
+Prefect server (Docker), starts the Sync HTTP API and a Prefect worker from
+this checkout, and applies the service deployment. It writes nothing to
+Infrahub and admits no Sync run: bringing the stack up is safe to repeat on an
+environment somebody is already using.
+
+The two write-bearing actions are explicit. `invoke preview.seed` puts the
+smoke dataset into Infrahub, and `invoke preview.smoke` seeds and then runs the
+smoke suite, which admits real Sync runs.
 
 Configuration ships in `development/preview.env` (no secrets — local-only
 defaults); personal overrides belong in the gitignored
@@ -24,7 +28,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from invoke import Context, task
+from invoke import Context, UnexpectedExit, task
 
 from .utils import ESCAPED_REPO_PATH
 
@@ -52,7 +56,6 @@ SMOKE_BRANCH = "preview-smoke"
 SMOKE_KIND = "InfraDevice"
 SHARED_DEVICE_NAME = "core01"
 SHARED_DEVICE_SEED_TYPE = "preview-seed"
-EXPECT_MAIN_EMPTY_ENV = "INFRAHUB_SYNC_PREVIEW_EXPECT_MAIN_EMPTY"
 # Process name -> substring its command line must contain before a recorded pid
 # is treated as ours (guards against pid recycling by unrelated processes).
 SERVICE_PROCESSES = {
@@ -397,7 +400,7 @@ def _stop_process(name: str) -> None:
 
 @task
 def up(context: Context) -> None:
-    """Bring up the full preview stack, prove it with the smoke suite, print URLs."""
+    """Bring up the full preview stack without writing to it, then print URLs."""
     values = load_preview_env()
     urls = preview_urls(values)
     env = _runtime_env(values)
@@ -409,12 +412,6 @@ def up(context: Context) -> None:
     _wait_for_http(f"{urls['infrahub']}/api/config", "Infrahub")
     _wait_for_http(f"{urls['prefect']}/api/health", "Prefect")
     assert_no_legacy_state(env["PREFECT_API_URL"], values["PREVIEW_WORK_POOL"])
-
-    print(f" - [{NAMESPACE}] Loading the example schema")
-    context.run(
-        f"uv run infrahubctl schema load {shlex.quote(str(SCHEMA_FILE))}",
-        env={"INFRAHUB_ADDRESS": env["INFRAHUB_ADDRESS"], "INFRAHUB_API_TOKEN": env["INFRAHUB_API_TOKEN"]},
-    )
 
     print(f" - [{NAMESPACE}] Ensuring the Prefect work pool exists")
     context.run(
@@ -460,8 +457,6 @@ def up(context: Context) -> None:
     )
     _wait_for_http(f"{urls['sync_api']}/openapi.json", "Sync API", timeout=90)
 
-    _run_smoke(context, expect_main_empty=True)
-
     tokens = json.loads(values["PREVIEW_BEARER_TOKENS"])
     print(f" - [{NAMESPACE}] Preview environment ready")
     print(f"     Infrahub UI:      {urls['infrahub']}  (admin / infrahub)")
@@ -469,37 +464,43 @@ def up(context: Context) -> None:
     print(f"     Sync API: {urls['sync_api']}  (bearer principals: {', '.join(sorted(tokens))})")
     print(f"     Config directory: {env['INFRAHUB_SYNC_CONFIG_DIRECTORY']}")
     print(f"     Runtime state:    {STATE_DIR}")
-    print("     Next: docs/docs/reference/sync-http-api.mdx and `uv run invoke preview.status`")
+    print("     Nothing has been written to Infrahub; `preview.seed` and `preview.smoke` write.")
+    print("     Next: `uv run invoke preview.seed`, `preview.smoke`, or `preview.status`")
 
 
-def _run_smoke(context: Context, *, expect_main_empty: bool) -> None:
-    """Run reusable smoke checks, optionally including startup acceptance."""
-    from infrahub_sdk.exceptions import (  # noqa: PLC0415 -- keep Invoke task imports lightweight
-        ServerNotReachableError,
-    )
-
+@task
+def seed(context: Context) -> None:
+    """Write the smoke dataset into the running preview: schema, branch, shared device."""
     values = load_preview_env()
     env = _runtime_env(values)
-    if expect_main_empty:
-        env[EXPECT_MAIN_EMPTY_ENV] = "1"
-    else:
-        env.pop(EXPECT_MAIN_EMPTY_ENV, None)
-    print(f" - [{NAMESPACE}] Ensuring the {SMOKE_BRANCH} Infrahub branch exists")
-    try:
-        ensure_smoke_branch(env)
-    except ServerNotReachableError:
-        # Preserve the suite's polite stopped-environment behavior: its session
-        # fixture reports the unavailable endpoint and skips the preview tests.
-        print(f" - [{NAMESPACE}] Infrahub is not reachable; smoke tests will report the environment state")
-    print(f" - [{NAMESPACE}] Running the preview smoke suite")
-    with context.cd(ESCAPED_REPO_PATH):
-        context.run("uv run pytest -m preview tests/preview -q", env=env)
+    print(f" - [{NAMESPACE}] Seeding {env['INFRAHUB_ADDRESS']}, which writes:")
+    print(f" - [{NAMESPACE}]   the schema in {SCHEMA_FILE}")
+    print(f" - [{NAMESPACE}]   {SMOKE_KIND} {SHARED_DEVICE_NAME} on main, then the {SMOKE_BRANCH} branch")
+    context.run(
+        f"uv run infrahubctl schema load {shlex.quote(str(SCHEMA_FILE))}",
+        env={"INFRAHUB_ADDRESS": env["INFRAHUB_ADDRESS"], "INFRAHUB_API_TOKEN": env["INFRAHUB_API_TOKEN"]},
+    )
+    ensure_smoke_branch(env)
 
 
 @task
 def smoke(context: Context) -> None:
-    """Run reusable smoke checks against the running environment."""
-    _run_smoke(context, expect_main_empty=False)
+    """Seed the smoke dataset, then run the smoke suite against the running environment."""
+    from infrahub_sdk.exceptions import (  # noqa: PLC0415 -- keep Invoke task imports lightweight
+        ServerNotReachableError,
+    )
+
+    env = _runtime_env(load_preview_env())
+    print(f" - [{NAMESPACE}] The smoke suite writes, so it seeds first")
+    try:
+        seed(context)
+    except (ServerNotReachableError, UnexpectedExit):
+        # Preserve the suite's polite stopped-environment behavior: its session
+        # fixture reports the unavailable endpoint and skips the preview tests.
+        print(f" - [{NAMESPACE}] The preview could not be seeded; smoke tests will report the environment state")
+    print(f" - [{NAMESPACE}] Running the preview smoke suite")
+    with context.cd(ESCAPED_REPO_PATH):
+        context.run("uv run pytest -m preview tests/preview -q", env=env)
 
 
 @task

--- a/tasks/preview.py
+++ b/tasks/preview.py
@@ -63,6 +63,10 @@ SERVICE_PROCESSES = {
     "prefect-worker": "infrahub_sync.service.worker",
 }
 WAIT_TIMEOUT_SECONDS = 420
+# Infrahub applies a loaded schema asynchronously, and the seed immediately creates a node
+# of the kind it just loaded. Without waiting for the schema to converge across Infrahub's
+# workers, that create fails with `SchemaNotFoundError` on a fresh instance.
+SCHEMA_CONVERGE_SECONDS = 120
 # The pre-stability names this preview used to register and run under. `preview.up`
 # reuses volumes and tolerates existing Prefect state, so a checkout that ran the old
 # names can still hold a live deployment, work pool, worker, or host process under them.
@@ -477,7 +481,7 @@ def seed(context: Context) -> None:
     print(f" - [{NAMESPACE}]   the schema in {SCHEMA_FILE}")
     print(f" - [{NAMESPACE}]   {SMOKE_KIND} {SHARED_DEVICE_NAME} on main, then the {SMOKE_BRANCH} branch")
     context.run(
-        f"uv run infrahubctl schema load {shlex.quote(str(SCHEMA_FILE))}",
+        f"uv run infrahubctl schema load --wait {SCHEMA_CONVERGE_SECONDS} {shlex.quote(str(SCHEMA_FILE))}",
         env={"INFRAHUB_ADDRESS": env["INFRAHUB_ADDRESS"], "INFRAHUB_API_TOKEN": env["INFRAHUB_API_TOKEN"]},
     )
     ensure_smoke_branch(env)

--- a/tests/preview/conftest.py
+++ b/tests/preview/conftest.py
@@ -5,6 +5,11 @@ the simple things on every preview surface (Python API, Sync HTTP API,
 Prefect) so a tester never starts from a broken environment. They are not a
 replacement for human testing, and they skip — never fail — when the preview
 environment is not running.
+
+They share one Infrahub branch and one Prefect deployment, and the collection
+hook below orders them against each other, so the suite runs single-process:
+under `pytest-xdist` the hook would order one worker's share of the modules and
+the shared branch would take concurrent writes.
 """
 
 from __future__ import annotations
@@ -22,18 +27,22 @@ if TYPE_CHECKING:
     from _pytest.nodes import Item
 
 _HERE = Path(__file__).parent
-# The Prefect surface smoke asserts on the flow runs the Sync API smoke creates, so it
-# has to run after it. Filename collation is not a dependency this suite may rest on:
-# renaming either module silently reverses them and the surface smoke then polls a
+# The Prefect surface smoke asserts on the flow runs every client smoke creates, so it
+# has to run after all of them. Filename collation is not a dependency this suite may
+# rest on: renaming any module silently reorders them and the surface smoke then polls a
 # deployment that nothing has submitted to yet.
-_RUN_CREATOR = _HERE / "test_service_api.py"
+_RUN_CREATORS = (
+    _HERE / "test_service_api.py",
+    _HERE / "test_cli_client.py",
+    _HERE / "test_python_client.py",
+)
 _RUN_OBSERVER = _HERE / "test_prefect_surface.py"
 
 
 def pytest_collection_modifyitems(items: list[Item]) -> None:
-    """Run the Sync API smoke before the Prefect surface smoke that observes it."""
+    """Run every run-creating smoke before the Prefect surface smoke that observes them."""
     observers = [item for item in items if item.path == _RUN_OBSERVER]
-    creators = [item for item in items if item.path == _RUN_CREATOR]
+    creators = [item for item in items if item.path in _RUN_CREATORS]
     if not observers or not creators or items.index(creators[-1]) < items.index(observers[0]):
         return
     for observer in observers:

--- a/tests/preview/test_cli_client.py
+++ b/tests/preview/test_cli_client.py
@@ -1,0 +1,194 @@
+"""CLI surface: the shipped console script drives one registered lifecycle.
+
+The Sync API smoke proves the wire; this proves the entrypoint a developer actually
+types. It runs `infrahub-sync` as the installed console script in its own process, so
+what is exercised is the packaged command, its environment settings, and its exit
+codes — not an in-process Typer invocation that would skip all three.
+
+The CLI has no results command, so final state is read back through the HTTP API and
+Infrahub itself. The assertions are outcomes: the run the service recorded, the counts
+it applied, and the value the destination branch ends up carrying. Field text is parsed
+only to carry the service-issued run id and reviewed checksum from one command to the
+next, which is what the documented review cycle asks an operator to do by hand.
+
+The lifecycle is the same shape as the Sync API smoke and shares its setup, so the two
+converge on the same branch in either order: the source is mirrored from the destination
+first and only the shared device is left differing, leaving exactly one update to plan.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess  # noqa: S404 -- fixed argv invocation of this repository's own console script
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+
+from tasks.preview import REPO_ROOT, SHARED_DEVICE_NAME, SMOKE_BRANCH
+from tests.preview.test_service_api import (
+    device_types,
+    infrahub_client,
+    seed_source_branch,
+    smoke_package,
+    unwritten_plan_reasons,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.preview
+
+# The CLI waits for its own run; bound it to the same budget the Sync API smoke polls
+# against, and give the subprocess room to exit after that wait expires.
+WAIT_TIMEOUT_SECONDS = 240
+POLL_INTERVAL_SECONDS = 3
+PROCESS_TIMEOUT_SECONDS = WAIT_TIMEOUT_SECONDS + 60
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _cli_environment(preview_env: dict[str, Any]) -> dict[str, str]:
+    """The settings one CLI invocation needs, with the renderer pinned.
+
+    `NO_COLOR` and a fixed `COLUMNS` remove the only two things that make the shipped
+    output depend on the terminal it happens to run in: colour escapes and the width
+    Rich wraps a long field value at. A wrapped run id is not a run id.
+    """
+    return {
+        **os.environ,
+        "INFRAHUB_SYNC_API_URL": preview_env["urls"]["sync_api"],
+        "INFRAHUB_SYNC_API_TOKEN": preview_env["bearer_token"],
+        "NO_COLOR": "1",
+        "COLUMNS": "200",
+    }
+
+
+def _fields(output: str) -> dict[str, str]:
+    """Parse the CLI's `name: value` field lines, ignoring anything else it prints."""
+    fields: dict[str, str] = {}
+    for line in _ANSI.sub("", output).splitlines():
+        name, separator, value = line.partition(": ")
+        if separator and name.isidentifier():
+            fields[name] = value.strip()
+    return fields
+
+
+def _run_cli(preview_env: dict[str, Any], *arguments: str) -> dict[str, str]:
+    """Run the installed console script to success and return its parsed fields."""
+    completed = subprocess.run(  # noqa: S603
+        ["uv", "run", "infrahub-sync", *arguments],  # noqa: S607 — resolved from PATH by design
+        cwd=REPO_ROOT,
+        env=_cli_environment(preview_env),
+        capture_output=True,
+        text=True,
+        timeout=PROCESS_TIMEOUT_SECONDS,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"`infrahub-sync {' '.join(arguments)}` exited {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    return _fields(completed.stdout)
+
+
+def _api(preview_env: dict[str, Any]) -> httpx.Client:
+    """The HTTP oracle: what the service recorded, read independently of the CLI."""
+    return httpx.Client(
+        base_url=preview_env["urls"]["sync_api"],
+        headers={"Authorization": f"Bearer {preview_env['bearer_token']}"},
+        timeout=30,
+    )
+
+
+def _package_file(preview_env: dict[str, Any], directory: Path) -> Path:
+    path = directory / "preview-smoke-package.json"
+    path.write_text(json.dumps(smoke_package(preview_env["urls"]["infrahub"])), encoding="utf-8")
+    return path
+
+
+def test_cli_registers_plans_reviews_and_applies_against_the_service(
+    preview_env: dict[str, Any], tmp_path: Path
+) -> None:
+    """`configs register` → `diff` → `runs plan` → `apply`, proved through the API."""
+    mutated_type = seed_source_branch(preview_env)
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] != mutated_type
+
+    registered = _run_cli(
+        preview_env,
+        "configs",
+        "register",
+        str(_package_file(preview_env, tmp_path)),
+        "--reason",
+        "preview CLI smoke: register the smoke configuration",
+        "--idempotency-key",
+        f"preview-cli-{uuid.uuid4()}",
+    )
+    config_id, registry_version = registered["config_id"], registered["registry_version"]
+
+    planned = _run_cli(
+        preview_env,
+        "diff",
+        "--config-id",
+        config_id,
+        "--version",
+        registry_version,
+        "--branch",
+        SMOKE_BRANCH,
+        "--reason",
+        "preview CLI smoke: create a service plan",
+        "--idempotency-key",
+        f"preview-cli-{uuid.uuid4()}",
+        "--wait-timeout",
+        str(WAIT_TIMEOUT_SECONDS),
+        "--poll-interval",
+        str(POLL_INTERVAL_SECONDS),
+    )
+    run_id, checksum = planned["run_id"], planned["plan_checksum"]
+
+    with _api(preview_env) as client:
+        plan = client.get(f"/runs/{run_id}/plan")
+        assert plan.status_code == 200, plan.text
+        summary = plan.json()["summary"]
+        # The same guard the Sync API smoke applies: a delete-only plan applies cleanly
+        # and writes nothing, so an apply over one would prove nothing about the CLI.
+        assert unwritten_plan_reasons(summary) == [], summary
+        assert summary["by_action"].get("update", 0) == 1, summary
+
+    reviewed = _run_cli(preview_env, "runs", "plan", run_id)
+    assert reviewed["run_id"] == run_id
+    assert reviewed["plan_checksum"] == checksum
+    assert reviewed["checksum_ok"] == "true"
+
+    _run_cli(
+        preview_env,
+        "apply",
+        run_id,
+        "--expected-checksum",
+        checksum,
+        "--branch",
+        SMOKE_BRANCH,
+        "--reason",
+        "preview CLI smoke: apply the reviewed plan",
+        "--idempotency-key",
+        f"preview-cli-{uuid.uuid4()}",
+        "--wait-timeout",
+        str(WAIT_TIMEOUT_SECONDS),
+        "--poll-interval",
+        str(POLL_INTERVAL_SECONDS),
+    )
+
+    with _api(preview_env) as client:
+        recorded = client.get(f"/runs/{run_id}")
+        assert recorded.status_code == 200, recorded.text
+        assert recorded.json()["run"]["phase"] == "applied", recorded.text
+        results = client.get(f"/runs/{run_id}/results")
+        assert results.status_code == 200, results.text
+        applied_summary = results.json()["results"]["summary"]
+        assert applied_summary.get("update", 0) > 0, applied_summary
+        assert applied_summary.get("delete", 0) == 0, applied_summary
+
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] == mutated_type

--- a/tests/preview/test_preview_configuration.py
+++ b/tests/preview/test_preview_configuration.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import infrahub_sdk
 import pytest
-from infrahub_sdk.exceptions import ServerNotReachableError
-from invoke import Context
+from invoke import Context, Result, UnexpectedExit
 
 from tasks import preview
 from tasks.preview import (
@@ -328,6 +327,7 @@ def test_the_smoke_task_seeds_before_it_checks(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
     monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
+    monkeypatch.setattr(preview, "_infrahub_reachable", lambda _address: True)
     monkeypatch.setattr(preview, "ensure_smoke_branch", lambda env: events.append(("branch", env)))
     monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
     monkeypatch.setattr(
@@ -377,6 +377,37 @@ def test_the_seed_task_loads_the_schema_before_it_creates_the_device(monkeypatch
     ]
 
 
+def test_the_smoke_task_does_not_run_the_suite_when_the_seed_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A seed that fails against a reachable Infrahub must stop the smoke, not be absorbed.
+
+    A rejected schema, an edit the destination refuses, or a wrong credential override
+    all fail here. Running the suite anyway would check the state the seed failed to
+    replace, and that state can still satisfy every assertion.
+    """
+    commands: list[str] = []
+    context = Context()
+    values = {"COMPOSE_PROJECT_NAME": "preview-test"}
+    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
+
+    def _refuse_the_schema_load(command: str, *, env: dict[str, str]) -> None:
+        del env
+        commands.append(command)
+        if "schema load" in command:
+            raise UnexpectedExit(Result(exited=1))
+
+    monkeypatch.setattr(preview, "load_preview_env", lambda: values)
+    monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
+    monkeypatch.setattr(preview, "_infrahub_reachable", lambda _address: True)
+    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda _env: commands.append("branch"))
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(context, "run", _refuse_the_schema_load)
+
+    with pytest.raises(UnexpectedExit):
+        cast("Task", preview.smoke).body(context)
+
+    assert [command for command in commands if "pytest" in command] == [], commands
+
+
 def test_actual_smoke_path_receives_the_preview_aws_credential_chain(monkeypatch: pytest.MonkeyPatch) -> None:
     """The reusable smoke command receives the same MinIO credentials as API, worker, and CLI."""
     events: list[tuple[str, dict[str, str]]] = []
@@ -399,6 +430,7 @@ def test_actual_smoke_path_receives_the_preview_aws_credential_chain(monkeypatch
     }
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
+    monkeypatch.setattr(preview, "_infrahub_reachable", lambda _address: True)
     monkeypatch.setattr(preview, "ensure_smoke_branch", lambda _env: None)
     monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
     monkeypatch.setattr(context, "run", lambda command, *, env: events.append((command, env.copy())))
@@ -412,6 +444,7 @@ def test_actual_smoke_path_receives_the_preview_aws_credential_chain(monkeypatch
 
 
 def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stopped stack is not seeded at all; the suite reports the unreachable endpoint."""
     events: list[object] = []
     context = Context()
     values = {"COMPOSE_PROJECT_NAME": "preview-test"}
@@ -419,11 +452,8 @@ def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch:
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
     monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
-    monkeypatch.setattr(
-        preview,
-        "ensure_smoke_branch",
-        lambda _env: (_ for _ in ()).throw(ServerNotReachableError(environment["INFRAHUB_ADDRESS"])),
-    )
+    monkeypatch.setattr(preview, "_infrahub_reachable", lambda _address: False)
+    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda env: events.append(("branch", env)))
     monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
     monkeypatch.setattr(
         context,
@@ -433,14 +463,7 @@ def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch:
 
     cast("Task", preview.smoke).body(context)
 
-    assert events == [
-        (
-            "run",
-            f"uv run infrahubctl schema load --wait {preview.SCHEMA_CONVERGE_SECONDS} {preview.SCHEMA_FILE}",
-            environment,
-        ),
-        ("run", "uv run pytest -m preview tests/preview -q", environment),
-    ]
+    assert events == [("run", "uv run pytest -m preview tests/preview -q", environment)]
 
 
 def test_netbox_tutorial_uses_one_checkout_for_code_and_configuration() -> None:

--- a/tests/preview/test_preview_configuration.py
+++ b/tests/preview/test_preview_configuration.py
@@ -16,7 +16,6 @@ from tasks.preview import (
     COMPOSE_FILES,
     DEV_DIR,
     ENV_FILE,
-    EXPECT_MAIN_EMPTY_ENV,
     REPO_ROOT,
     SHARED_DEVICE_NAME,
     SHARED_DEVICE_SEED_TYPE,
@@ -26,6 +25,14 @@ from tasks.preview import (
 )
 
 PREVIEW_MINIO_SECRET = "preview-minio-secret"  # noqa: S105 - disposable local contract canary.
+UP_VALUES = {
+    "COMPOSE_PROJECT_NAME": "preview-test",
+    "PREVIEW_INFRAHUB_PORT": "8080",
+    "PREVIEW_PREFECT_PORT": "4210",
+    "PREVIEW_SYNC_API_PORT": "8090",
+    "PREVIEW_WORK_POOL": "preview-pool",
+    "PREVIEW_BEARER_TOKENS": '{"tester@local": {"token": "t", "administrator": true}}',
+}
 SMOKE_ENVIRONMENT = {"INFRAHUB_ADDRESS": "http://127.0.0.1:8080", "INFRAHUB_API_TOKEN": "local-token"}
 # The source the CLI-cycle smoke plans against the same branch.
 CLI_SMOKE_SOURCE = REPO_ROOT / "examples" / "custom_adapter" / "custom_adapter_src" / "mock_db.json"
@@ -142,6 +149,49 @@ def test_preview_up_uses_a_bounded_compose_wait(monkeypatch: pytest.MonkeyPatch,
         cast("Task", preview.up).body(context)
 
     assert compose_calls == ["up --detach --wait --wait-timeout 420 --quiet-pull"]
+
+
+def test_bringing_the_preview_up_writes_nothing_to_infrahub(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`up` starts the stack and nothing else; `seed` and `smoke` own every write.
+
+    The daily bring-up must leave the disposable Infrahub exactly as it found it, so the
+    commands `up` issues are pinned in full: no schema load, no seeded branch or device,
+    and no smoke suite -- the one path that admits a Sync run.
+    """
+    started: list[str] = []
+    commands: list[str] = []
+    seeded: list[dict[str, str]] = []
+    context = Context()
+
+    monkeypatch.setattr(preview, "STATE_DIR", tmp_path / ".preview")
+    monkeypatch.setattr(preview, "load_preview_env", lambda: UP_VALUES)
+    monkeypatch.setattr(
+        preview,
+        "_runtime_env",
+        lambda _values: {
+            "INFRAHUB_ADDRESS": "http://localhost:8080",
+            "INFRAHUB_API_TOKEN": "local-token",
+            "PREFECT_API_URL": "http://localhost:4210/api",
+            "INFRAHUB_SYNC_CONFIG_DIRECTORY": str(tmp_path / "examples"),
+            "INFRAHUB_SYNC_CACHE_DIR": str(tmp_path / "sync-cache"),
+        },
+    )
+    monkeypatch.setattr(preview, "_compose", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(preview, "_wait_for_http", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(preview, "assert_no_legacy_state", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(preview, "_start_process", lambda name, _argv, _env: started.append(name))
+    monkeypatch.setattr(preview, "ensure_smoke_branch", seeded.append)
+    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(context, "run", lambda command, **_kwargs: commands.append(command))
+
+    cast("Task", preview.up).body(context)
+
+    assert started == ["prefect-worker", "sync-api"]
+    assert commands == [
+        "uv run prefect work-pool create preview-pool --type process",
+        "uv run python -m infrahub_sync.service.deploy",
+    ]
+    assert seeded == []
 
 
 def test_compose_receives_merged_local_preview_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -265,15 +315,16 @@ def test_the_seeded_device_is_one_the_cli_smoke_source_already_owns() -> None:
     assert SHARED_DEVICE_NAME in {device["name"] for device in devices}
 
 
-def test_the_smoke_task_ensures_its_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_smoke_task_seeds_before_it_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The suite writes, so `smoke` puts the dataset in place before running it.
+
+    Order is the property: seeded afterwards, the suite would plan against an Infrahub
+    that holds neither the schema nor the shared device it asserts on.
+    """
     events: list[object] = []
     context = Context()
     values = {"COMPOSE_PROJECT_NAME": "preview-test"}
-    environment = {
-        "INFRAHUB_ADDRESS": "http://localhost:8080",
-        "INFRAHUB_API_TOKEN": "local-token",
-        EXPECT_MAIN_EMPTY_ENV: "1",
-    }
+    environment = {"INFRAHUB_ADDRESS": "http://localhost:8080", "INFRAHUB_API_TOKEN": "local-token"}
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
     monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
@@ -287,14 +338,15 @@ def test_the_smoke_task_ensures_its_branch(monkeypatch: pytest.MonkeyPatch) -> N
 
     cast("Task", preview.smoke).body(context)
 
-    assert EXPECT_MAIN_EMPTY_ENV not in environment
     assert events == [
+        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
         ("branch", environment),
         ("run", "uv run pytest -m preview tests/preview -q", environment),
     ]
 
 
-def test_startup_smoke_requests_the_pristine_main_check(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_seed_task_loads_the_schema_before_it_creates_the_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ensure_smoke_branch` creates a node of the kind the schema defines, so it comes second."""
     events: list[object] = []
     context = Context()
     values = {"COMPOSE_PROJECT_NAME": "preview-test"}
@@ -302,21 +354,18 @@ def test_startup_smoke_requests_the_pristine_main_check(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(preview, "load_preview_env", lambda: values)
     monkeypatch.setattr(preview, "_runtime_env", lambda _values: environment)
-    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda _env: None)
-    monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
+    monkeypatch.setattr(preview, "ensure_smoke_branch", lambda env: events.append(("branch", env)))
     monkeypatch.setattr(
         context,
         "run",
-        lambda command, *, env: events.append((command, env.copy())),
+        lambda command, *, env: events.append(("run", command, env)),
     )
 
-    preview._run_smoke(context, expect_main_empty=True)
+    cast("Task", preview.seed).body(context)
 
     assert events == [
-        (
-            "uv run pytest -m preview tests/preview -q",
-            {**environment, EXPECT_MAIN_EMPTY_ENV: "1"},
-        )
+        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
+        ("branch", environment),
     ]
 
 
@@ -346,13 +395,12 @@ def test_actual_smoke_path_receives_the_preview_aws_credential_chain(monkeypatch
     monkeypatch.setattr(context, "cd", lambda _path: nullcontext())
     monkeypatch.setattr(context, "run", lambda command, *, env: events.append((command, env.copy())))
 
-    preview._run_smoke(context, expect_main_empty=False)
+    cast("Task", preview.smoke).body(context)
 
-    assert len(events) == 1
-    command, smoke_environment = events[0]
-    assert command == "uv run pytest -m preview tests/preview -q"
-    assert smoke_environment["AWS_ACCESS_KEY_ID"] == "preview-minio-access"
-    assert smoke_environment["AWS_SECRET_ACCESS_KEY"] == PREVIEW_MINIO_SECRET
+    smoke_environments = [env for command, env in events if "pytest" in command]
+    assert len(smoke_environments) == 1
+    assert smoke_environments[0]["AWS_ACCESS_KEY_ID"] == "preview-minio-access"
+    assert smoke_environments[0]["AWS_SECRET_ACCESS_KEY"] == PREVIEW_MINIO_SECRET
 
 
 def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -377,7 +425,10 @@ def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch:
 
     cast("Task", preview.smoke).body(context)
 
-    assert events == [("run", "uv run pytest -m preview tests/preview -q", environment)]
+    assert events == [
+        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
+        ("run", "uv run pytest -m preview tests/preview -q", environment),
+    ]
 
 
 def test_netbox_tutorial_uses_one_checkout_for_code_and_configuration() -> None:

--- a/tests/preview/test_preview_configuration.py
+++ b/tests/preview/test_preview_configuration.py
@@ -339,7 +339,11 @@ def test_the_smoke_task_seeds_before_it_checks(monkeypatch: pytest.MonkeyPatch) 
     cast("Task", preview.smoke).body(context)
 
     assert events == [
-        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
+        (
+            "run",
+            f"uv run infrahubctl schema load --wait {preview.SCHEMA_CONVERGE_SECONDS} {preview.SCHEMA_FILE}",
+            environment,
+        ),
         ("branch", environment),
         ("run", "uv run pytest -m preview tests/preview -q", environment),
     ]
@@ -364,7 +368,11 @@ def test_the_seed_task_loads_the_schema_before_it_creates_the_device(monkeypatch
     cast("Task", preview.seed).body(context)
 
     assert events == [
-        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
+        (
+            "run",
+            f"uv run infrahubctl schema load --wait {preview.SCHEMA_CONVERGE_SECONDS} {preview.SCHEMA_FILE}",
+            environment,
+        ),
         ("branch", environment),
     ]
 
@@ -426,7 +434,11 @@ def test_the_smoke_task_leaves_an_unreachable_environment_to_pytest(monkeypatch:
     cast("Task", preview.smoke).body(context)
 
     assert events == [
-        ("run", f"uv run infrahubctl schema load {preview.SCHEMA_FILE}", environment),
+        (
+            "run",
+            f"uv run infrahubctl schema load --wait {preview.SCHEMA_CONVERGE_SECONDS} {preview.SCHEMA_FILE}",
+            environment,
+        ),
         ("run", "uv run pytest -m preview tests/preview -q", environment),
     ]
 

--- a/tests/preview/test_preview_legacy_state.py
+++ b/tests/preview/test_preview_legacy_state.py
@@ -99,7 +99,6 @@ def _staged_up(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, started: list[st
     )
     monkeypatch.setattr(preview, "_compose", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(preview, "_wait_for_http", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(preview, "_run_smoke", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(preview, "_start_process", lambda name, _argv, _env: started.append(name))
 
     class _SilentContext(Context):

--- a/tests/preview/test_preview_worker_identity.py
+++ b/tests/preview/test_preview_worker_identity.py
@@ -44,7 +44,6 @@ def _staged_up(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Any
     monkeypatch.setattr(preview, "_compose", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(preview, "_wait_for_http", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(preview, "assert_no_legacy_state", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(preview, "_run_smoke", lambda *_args, **_kwargs: None)
 
     def _start(name: str, argv: list[str], env: dict[str, str]) -> None:
         captured[f"argv:{name}"] = argv

--- a/tests/preview/test_python_client.py
+++ b/tests/preview/test_python_client.py
@@ -1,0 +1,102 @@
+"""Python client surface: `SyncClient` drives one registered lifecycle live.
+
+The typed client can regress independently of the wire the Sync API smoke covers: its
+response models, its compatibility handshake, its bearer plumbing, and its bounded
+`wait_for_run` all interpret what the service sends rather than repeat it. So this
+module drives the documented cycle — register, validate, plan, wait, apply, wait,
+`get_results` — through the shipped client against the running stack.
+
+It shares the Sync API smoke's setup and package, so the two converge on the same
+branch in either order: the source is mirrored from the destination first and only the
+shared device is left differing, leaving exactly one update to plan.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from infrahub_sync.client import SyncClient
+from infrahub_sync.client.models import ApplyRunRequest, ConfigMutationRequest, CreateRunRequest
+from tasks.preview import SHARED_DEVICE_NAME, SMOKE_BRANCH
+from tests.preview.test_service_api import (
+    device_types,
+    infrahub_client,
+    seed_source_branch,
+    smoke_package,
+    unwritten_plan_reasons,
+)
+
+pytestmark = pytest.mark.preview
+
+WAIT_TIMEOUT_SECONDS = 240.0
+POLL_INTERVAL_SECONDS = 3.0
+
+
+def _key() -> str:
+    """A fresh key per mutation, so a re-run never replays an earlier smoke's response."""
+    return f"preview-python-{uuid.uuid4()}"
+
+
+def test_sync_client_registers_plans_and_applies_against_the_service(preview_env: dict[str, Any]) -> None:
+    """The typed client completes register → validate → plan → apply → results live."""
+    mutated_type = seed_source_branch(preview_env)
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] != mutated_type
+
+    with SyncClient(preview_env["urls"]["sync_api"], preview_env["bearer_token"], timeout=30.0) as client:
+        registered = client.register_config(
+            ConfigMutationRequest(
+                package=smoke_package(preview_env["urls"]["infrahub"]),
+                reason="preview Python client smoke: register the smoke configuration",
+            ),
+            _key(),
+        )
+        config_id = registered.version.config_id
+        registry_version = registered.version.registry_version
+
+        report = client.validate_config(config_id, registry_version)
+        assert report.findings == (), report
+
+        accepted = client.plan(
+            CreateRunRequest(
+                operation="plan",
+                config_id=config_id,
+                registry_version=registry_version,
+                branch=SMOKE_BRANCH,
+                reason="preview Python client smoke: create a service plan",
+            ),
+            _key(),
+        )
+        run_id = accepted.run.run_id
+        planned = client.wait_for_run(accepted, timeout=WAIT_TIMEOUT_SECONDS, poll_interval=POLL_INTERVAL_SECONDS)
+        assert planned.run.phase == "planned", planned.run
+
+        plan = client.get_plan(run_id)
+        assert plan.checksum_ok is True, plan
+        # The same guard the Sync API smoke applies: a delete-only plan applies cleanly
+        # and writes nothing, so an apply over one would prove nothing about the client.
+        assert unwritten_plan_reasons(plan.summary.model_dump()) == [], plan.summary
+        assert plan.summary.by_action.get("update", 0) == 1, plan.summary
+
+        apply_accepted = client.apply(
+            run_id,
+            ApplyRunRequest(
+                expected_checksum=plan.checksum,
+                confirm_writes=True,
+                branch=SMOKE_BRANCH,
+                reason="preview Python client smoke: apply the reviewed plan",
+            ),
+            _key(),
+        )
+        applied = client.wait_for_run(apply_accepted, timeout=WAIT_TIMEOUT_SECONDS, poll_interval=POLL_INTERVAL_SECONDS)
+        assert applied.run.phase == "applied", applied.run
+
+        results = client.get_results(run_id)
+        assert results.run_id == run_id
+        applied_summary = results.results["summary"]
+        assert applied_summary.get("update", 0) > 0, applied_summary
+        assert applied_summary.get("delete", 0) == 0, applied_summary
+
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] == mutated_type

--- a/tests/preview/test_service_api.py
+++ b/tests/preview/test_service_api.py
@@ -181,6 +181,7 @@ def _registered_version(client: httpx.Client, preview_env: dict[str, Any]) -> tu
 
 
 def infrahub_client(preview_env: dict[str, Any]) -> Any:  # noqa: ANN401 — the SDK's sync client
+    """An Infrahub SDK client for the preview instance, used as the smokes' own oracle."""
     from infrahub_sdk import InfrahubClientSync
 
     return InfrahubClientSync(
@@ -221,6 +222,7 @@ def mutation_payload(mutated_type: str) -> dict[str, Any]:
 
 
 def device_types(client: Any, branch: str) -> dict[str, Any]:  # noqa: ANN401 — the SDK's sync client
+    """The mapped `type` of every device on one branch, keyed by the device's name."""
     return {node.name.value: node.type.value for node in client.all(kind=SMOKE_KIND, branch=branch)}
 
 

--- a/tests/preview/test_service_api.py
+++ b/tests/preview/test_service_api.py
@@ -8,7 +8,7 @@ The package is Infrahub-to-Infrahub against the preview's own instance — `main
 source, the disposable smoke branch as the destination — because the registered path
 resolves adapters through the installed loader and admits no filesystem adapter.
 
-What this smoke proves is an **update**. `preview.up` seeds one device on `main` before
+What this smoke proves is an **update**. `preview.seed` puts one device on `main` before
 the smoke branch forks, so both branches hold it; the smoke then mutates that device on
 `main` alone, and the registered workflow has one real cross-branch update to plan and
 apply. The mutation carries a fresh value on every run, because a fixed one would
@@ -46,7 +46,7 @@ POLL_TIMEOUT_SECONDS = 240
 
 # The fields the package maps. A mirror has to carry all of them, or the mirrored device
 # becomes an update rather than a match. The kind and the shared device's name come from
-# `tasks.preview`, which seeds that device on `main` before the smoke branch forks.
+# `tasks.preview`, whose `seed` task puts that device on `main` before the branch forks.
 SMOKE_FIELDS = ("name", "type")
 
 
@@ -180,7 +180,7 @@ def _registered_version(client: httpx.Client, preview_env: dict[str, Any]) -> tu
     return config_id, registry_version
 
 
-def _infrahub_client(preview_env: dict[str, Any]) -> Any:  # noqa: ANN401 — the SDK's sync client
+def infrahub_client(preview_env: dict[str, Any]) -> Any:  # noqa: ANN401 — the SDK's sync client
     from infrahub_sdk import InfrahubClientSync
 
     return InfrahubClientSync(
@@ -220,11 +220,11 @@ def mutation_payload(mutated_type: str) -> dict[str, Any]:
     return {"name": SHARED_DEVICE_NAME, "type": mutated_type}
 
 
-def _device_types(client: Any, branch: str) -> dict[str, Any]:  # noqa: ANN401 — the SDK's sync client
+def device_types(client: Any, branch: str) -> dict[str, Any]:  # noqa: ANN401 — the SDK's sync client
     return {node.name.value: node.type.value for node in client.all(kind=SMOKE_KIND, branch=branch)}
 
 
-def _seed_source_branch(preview_env: dict[str, Any]) -> str:
+def seed_source_branch(preview_env: dict[str, Any]) -> str:
     """Leave `main` differing from the destination in one device, and return its new type.
 
     Mirroring first is what removes everything else from the plan: `main` ends up holding
@@ -236,11 +236,12 @@ def _seed_source_branch(preview_env: dict[str, Any]) -> str:
     Both writes upsert on the device's unique name, so a re-run converges rather than
     duplicating.
     """
-    client = _infrahub_client(preview_env)
+    client = infrahub_client(preview_env)
     payloads = mirrored_device_payloads(client.all(kind=SMOKE_KIND, branch=SMOKE_BRANCH))
     assert SHARED_DEVICE_NAME in {payload["name"] for payload in payloads}, (
         f"{SHARED_DEVICE_NAME!r} is not on {SMOKE_BRANCH}; `tasks.preview.ensure_smoke_branch` seeds it on "
-        f"main before the branch forks, and without it this smoke has no update to plan"
+        f"main before the branch forks, and without it this smoke has no update to plan; "
+        f"run `uv run invoke preview.seed`"
     )
     for payload in payloads:
         client.create(kind=SMOKE_KIND, branch="main", data=payload).save(allow_upsert=True)
@@ -256,8 +257,8 @@ def test_requests_without_a_bearer_token_are_refused(preview_env: dict[str, Any]
 
 
 def test_service_plan_and_apply_lifecycle(preview_env: dict[str, Any]) -> None:
-    mutated_type = _seed_source_branch(preview_env)
-    assert _device_types(_infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] != mutated_type
+    mutated_type = seed_source_branch(preview_env)
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] != mutated_type
 
     with _client(preview_env, token=preview_env["bearer_token"]) as client:
         config_id, registry_version = _registered_version(client, preview_env)
@@ -307,4 +308,4 @@ def test_service_plan_and_apply_lifecycle(preview_env: dict[str, Any]) -> None:
         assert results.json()["results"]["summary"]["update"] > 0, results.text
 
     # The destination now carries the value the source was mutated to.
-    assert _device_types(_infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] == mutated_type
+    assert device_types(infrahub_client(preview_env), SMOKE_BRANCH)[SHARED_DEVICE_NAME] == mutated_type

--- a/tests/test_development_stack_docs.py
+++ b/tests/test_development_stack_docs.py
@@ -1,0 +1,27 @@
+"""The local development stack page is reachable from the two entrypoints that lead to it.
+
+Neither link is covered by the documentation build. Docusaurus only warns on a broken
+Markdown link, and it never inspects the root README at all, so a page that exists but
+is listed nowhere still builds clean while nobody can find it.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCUMENT_ID = "development-stack"
+PAGE = REPO_ROOT / "docs" / "docs" / f"{DOCUMENT_ID}.mdx"
+
+
+def test_the_development_stack_page_is_listed_in_the_docs_sidebar() -> None:
+    """Docusaurus renders no navigation entry for a page the sidebar omits."""
+    sidebar = (REPO_ROOT / "docs" / "sidebars.ts").read_text(encoding="utf-8")
+
+    assert PAGE.is_file(), PAGE
+    assert f"'{DOCUMENT_ID}'" in sidebar
+
+
+def test_the_root_readme_links_the_development_stack_page() -> None:
+    """The published page is how a contributor reaches the stack from the repository front page."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert f"https://docs.infrahub.app/sync/{DOCUMENT_ID}" in readme

--- a/tests/test_development_stack_docs.py
+++ b/tests/test_development_stack_docs.py
@@ -5,23 +5,48 @@ Markdown link, and it never inspects the root README at all, so a page that exis
 is listed nowhere still builds clean while nobody can find it.
 """
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCUMENT_ID = "development-stack"
 PAGE = REPO_ROOT / "docs" / "docs" / f"{DOCUMENT_ID}.mdx"
+SIDEBAR = REPO_ROOT / "docs" / "sidebars.ts"
+# The link has to be a Markdown target, not the address written somewhere in prose:
+# only a target is what a reader can follow.
+README_LINK = re.compile(rf"\]\(https://docs\.infrahub\.app/sync/{re.escape(DOCUMENT_ID)}\)")
+
+
+def sync_sidebar() -> str:
+    """Return the text of the `syncSidebar` array alone.
+
+    Scoping matters: the document id appearing anywhere else in the file — a redirect, a
+    second sidebar, a comment — would satisfy a whole-file search while the rendered
+    navigation still omits the page. Document ids carry no brackets, so matching the
+    array's own brackets by depth is enough and needs no parser.
+    """
+    text = SIDEBAR.read_text(encoding="utf-8")
+    start = text.index("[", text.index("syncSidebar:"))
+    depth = 0
+    for offset in range(start, len(text)):
+        if text[offset] == "[":
+            depth += 1
+        elif text[offset] == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : offset + 1]
+    msg = f"syncSidebar in {SIDEBAR} is not a closed array"
+    raise AssertionError(msg)
 
 
 def test_the_development_stack_page_is_listed_in_the_docs_sidebar() -> None:
     """Docusaurus renders no navigation entry for a page the sidebar omits."""
-    sidebar = (REPO_ROOT / "docs" / "sidebars.ts").read_text(encoding="utf-8")
-
     assert PAGE.is_file(), PAGE
-    assert f"'{DOCUMENT_ID}'" in sidebar
+    assert f"'{DOCUMENT_ID}'" in sync_sidebar()
 
 
 def test_the_root_readme_links_the_development_stack_page() -> None:
     """The published page is how a contributor reaches the stack from the repository front page."""
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
-    assert f"https://docs.infrahub.app/sync/{DOCUMENT_ID}" in readme
+    assert README_LINK.search(readme) is not None


### PR DESCRIPTION
## Problem

The preview rig was the only local V3 stack, and starting it mutated the disposable Infrahub (schema load, seed device, write-bearing smoke apply) as part of `preview.up`. Live smoke coverage reached the service only over raw HTTP; the shipped CLI and the typed `SyncClient` had zero live coverage. The only human entrypoint was `development/README.md`, which also claimed `main` stays empty while the code seeded it.

## Solution

Promote the rig to the supported local developer stack in three commit groups, tasks/tests/docs only, no `infrahub_sync/` change:

- **Non-mutating start.** `invoke preview.up` brings up containers and host processes and writes nothing. Seeding is an explicit, idempotent `preview.seed`; `preview.smoke` announces and runs the seed first, then the suite. A failed seed on a reachable stack fails the smoke; an unreachable stack still yields the suite's polite skip. The dead `INFRAHUB_SYNC_PREVIEW_EXPECT_MAIN_EMPTY` variable is gone.
- **Client-through-service smoke.** Two live modules drive the shipped CLI (`configs register → diff → runs plan → apply`, final state asserted through the HTTP API) and `SyncClient` (through `get_results()`), joining the declared single-process collection order.
- **One documented entrypoint.** New `docs/docs/development-stack.mdx`, linked from the sidebar and root README, with a static test that gates both links; `development/README.md` and `contributing.mdx` agree with it. Base Compose credential-shaped defaults verified byte-identical to upstream Infrahub 1.10.6 and documented as local-dev-only.

### Before / after

```bash
# before: one command, and it wrote to Infrahub and applied a sync
uv run invoke preview.up

# after: start writes nothing; seeding and the write-bearing smoke are explicit
uv run invoke preview.up
uv run invoke preview.seed     # idempotent
uv run invoke preview.smoke    # seeds, then runs tests/preview (serial)
```

### User-visible changes

- New Invoke task `preview.seed`; `preview.up` no longer loads the schema or runs the smoke.
- New docs page `development-stack` in the sidebar; root README Contribute row links it.
- `preview.smoke` now fails when its seed fails on a reachable stack.

## Review record

Accepted unit envelope: `.planning/active-path/local-developer-stack-envelope.md` in `opsmill/infrahub-sync-lab` (acceptance rules AR-D1–AR-D6). Writer: Claude Opus 5 (1M). Independent complete-diff review: GPT-5.6 Sol — SEND BACK with two accepted blockers (docs preflight ordering; `UnexpectedExit` catch masking a failed seed), one batched correction `6ba8ae0`, bounded verification **READY** at this head with AR-D1–AR-D5 met. AR-D6 live leg: recorded as a follow-up comment on this PR when the runner completes.

Known limitation: each live client module re-registers the smoke package per run (as the raw-HTTP smoke already did); registry growth on a long-lived local instance is cosmetic.

Merge is Blake's action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for running the complete Sync development stack locally.
  * Added a dedicated local development stack page to the documentation navigation.
  * Added a `preview.seed` command for preparing example data and a separate `preview.smoke` command for running smoke tests.
  * Added end-to-end coverage for CLI and Python client workflows.

* **Documentation**
  * Clarified preview environment behavior, service endpoints, credentials, setup requirements, and testing workflows.
  * Linked local development instructions from the README and contributing guide.

* **Bug Fixes**
  * Improved preview smoke execution reliability by coordinating shared test resources and run ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->