### PR TITLE
Add an inert PostgreSQL configuration write guard

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -164,3 +164,8 @@ Yaml
 yamllint
 ty
 formatters
+Potenda
+autocommit
+pooler
+serializer
+traceback

--- a/dev/knowledge/README.md
+++ b/dev/knowledge/README.md
@@ -25,6 +25,9 @@ procedures see [`dev/guides/`](../guides/README.md).
 - [Planned writes and apply](planned-write-and-apply.md) — the second write path: the
   destination write surface and what its type does and does not enforce, apply-time peer
   resolution, replace-set flush semantics, and how deletes are recorded but not executed.
+- [The configuration write guard](apply-guard.md) — the PostgreSQL session advisory lock
+  that serializes one configuration's writes across processes: its direct-connection
+  requirement, key derivation, deadline bounds, ownership proof, and failure sanitizing.
 
 ## Running a sync from something other than the CLI
 

--- a/dev/knowledge/apply-guard.md
+++ b/dev/knowledge/apply-guard.md
@@ -74,13 +74,34 @@ the advisory locks it held, so retirement also frees the configuration.
 ## Confirmed release and cleanup precedence
 
 Leaving the `hold_apply_guard` block confirms release, and callers may confirm it
-explicitly before publishing any success. Confirmation means `pg_advisory_unlock`
-returned true on the same backend session; a false result, a driver failure, or a failed
-close all fail the guard use even though the body succeeded.
+explicitly before publishing any success. A release means two things happened:
+`pg_advisory_unlock` returned true on the same backend session, **and** the dedicated
+session then closed. A false result, a provider failure, or a failed close all fail the
+guard use even though the body succeeded, and all leave the guard permanently retired —
+so a caller that catches one cannot let the block exit as a success.
 
 When the body raises, that exception is preserved and the cleanup detail is dropped. This
 holds for `BaseException` as well as `Exception`, so a cancellation is not replaced by a
 cleanup failure. A cleanup-only failure, with no body exception to preserve, is raised.
+
+## Containing every exception class
+
+A boundary that catches only `psycopg.Error` is not a boundary. The connection the guard
+receives is injected, so its `connect`, `execute`, and `close` may be any implementation
+and may raise an ordinary `Exception`; an interrupt or a cancellation can also arrive
+mid-statement. Three rules cover it:
+
+- A provider `Exception` — driver or not — becomes a sanitized guard failure. Only a
+  `psycopg.Error` carrying SQLSTATE `55P03` is contention, so an unrelated class that
+  merely exposes a `sqlstate` attribute is reported as unavailability.
+- A `BaseException` that is not an `Exception` is contained rather than converted: the
+  session is retired first, then the original propagates unchanged. Converting a
+  cancellation into a guard failure would defeat the cancellation, and leaving the session
+  open would leave the configuration held by a session nobody owns.
+- `close` never raises. It reports its outcome, because a cleanup failure must not be able
+  to replace the body exception or the primary provider failure a caller is already
+  unwinding on. The cost is that an interrupt delivered during that one `close` call is
+  absorbed; losing the primary failure instead is worse.
 
 ## Sanitizing the whole failure graph
 

--- a/dev/knowledge/apply-guard.md
+++ b/dev/knowledge/apply-guard.md
@@ -1,0 +1,120 @@
+# The configuration write guard
+
+> Part of: `dev/knowledge/` | Related: [The shared execution surface](execution-surface.md), [Secret redaction](../guidelines/secret-redaction.md)
+
+`infrahub_sync/service/apply_guard.py` serializes writes to one configuration across
+processes. Once workers stop sharing a filesystem, a file lock can no longer exclude a
+second writer, so the mechanism is a PostgreSQL session-level advisory lock instead.
+
+The primitive is inert: no supported write path calls it yet.
+
+## Deployment requirements
+
+**The guard needs a direct PostgreSQL connection, or a session-mode pooler.** Two
+properties make that a hard requirement rather than a preference:
+
+- The lock is **session level**, not transaction level. A write is held across many
+  destination operations, and a transaction-scoped lock would be released at the first
+  commit.
+- The lock and the writer must be **the same backend session**. A transaction-mode
+  connection pooler multiplexes one server session across clients between transactions,
+  so the session holding the lock and the session doing the next statement are not
+  guaranteed to be the same one.
+
+**Transaction-mode PgBouncer is therefore unsupported.** Point the guard at PostgreSQL
+directly, or at a pooler in session mode. The guard opens its own dedicated connection
+for each hold and never hands it to an adapter.
+
+The connection is opened with autocommit on, so the session-level `lock_timeout` and the
+advisory lock live outside any transaction. Holding the guard across a long write does
+not leave a backend `idle in transaction`.
+
+## The advisory key
+
+Each configuration gets one signed 64-bit key: the first eight bytes of the SHA-256
+digest of `infrahub-sync:apply:v1:<configuration-id>`, read in network byte order as a
+signed integer. That is the range PostgreSQL accepts for a single-key advisory lock.
+
+Every process that writes a configuration has to derive the identical value, so the
+derivation is pinned by literal vectors in `tests/service/test_apply_guard.py` rather
+than recomputed by the tests. Changing the prefix, the byte count, the byte order, or the
+signed reading is a cross-process incompatibility, which is what the `v1` in the prefix
+exists to version.
+
+`pg_locks` records a single-`bigint` advisory key as the high and low halves of its two
+`oid` columns, with `objsubid = 1`. The ownership query reverses that split.
+
+## The deadline
+
+The deadline defaults to 30 seconds. Accepted values run from 0.001 through 300 seconds;
+zero, negatives, and non-finite values refuse before any connection is opened.
+
+Conversion to provider milliseconds **rounds up**, giving 1 through 300,000. Rounding up
+is not cosmetic: PostgreSQL reads `lock_timeout = 0` as "wait forever", so a
+sub-millisecond deadline must reach the server as 1, never as 0.
+
+The deadline is applied by setting `lock_timeout` on the guard session and then calling
+`pg_advisory_lock`. A wait that exceeds it aborts with SQLSTATE `55P03`, which the guard
+reports as contention. Every other driver failure is reported as unavailability, so a
+broken deployment is not misread as a busy one.
+
+## Proving ownership without reacquiring
+
+`ApplyGuard.require_ownership` reads `pg_locks` and compares both the backend PID
+recorded at acquisition and the exact key. It never calls `pg_advisory_lock` again:
+session advisory locks are counted, so a proof that reacquired would stack a second hold
+and mask the loss it was meant to detect — and one confirmed unlock would then leave the
+key held.
+
+A proof fails when the backend session changed, when the lock row is gone (an external
+unlock), or when the statement itself fails (a terminated backend). Any of those retires
+the session: the guard closes it and refuses every later use. Closing a session releases
+the advisory locks it held, so retirement also frees the configuration.
+
+## Confirmed release and cleanup precedence
+
+Leaving the `hold_apply_guard` block confirms release, and callers may confirm it
+explicitly before publishing any success. Confirmation means `pg_advisory_unlock`
+returned true on the same backend session; a false result, a driver failure, or a failed
+close all fail the guard use even though the body succeeded.
+
+When the body raises, that exception is preserved and the cleanup detail is dropped. This
+holds for `BaseException` as well as `Exception`, so a cancellation is not replaced by a
+cleanup failure. A cleanup-only failure, with no body exception to preserve, is raised.
+
+## Sanitizing the whole failure graph
+
+Guard failures can reach Prefect logs and persisted results, so no driver text may travel
+in them. Each failure carries a fixed message and, as its cause, the rebuilt redacted
+copy that `sanitize_exception_chain` produces, which covers the original message, its
+structured arguments, and its own cause and context chain, and which drops its notes.
+
+`__context__` needs its own handling. Raising inside an `except` block binds the handled
+driver exception to `__context__`, and `__suppress_context__` only keeps it out of a
+*rendered* traceback — a serializer walking the graph still reaches it. Every guard
+failure is therefore raised through one choke point that clears `__context__` after the
+raise.
+
+A keyword connection string (`host=… password=…`) is not URL-shaped, so
+`collect_secret_values` does not see its password. `dsn_secret_values` extracts it, and
+callers pass it in through `secrets`. It applies the shared `MIN_SECRET_LENGTH` floor for
+the reason the shared collector does: redacting a short value shreds unrelated
+diagnostics.
+
+## Testing it
+
+The unit suite drives the guard against a scripted session fake, so every failure path is
+reachable. The provider facts that fake assumes are proven separately against a real
+server in `tests/integration/test_apply_guard_integration.py`, which is opt-in with
+`-m integration` and a reachable `APPLY_GUARD_TEST_POSTGRESQL_DSN`. Those tests terminate
+backends, so the DSN must point at a disposable, single-purpose database.
+
+Real PostgreSQL is a hard gate for this module. A skipped guard case is not evidence.
+
+## See also
+
+- [The shared execution surface](execution-surface.md) — the entry point to one run, and
+  the local pipeline lock the guard replaces for distributed writes.
+- [Secret redaction](../guidelines/secret-redaction.md) — the shared collector and cause-chain
+  rules the guard reuses.
+- [Testing](../guidelines/testing.md) — why a killed mutation, not a passing test, is the evidence.

--- a/infrahub_sync/service/apply_guard.py
+++ b/infrahub_sync/service/apply_guard.py
@@ -206,7 +206,8 @@ class ApplyGuard:
             _fail(self._failure(ApplyGuardOwnershipError, _RETIRED))
         try:
             row = self._connection.execute(_OWNERSHIP, _lock_columns(self._key)).fetchone()
-        except Exception as exc:  # noqa: BLE001 - one provider boundary; classified here.
+        # One provider boundary; every class is classified rather than escaping.
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             failure = self._failure(ApplyGuardOwnershipError, _SESSION_LOST.format(type(exc).__name__), exc)
             self.retire()
             _fail(failure)
@@ -231,7 +232,8 @@ class ApplyGuard:
             _fail(self._failure(ApplyGuardReleaseError, _RETIRED))
         try:
             row = self._connection.execute(_RELEASE, (self._key,)).fetchone()
-        except Exception as exc:  # noqa: BLE001 - one provider boundary; classified here.
+        # One provider boundary; every class is classified rather than escaping.
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             failure = self._failure(ApplyGuardReleaseError, _RELEASE_FAILED.format(type(exc).__name__), exc)
             self.retire()
             _fail(failure)
@@ -268,7 +270,8 @@ class ApplyGuard:
         """
         try:
             self._connection.close()
-        except BaseException as exc:  # noqa: BLE001 - one cleanup boundary; never replaces a primary failure.
+        # One cleanup boundary; a close failure never replaces a primary failure.
+        except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             return self._failure(ApplyGuardReleaseError, _CLOSE_FAILED.format(type(exc).__name__), exc)
         return None
 
@@ -327,7 +330,8 @@ def _acquire(
         connection.execute(_SET_DEADLINE, (str(milliseconds),))
         connection.execute(_ACQUIRE, (key,))
         row = connection.execute(_OWNERSHIP, _lock_columns(key)).fetchone()
-    except Exception as exc:  # noqa: BLE001 - one provider boundary; classified below.
+    # One provider boundary; every class is classified rather than escaping.
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         failure = _acquisition_failure(exc, secrets)
     except BaseException:  # Contained, then re-raised unchanged.
         if connection is not None:

--- a/infrahub_sync/service/apply_guard.py
+++ b/infrahub_sync/service/apply_guard.py
@@ -1,7 +1,8 @@
 """Configuration-scoped PostgreSQL advisory guard that serializes one configuration's writes.
 
 The guard takes a **session-level** advisory lock on **one dedicated direct
-PostgreSQL connection**. Both properties are load-bearing:
+PostgreSQL connection**. Neither property is a preference; each one is required
+for the guard to exclude anything at all:
 
 - session level, because a write is held across many destination operations and a
   transaction-scoped lock would be released at the first commit; and
@@ -9,6 +10,13 @@ PostgreSQL connection**. Both properties are load-bearing:
   session across clients, so the lock and the writer would no longer be the same
   session. **Transaction-mode PgBouncer is unsupported.** Session-mode pooling, or
   a direct connection, is required.
+
+Every provider and cleanup boundary contains all exception classes, not only
+`psycopg.Error`: a connection, cursor, or protocol implementation may raise
+anything, and an interrupt can arrive mid-statement. A provider `Exception`
+becomes a sanitized guard failure, a non-`Exception` `BaseException` is re-raised
+unchanged once the session is retired, and a cleanup failure never replaces the
+body exception or the primary failure already unwinding.
 
 The guard is inert on its own: nothing in the supported write path calls it yet.
 """
@@ -197,11 +205,14 @@ class ApplyGuard:
         if self._state != "held":
             _fail(self._failure(ApplyGuardOwnershipError, _RETIRED))
         try:
-            row = self._connection.execute(_OWNERSHIP, self._lock_columns()).fetchone()
-        except psycopg.Error as exc:
+            row = self._connection.execute(_OWNERSHIP, _lock_columns(self._key)).fetchone()
+        except Exception as exc:  # noqa: BLE001 - one provider boundary; classified here.
             failure = self._failure(ApplyGuardOwnershipError, _SESSION_LOST.format(type(exc).__name__), exc)
             self.retire()
             _fail(failure)
+        except BaseException:  # Contained, then re-raised unchanged.
+            self.retire()
+            raise
         if row != (self._backend_pid, True):
             self.retire()
             _fail(self._failure(ApplyGuardOwnershipError, _NOT_OWNED))
@@ -210,8 +221,9 @@ class ApplyGuard:
         """Confirm the provider released exactly this key, then close the session.
 
         Callers may confirm release explicitly before publishing any success;
-        leaving the `hold_apply_guard` block confirms it otherwise. Repeating a
-        confirmed release is a no-op.
+        leaving the `hold_apply_guard` block confirms it otherwise. Only a
+        confirmed unlock followed by a successful close is a release, so repeating
+        one is a no-op while every other outcome leaves the session retired.
         """
         if self._state == "released":
             return
@@ -219,23 +231,28 @@ class ApplyGuard:
             _fail(self._failure(ApplyGuardReleaseError, _RETIRED))
         try:
             row = self._connection.execute(_RELEASE, (self._key,)).fetchone()
-        except psycopg.Error as exc:
+        except Exception as exc:  # noqa: BLE001 - one provider boundary; classified here.
             failure = self._failure(ApplyGuardReleaseError, _RELEASE_FAILED.format(type(exc).__name__), exc)
             self.retire()
             _fail(failure)
+        except BaseException:  # Contained, then re-raised unchanged.
+            self.retire()
+            raise
         confirmed = row == (True, self._backend_pid)
-        self._state = "released" if confirmed else "retired"
         close_failure = self._close()
         if not confirmed:
+            self._state = "retired"
             _fail(self._failure(ApplyGuardReleaseError, _UNCONFIRMED))
         if close_failure is not None:
+            self._state = "retired"
             _fail(close_failure)
+        self._state = "released"
 
     def retire(self) -> None:
         """Discard the session permanently; closing it releases any key it holds.
 
-        Never raises, so a caller unwinding on its own exception keeps that
-        exception rather than a cleanup failure.
+        Never raises, whatever the connection does, so a caller unwinding on its
+        own failure keeps that failure rather than a cleanup one.
         """
         if self._state != "held":
             return
@@ -243,16 +260,17 @@ class ApplyGuard:
         self._close()
 
     def _close(self) -> ApplyGuardError | None:
-        """Close the dedicated session, returning a failure rather than raising."""
+        """Close the dedicated session, returning any failure rather than raising.
+
+        A close failure is never allowed to replace the body exception or the
+        primary provider failure that a caller is already unwinding on, so this
+        boundary contains every exception class and reports the outcome instead.
+        """
         try:
             self._connection.close()
-        except psycopg.Error as exc:
+        except BaseException as exc:  # noqa: BLE001 - one cleanup boundary; never replaces a primary failure.
             return self._failure(ApplyGuardReleaseError, _CLOSE_FAILED.format(type(exc).__name__), exc)
         return None
-
-    def _lock_columns(self) -> tuple[int, int]:
-        """Split the signed key into the `oid` pair `pg_locks` records."""
-        return (self._key >> 32) & _OID_MASK, self._key & _OID_MASK
 
     def _failure(
         self, error_type: type[ApplyGuardError], message: str, cause: BaseException | None = None
@@ -308,20 +326,43 @@ def _acquire(
         connection = connect()
         connection.execute(_SET_DEADLINE, (str(milliseconds),))
         connection.execute(_ACQUIRE, (key,))
-        row = connection.execute(_OWNERSHIP, ((key >> 32) & _OID_MASK, key & _OID_MASK)).fetchone()
-    except psycopg.Error as exc:
-        if exc.sqlstate == _LOCK_NOT_AVAILABLE:
-            failure = _guard_failure(ApplyGuardContentionError, _CONTENDED, exc, secrets)
-        else:
-            failure = _guard_failure(ApplyGuardUnavailableError, _UNAVAILABLE.format(type(exc).__name__), exc, secrets)
+        row = connection.execute(_OWNERSHIP, _lock_columns(key)).fetchone()
+    except Exception as exc:  # noqa: BLE001 - one provider boundary; classified below.
+        failure = _acquisition_failure(exc, secrets)
+    except BaseException:  # Contained, then re-raised unchanged.
+        if connection is not None:
+            _discard(connection)
+        raise
     else:
         if row is not None and row[1] is True:
             return ApplyGuard(connection=connection, key=key, backend_pid=row[0], secrets=secrets)
         failure = _guard_failure(ApplyGuardUnavailableError, _UNPROVEN, None, secrets)
     if connection is not None:
-        with suppress(psycopg.Error):
-            connection.close()
+        _discard(connection)
     _fail(failure)
+
+
+def _acquisition_failure(exc: Exception, secrets: Sequence[str]) -> ApplyGuardError:
+    """Classify one acquisition failure. Only a driver lock timeout is contention."""
+    if isinstance(exc, psycopg.Error) and exc.sqlstate == _LOCK_NOT_AVAILABLE:
+        return _guard_failure(ApplyGuardContentionError, _CONTENDED, exc, secrets)
+    return _guard_failure(ApplyGuardUnavailableError, _UNAVAILABLE.format(type(exc).__name__), exc, secrets)
+
+
+def _discard(connection: GuardConnection) -> None:
+    """Close a session that never became a hold, keeping the primary failure.
+
+    Closing releases any advisory lock the session took, so a discarded session
+    cannot keep holding a configuration. A failure here is never reported: the
+    failure that caused the discard is the one the caller needs.
+    """
+    with suppress(BaseException):
+        connection.close()
+
+
+def _lock_columns(key: int) -> tuple[int, int]:
+    """Split the signed key into the `oid` pair `pg_locks` records."""
+    return (key >> 32) & _OID_MASK, key & _OID_MASK
 
 
 def _guard_failure(

--- a/infrahub_sync/service/apply_guard.py
+++ b/infrahub_sync/service/apply_guard.py
@@ -1,0 +1,352 @@
+"""Configuration-scoped PostgreSQL advisory guard that serializes one configuration's writes.
+
+The guard takes a **session-level** advisory lock on **one dedicated direct
+PostgreSQL connection**. Both properties are load-bearing:
+
+- session level, because a write is held across many destination operations and a
+  transaction-scoped lock would be released at the first commit; and
+- direct, because a transaction-mode connection pooler multiplexes one server
+  session across clients, so the lock and the writer would no longer be the same
+  session. **Transaction-mode PgBouncer is unsupported.** Session-mode pooling, or
+  a direct connection, is required.
+
+The guard is inert on its own: nothing in the supported write path calls it yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any, Protocol
+
+import psycopg
+from psycopg import conninfo
+from typing_extensions import LiteralString
+
+from infrahub_sync.execution import MIN_SECRET_LENGTH, collect_secret_values, sanitize_exception_chain
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+    from typing import Literal, NoReturn
+
+ADVISORY_KEY_PREFIX = "infrahub-sync:apply:v1:"
+DEFAULT_DEADLINE_SECONDS = 30.0
+MIN_DEADLINE_SECONDS = 0.001
+MAX_DEADLINE_SECONDS = 300.0
+
+_LOCK_NOT_AVAILABLE = "55P03"
+_OID_MASK = 0xFFFFFFFF
+
+# `set_config(..., false)` rather than `SET`, because `SET` takes no parameters and
+# the deadline must never be interpolated into the statement text.
+_SET_DEADLINE = "SELECT set_config('lock_timeout', %s, false)"
+_ACQUIRE = "SELECT pg_advisory_lock(%s)"
+# Reads the holder; it never reacquires. `pg_locks` records a single-`bigint`
+# advisory key as the high and low halves of its two `oid` columns, with
+# `objsubid = 1`.
+_OWNERSHIP = """
+SELECT pg_backend_pid(), EXISTS (
+    SELECT 1 FROM pg_locks
+    WHERE locktype = 'advisory' AND granted AND pid = pg_backend_pid()
+      AND classid::bigint = %s AND objid::bigint = %s AND objsubid = 1
+)
+"""
+_RELEASE = "SELECT pg_advisory_unlock(%s), pg_backend_pid()"
+
+_DEADLINE_REFUSED = (
+    "the configuration write guard deadline must be a finite value from "
+    f"{MIN_DEADLINE_SECONDS} through {MAX_DEADLINE_SECONDS} seconds"
+)
+_CONTENDED = "another writer holds this configuration's write guard"
+_UNAVAILABLE = "the configuration write guard could not acquire a direct PostgreSQL session ({0})"
+_UNPROVEN = "the configuration write guard could not prove its own advisory lock"
+_SESSION_LOST = "the configuration write guard lost its PostgreSQL session ({0})"
+_NOT_OWNED = "the configuration write guard no longer owns its advisory key"
+_RETIRED = "the configuration write guard session was retired"
+_RELEASE_FAILED = "the configuration write guard could not release its advisory key ({0})"
+_UNCONFIRMED = "the configuration write guard could not confirm its advisory unlock"
+_CLOSE_FAILED = "the configuration write guard could not close its dedicated session ({0})"
+
+
+class ApplyGuardError(Exception):
+    """Base guard failure. Its message and cause chain are already sanitized."""
+
+
+class ApplyGuardDeadlineError(ApplyGuardError):
+    """The requested deadline is outside the accepted range."""
+
+
+class ApplyGuardUnavailableError(ApplyGuardError):
+    """No usable dedicated PostgreSQL session could hold the key."""
+
+
+class ApplyGuardContentionError(ApplyGuardError):
+    """Another writer held the configuration's key for the whole deadline."""
+
+
+class ApplyGuardOwnershipError(ApplyGuardError):
+    """The same live session could not be proven to still own the exact key."""
+
+
+class ApplyGuardReleaseError(ApplyGuardError):
+    """The release of the key could not be confirmed."""
+
+
+class GuardCursor(Protocol):
+    """The single-row read surface the guard needs from a cursor."""
+
+    def fetchone(self) -> Any: ...
+
+
+class GuardConnection(Protocol):
+    """The narrow direct-PostgreSQL session surface the guard uses."""
+
+    def execute(self, query: LiteralString, params: Sequence[Any] | None = None) -> GuardCursor: ...
+
+    def close(self) -> None: ...
+
+
+def advisory_lock_key(configuration_id: str) -> int:
+    """Derive one configuration's signed 64-bit advisory key.
+
+    The first eight SHA-256 bytes of `infrahub-sync:apply:v1:<configuration-id>`,
+    read in network byte order as a signed integer — the range PostgreSQL accepts
+    for a single-key advisory lock. Every process that writes one configuration
+    must derive exactly this value, so the derivation is pinned by literal vectors
+    in the tests.
+    """
+    digest = hashlib.sha256((ADVISORY_KEY_PREFIX + configuration_id).encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=True)
+
+
+def deadline_milliseconds(seconds: float) -> int:
+    """Convert one accepted deadline to `lock_timeout` milliseconds, rounding up.
+
+    Rounding up matters: PostgreSQL reads `lock_timeout = 0` as "wait forever", so
+    a sub-millisecond deadline must become 1 rather than 0. The range comparison
+    also rejects every non-finite value, since `nan`, `inf`, and `-inf` all fail it.
+    """
+    if not MIN_DEADLINE_SECONDS <= seconds <= MAX_DEADLINE_SECONDS:
+        _fail(ApplyGuardDeadlineError(_DEADLINE_REFUSED))
+    return math.ceil(seconds * 1000)
+
+
+def dsn_secret_values(dsn: str) -> tuple[str, ...]:
+    """Return the password a connection string carries, for guard redaction.
+
+    `collect_secret_values` scans every environment value for URL userinfo, but a
+    keyword connection string (`host=… password=…`) is not URL-shaped, so its
+    password would reach a driver message uncollected. Values below
+    `MIN_SECRET_LENGTH` are dropped for the reason the shared collector drops
+    them: redacting a short value shreds unrelated diagnostics.
+    """
+    try:
+        parsed = conninfo.conninfo_to_dict(dsn)
+    except psycopg.Error:
+        return ()
+    password = parsed.get("password")
+    if isinstance(password, str) and len(password) >= MIN_SECRET_LENGTH:
+        return (password,)
+    return ()
+
+
+def connect_guard_session(dsn: str) -> psycopg.Connection[Any]:
+    """Open one dedicated direct session for exactly one guard hold.
+
+    Autocommit keeps the session-level `lock_timeout` and the advisory lock outside
+    any transaction, so holding the guard across a long write does not leave a
+    backend idle in a transaction.
+    """
+    return psycopg.connect(dsn, autocommit=True)
+
+
+class ApplyGuard:
+    """One live hold of one configuration's advisory write key."""
+
+    def __init__(
+        self,
+        *,
+        connection: GuardConnection,
+        key: int,
+        backend_pid: int,
+        secrets: Sequence[str],
+    ) -> None:
+        self._connection = connection
+        self._key = key
+        self._backend_pid = backend_pid
+        self._secrets = tuple(secrets)
+        self._state: Literal["held", "released", "retired"] = "held"
+
+    @property
+    def key(self) -> int:
+        """The signed 64-bit advisory key this hold owns."""
+        return self._key
+
+    @property
+    def retired(self) -> bool:
+        """Whether the session was discarded as lost, broken, or uncertain."""
+        return self._state == "retired"
+
+    def require_ownership(self) -> None:
+        """Prove the same live backend session still holds exactly this key.
+
+        Reads `pg_locks`; it never reacquires, so a key lost to session death or to
+        a stray unlock cannot be silently restored by the proof itself.
+        """
+        if self._state != "held":
+            _fail(self._failure(ApplyGuardOwnershipError, _RETIRED))
+        try:
+            row = self._connection.execute(_OWNERSHIP, self._lock_columns()).fetchone()
+        except psycopg.Error as exc:
+            failure = self._failure(ApplyGuardOwnershipError, _SESSION_LOST.format(type(exc).__name__), exc)
+            self.retire()
+            _fail(failure)
+        if row != (self._backend_pid, True):
+            self.retire()
+            _fail(self._failure(ApplyGuardOwnershipError, _NOT_OWNED))
+
+    def release(self) -> None:
+        """Confirm the provider released exactly this key, then close the session.
+
+        Callers may confirm release explicitly before publishing any success;
+        leaving the `hold_apply_guard` block confirms it otherwise. Repeating a
+        confirmed release is a no-op.
+        """
+        if self._state == "released":
+            return
+        if self._state == "retired":
+            _fail(self._failure(ApplyGuardReleaseError, _RETIRED))
+        try:
+            row = self._connection.execute(_RELEASE, (self._key,)).fetchone()
+        except psycopg.Error as exc:
+            failure = self._failure(ApplyGuardReleaseError, _RELEASE_FAILED.format(type(exc).__name__), exc)
+            self.retire()
+            _fail(failure)
+        confirmed = row == (True, self._backend_pid)
+        self._state = "released" if confirmed else "retired"
+        close_failure = self._close()
+        if not confirmed:
+            _fail(self._failure(ApplyGuardReleaseError, _UNCONFIRMED))
+        if close_failure is not None:
+            _fail(close_failure)
+
+    def retire(self) -> None:
+        """Discard the session permanently; closing it releases any key it holds.
+
+        Never raises, so a caller unwinding on its own exception keeps that
+        exception rather than a cleanup failure.
+        """
+        if self._state != "held":
+            return
+        self._state = "retired"
+        self._close()
+
+    def _close(self) -> ApplyGuardError | None:
+        """Close the dedicated session, returning a failure rather than raising."""
+        try:
+            self._connection.close()
+        except psycopg.Error as exc:
+            return self._failure(ApplyGuardReleaseError, _CLOSE_FAILED.format(type(exc).__name__), exc)
+        return None
+
+    def _lock_columns(self) -> tuple[int, int]:
+        """Split the signed key into the `oid` pair `pg_locks` records."""
+        return (self._key >> 32) & _OID_MASK, self._key & _OID_MASK
+
+    def _failure(
+        self, error_type: type[ApplyGuardError], message: str, cause: BaseException | None = None
+    ) -> ApplyGuardError:
+        return _guard_failure(error_type, message, cause, self._secrets)
+
+
+@contextmanager
+def hold_apply_guard(
+    configuration_id: str,
+    *,
+    connect: Callable[[], GuardConnection],
+    deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    secrets: Sequence[str] = (),
+) -> Iterator[ApplyGuard]:
+    """Hold one configuration's advisory write key for exactly the body's duration.
+
+    Refuses a rejected deadline before opening any session, waits at most the
+    deadline for the key, and confirms release before returning. A body exception
+    is preserved over any cleanup failure; a cleanup-only failure fails the use.
+
+    `secrets` adds values — a keyword DSN's password, via `dsn_secret_values` —
+    that the environment collector cannot see, so no driver message can carry
+    them out through a failure's cause chain.
+    """
+    milliseconds = deadline_milliseconds(deadline_seconds)
+    collected = tuple(dict.fromkeys((*collect_secret_values(), *secrets)))
+    guard = _acquire(
+        key=advisory_lock_key(configuration_id),
+        connect=connect,
+        milliseconds=milliseconds,
+        secrets=collected,
+    )
+    try:
+        yield guard
+    except BaseException:
+        guard.retire()
+        raise
+    guard.release()
+
+
+def _acquire(
+    *,
+    key: int,
+    connect: Callable[[], GuardConnection],
+    milliseconds: int,
+    secrets: tuple[str, ...],
+) -> ApplyGuard:
+    """Bound the deadline, take the key, and prove the hold before returning it."""
+    failure: ApplyGuardError
+    connection: GuardConnection | None = None
+    try:
+        connection = connect()
+        connection.execute(_SET_DEADLINE, (str(milliseconds),))
+        connection.execute(_ACQUIRE, (key,))
+        row = connection.execute(_OWNERSHIP, ((key >> 32) & _OID_MASK, key & _OID_MASK)).fetchone()
+    except psycopg.Error as exc:
+        if exc.sqlstate == _LOCK_NOT_AVAILABLE:
+            failure = _guard_failure(ApplyGuardContentionError, _CONTENDED, exc, secrets)
+        else:
+            failure = _guard_failure(ApplyGuardUnavailableError, _UNAVAILABLE.format(type(exc).__name__), exc, secrets)
+    else:
+        if row is not None and row[1] is True:
+            return ApplyGuard(connection=connection, key=key, backend_pid=row[0], secrets=secrets)
+        failure = _guard_failure(ApplyGuardUnavailableError, _UNPROVEN, None, secrets)
+    if connection is not None:
+        with suppress(psycopg.Error):
+            connection.close()
+    _fail(failure)
+
+
+def _guard_failure(
+    error_type: type[ApplyGuardError],
+    message: str,
+    cause: BaseException | None,
+    secrets: Sequence[str],
+) -> ApplyGuardError:
+    """Build one guard failure whose cause chain is a redacted, rebuilt copy."""
+    error = error_type(message)
+    error.__cause__ = None if cause is None else sanitize_exception_chain(cause, secrets)
+    error.__suppress_context__ = True
+    return error
+
+
+def _fail(error: ApplyGuardError) -> NoReturn:
+    """Raise `error` with no unsanitized exception reachable from its graph.
+
+    Raising inside an `except` block binds the handled driver exception to
+    `__context__`, which a result serializer can still walk even though
+    `__suppress_context__` keeps it out of a rendered traceback. Clearing it after
+    the raise is the one place where every guard failure is context-free.
+    """
+    try:
+        raise error
+    except ApplyGuardError:
+        error.__context__ = None
+        raise

--- a/tests/integration/test_apply_guard_integration.py
+++ b/tests/integration/test_apply_guard_integration.py
@@ -1,0 +1,285 @@
+"""Opt-in proof of the configuration write guard against a real PostgreSQL server.
+
+The unit suite drives the guard against a scripted fake. These tests prove the
+provider facts that fake assumes: that a session-level `lock_timeout` bounds
+`pg_advisory_lock`, that `pg_locks` reports the holding backend, that
+`pg_advisory_unlock` confirms release, and that two independent OS processes
+serialize on one configuration while different configurations do not contend.
+
+WARNING: point the DSN only at a disposable, single-purpose database. These tests
+terminate backends on it.
+
+Opt in with ``-m integration`` and a reachable ``APPLY_GUARD_TEST_POSTGRESQL_DSN``::
+
+    docker run -d --rm --name ph3-pg16 -e POSTGRES_PASSWORD=probe -e POSTGRES_DB=probe \\
+        -p 127.0.0.1:55433:5432 postgres:16-alpine
+    APPLY_GUARD_TEST_POSTGRESQL_DSN="host=127.0.0.1 port=55433 user=postgres password=probe dbname=probe" \\
+        uv run pytest -m integration tests/integration/test_apply_guard_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404 - the holder process runs a fixed interpreter and inline script.
+import sys
+import textwrap
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("psycopg")
+
+import psycopg
+from infrahub_sync.service.apply_guard import (
+    ApplyGuardContentionError,
+    ApplyGuardOwnershipError,
+    advisory_lock_key,
+    connect_guard_session,
+    hold_apply_guard,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+pytestmark = pytest.mark.integration
+
+_Session = psycopg.Connection[Any]
+
+_DSN_ENVIRONMENT_NAME = "APPLY_GUARD_TEST_POSTGRESQL_DSN"
+_ALPHA = "guard-integration-alpha"
+_BETA = "guard-integration-beta"
+# Pinned independently of the product code: an independent process must derive
+# exactly these keys from `infrahub-sync:apply:v1:<configuration-id>`.
+_ALPHA_KEY = -2161056473457444919
+_BETA_KEY = -2624437274915816768
+_CHILD_TIMEOUT_SECONDS = 60
+_CONTENTION_DEADLINE_SECONDS = 0.5
+
+_HOLDER_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    from infrahub_sync.service.apply_guard import connect_guard_session, hold_apply_guard
+
+    dsn, configuration_id = sys.argv[1], sys.argv[2]
+    with hold_apply_guard(configuration_id, connect=lambda: connect_guard_session(dsn)) as guard:
+        print(f"HELD {guard.key}", flush=True)
+        sys.stdin.readline()
+        guard.require_ownership()
+    print("RELEASED", flush=True)
+    """
+)
+
+_LOCK_TIMEOUT_SETTING = "SELECT setting FROM pg_settings WHERE name = 'lock_timeout'"
+_ADVISORY_HOLDERS = """
+SELECT pid FROM pg_locks
+WHERE locktype = 'advisory' AND granted
+  AND classid::bigint = %s AND objid::bigint = %s AND objsubid = 1
+"""
+
+
+def _dsn_or_skip() -> str:
+    """Return a reachable disposable DSN, or skip before any server is contacted."""
+    dsn = os.environ.get(_DSN_ENVIRONMENT_NAME)
+    if not dsn:
+        pytest.skip(f"the apply-guard integration tests require {_DSN_ENVIRONMENT_NAME}")
+    try:
+        with psycopg.connect(dsn, connect_timeout=5) as probe:
+            probe.execute("SELECT 1")
+    except psycopg.Error:
+        pytest.skip(f"{_DSN_ENVIRONMENT_NAME} is not reachable")
+    return dsn
+
+
+@pytest.fixture(name="dsn")
+def dsn_fixture() -> str:
+    return _dsn_or_skip()
+
+
+@pytest.fixture(name="admin")
+def admin_fixture(dsn: str) -> Iterator[_Session]:
+    """One independent observer session that never holds the guard's key."""
+    with psycopg.connect(dsn, autocommit=True) as connection:
+        yield connection
+
+
+def _connect(dsn: str) -> Callable[[], _Session]:
+    return lambda: connect_guard_session(dsn)
+
+
+def _capturing_connect(dsn: str, captured: list[_Session]) -> Callable[[], _Session]:
+    """Return a connect callable that also hands the live session to the test."""
+
+    def connect() -> _Session:
+        session = connect_guard_session(dsn)
+        captured.append(session)
+        return session
+
+    return connect
+
+
+def _advisory_holders(admin: _Session, key: int) -> list[int]:
+    """Return the backend PIDs holding one exact single-bigint advisory key."""
+    rows = admin.execute(_ADVISORY_HOLDERS, ((key >> 32) & 0xFFFFFFFF, key & 0xFFFFFFFF)).fetchall()
+    return sorted(row[0] for row in rows)
+
+
+def test_a_hold_registers_exactly_its_own_key_on_one_live_session(dsn: str, admin: _Session) -> None:
+    """The real server must show one holder for the derived key and none for another."""
+    with hold_apply_guard(_ALPHA, connect=_connect(dsn)) as guard:
+        assert guard.key == advisory_lock_key(_ALPHA) == _ALPHA_KEY
+        holders = _advisory_holders(admin, _ALPHA_KEY)
+        other = _advisory_holders(admin, _BETA_KEY)
+        guard.require_ownership()
+
+    assert len(holders) == 1
+    assert other == []
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+
+
+def test_repeated_ownership_proofs_never_stack_a_second_lock(dsn: str, admin: _Session) -> None:
+    """A proof that reacquired would leave the key held after one confirmed unlock."""
+    with hold_apply_guard(_ALPHA, connect=_connect(dsn)) as guard:
+        for _ in range(5):
+            guard.require_ownership()
+
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+
+
+def test_the_guard_session_holds_no_open_transaction(dsn: str, admin: _Session) -> None:
+    """A guard held across a long write must not sit idle in a transaction."""
+    with hold_apply_guard(_ALPHA, connect=_connect(dsn)) as guard:
+        pid = _advisory_holders(admin, guard.key)[0]
+        state = admin.execute("SELECT state FROM pg_stat_activity WHERE pid = %s", (pid,)).fetchone()
+
+    assert state == ("idle",)
+
+
+@pytest.mark.parametrize(("deadline_seconds", "expected"), [(0.001, "1"), (1.5, "1500"), (300.0, "300000")])
+def test_the_deadline_reaches_the_server_as_bounded_milliseconds(
+    dsn: str, deadline_seconds: float, expected: str
+) -> None:
+    """PostgreSQL reads `lock_timeout = 0` as "wait forever"; the guard never sends it."""
+    captured: list[_Session] = []
+
+    with hold_apply_guard(_ALPHA, connect=_capturing_connect(dsn, captured), deadline_seconds=deadline_seconds):
+        setting = captured[0].execute(_LOCK_TIMEOUT_SETTING).fetchone()
+
+    assert setting == (expected,)
+
+
+def test_an_external_unlock_breaks_the_ownership_proof(dsn: str, admin: _Session) -> None:
+    """A stray unlock on the guard's own session must not pass as ownership."""
+    captured: list[_Session] = []
+
+    def unlock_then_prove() -> None:
+        with hold_apply_guard(_ALPHA, connect=_capturing_connect(dsn, captured)) as guard:
+            captured[0].execute("SELECT pg_advisory_unlock(%s)", (guard.key,))
+            guard.require_ownership()
+
+    with pytest.raises(ApplyGuardOwnershipError):
+        unlock_then_prove()
+
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+
+
+def test_backend_session_loss_breaks_the_ownership_proof(dsn: str, admin: _Session) -> None:
+    """A terminated backend releases the lock; the guard must refuse, not assume."""
+
+    def terminate_then_prove() -> None:
+        with hold_apply_guard(_ALPHA, connect=_connect(dsn)) as guard:
+            pid = _advisory_holders(admin, guard.key)[0]
+            admin.execute("SELECT pg_terminate_backend(%s)", (pid,))
+            guard.require_ownership()
+
+    with pytest.raises(ApplyGuardOwnershipError):
+        terminate_then_prove()
+
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+
+
+def test_a_body_exception_releases_the_real_lock(dsn: str, admin: _Session) -> None:
+    """An interrupted hold must leave the configuration immediately writable again."""
+    message = "interrupted"
+
+    def interrupted_hold() -> None:
+        with hold_apply_guard(_ALPHA, connect=_connect(dsn)):
+            assert len(_advisory_holders(admin, _ALPHA_KEY)) == 1
+            raise ValueError(message)
+
+    with pytest.raises(ValueError, match=message):
+        interrupted_hold()
+
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+    with hold_apply_guard(_ALPHA, connect=_connect(dsn), deadline_seconds=_CONTENTION_DEADLINE_SECONDS):
+        assert len(_advisory_holders(admin, _ALPHA_KEY)) == 1
+
+
+def _start_holder(dsn: str, configuration_id: str) -> tuple[subprocess.Popen[str], int]:
+    """Start an independent process holding one configuration's guard, and read its key."""
+    child = subprocess.Popen(  # noqa: S603 - fixed interpreter and inline script.
+        [sys.executable, "-c", _HOLDER_SCRIPT, dsn, configuration_id],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert child.stdout is not None
+    first = child.stdout.readline().strip()
+    if not first.startswith("HELD "):
+        child.kill()
+        pytest.fail(f"holder process did not acquire the guard: {first!r} {child.communicate()!r}")
+    return child, int(first.split()[1])
+
+
+def _finish_holder(child: subprocess.Popen[str]) -> tuple[str, str]:
+    assert child.stdin is not None
+    child.stdin.write("go\n")
+    child.stdin.flush()
+    return child.communicate(timeout=_CHILD_TIMEOUT_SECONDS)
+
+
+def test_two_independent_processes_serialize_one_configuration(dsn: str, admin: _Session) -> None:
+    """The mechanism must exclude a second OS process, not only a second object.
+
+    Also pins the cross-process contract: exclusion only works because the child
+    process derives exactly the same literal key from the same configuration.
+    """
+
+    def contended_hold() -> None:
+        with hold_apply_guard(_ALPHA, connect=_connect(dsn), deadline_seconds=_CONTENTION_DEADLINE_SECONDS) as guard:
+            pytest.fail(f"a contended configuration must not be entered: {guard!r}")
+
+    child, child_key = _start_holder(dsn, _ALPHA)
+    try:
+        assert child_key == _ALPHA_KEY
+        assert len(_advisory_holders(admin, _ALPHA_KEY)) == 1
+        started = time.monotonic()
+        with pytest.raises(ApplyGuardContentionError):
+            contended_hold()
+        waited = time.monotonic() - started
+    finally:
+        stdout, stderr = _finish_holder(child)
+
+    assert waited >= _CONTENTION_DEADLINE_SECONDS, f"the guard returned before its deadline: {waited}s"
+    assert "RELEASED" in stdout, stderr
+    assert child.returncode == 0, stderr
+    assert _advisory_holders(admin, _ALPHA_KEY) == []
+    with hold_apply_guard(_ALPHA, connect=_connect(dsn), deadline_seconds=1.0) as guard:
+        guard.require_ownership()
+
+
+def test_different_configurations_write_concurrently(dsn: str, admin: _Session) -> None:
+    """Serialization is per configuration, not global."""
+    child, _ = _start_holder(dsn, _ALPHA)
+    try:
+        with hold_apply_guard(_BETA, connect=_connect(dsn), deadline_seconds=_CONTENTION_DEADLINE_SECONDS) as guard:
+            guard.require_ownership()
+            assert len(_advisory_holders(admin, _BETA_KEY)) == 1
+            assert len(_advisory_holders(admin, _ALPHA_KEY)) == 1
+    finally:
+        stdout, stderr = _finish_holder(child)
+
+    assert "RELEASED" in stdout, stderr
+    assert child.returncode == 0, stderr

--- a/tests/integration/test_apply_guard_integration.py
+++ b/tests/integration/test_apply_guard_integration.py
@@ -28,11 +28,11 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-pytest.importorskip("psycopg")
+psycopg: Any = pytest.importorskip("psycopg")
 
-import psycopg
-
-from infrahub_sync.service.apply_guard import (
+# Imported after the skip: the guard module imports psycopg itself, so a static
+# import here would raise instead of skipping where the service extra is absent.
+from infrahub_sync.service.apply_guard import (  # noqa: E402
     ApplyGuardContentionError,
     ApplyGuardOwnershipError,
     ApplyGuardReleaseError,

--- a/tests/integration/test_apply_guard_integration.py
+++ b/tests/integration/test_apply_guard_integration.py
@@ -31,9 +31,11 @@ import pytest
 pytest.importorskip("psycopg")
 
 import psycopg
+
 from infrahub_sync.service.apply_guard import (
     ApplyGuardContentionError,
     ApplyGuardOwnershipError,
+    ApplyGuardReleaseError,
     advisory_lock_key,
     connect_guard_session,
     hold_apply_guard,
@@ -72,6 +74,7 @@ _HOLDER_SCRIPT = textwrap.dedent(
 )
 
 _LOCK_TIMEOUT_SETTING = "SELECT setting FROM pg_settings WHERE name = 'lock_timeout'"
+_UNLOCK = "SELECT pg_advisory_unlock(%s)"
 _ADVISORY_HOLDERS = """
 SELECT pid FROM pg_locks
 WHERE locktype = 'advisory' AND granted
@@ -139,11 +142,26 @@ def test_a_hold_registers_exactly_its_own_key_on_one_live_session(dsn: str, admi
 
 
 def test_repeated_ownership_proofs_never_stack_a_second_lock(dsn: str, admin: _Session) -> None:
-    """A proof that reacquired would leave the key held after one confirmed unlock."""
-    with hold_apply_guard(_ALPHA, connect=_connect(dsn)) as guard:
-        for _ in range(5):
-            guard.require_ownership()
+    """Session advisory locks are counted, so one unlock must fully release the key.
 
+    Counting the hold levels from the guard's own session is what makes this
+    discriminating: closing the session releases every level at once, so a proof
+    that reacquired would leave no trace once the hold ended.
+    """
+    captured: list[_Session] = []
+    unlocks: list[tuple[Any, ...] | None] = []
+
+    def prove_repeatedly() -> None:
+        with hold_apply_guard(_ALPHA, connect=_capturing_connect(dsn, captured)) as guard:
+            for _ in range(5):
+                guard.require_ownership()
+            unlocks.append(captured[0].execute(_UNLOCK, (guard.key,)).fetchone())
+            unlocks.append(captured[0].execute(_UNLOCK, (guard.key,)).fetchone())
+
+    with pytest.raises(ApplyGuardReleaseError):
+        prove_repeatedly()
+
+    assert unlocks == [(True,), (False,)]
     assert _advisory_holders(admin, _ALPHA_KEY) == []
 
 
@@ -175,7 +193,7 @@ def test_an_external_unlock_breaks_the_ownership_proof(dsn: str, admin: _Session
 
     def unlock_then_prove() -> None:
         with hold_apply_guard(_ALPHA, connect=_capturing_connect(dsn, captured)) as guard:
-            captured[0].execute("SELECT pg_advisory_unlock(%s)", (guard.key,))
+            captured[0].execute(_UNLOCK, (guard.key,))
             guard.require_ownership()
 
     with pytest.raises(ApplyGuardOwnershipError):

--- a/tests/service/test_apply_guard.py
+++ b/tests/service/test_apply_guard.py
@@ -1,0 +1,623 @@
+"""Contract for the configuration-scoped PostgreSQL advisory write guard.
+
+These tests drive the guard against one scripted direct-session fake. The provider
+facts that fake assumes — that a session-level `lock_timeout` bounds
+`pg_advisory_lock`, that `pg_locks` reports the holding backend, and that
+`pg_advisory_unlock` confirms release — are proven against a real server in
+`tests/integration/test_apply_guard_integration.py`.
+"""
+
+from __future__ import annotations
+
+import traceback
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import pytest
+
+pytest.importorskip("psycopg")
+
+import psycopg
+from infrahub_sync.service.apply_guard import (
+    DEFAULT_DEADLINE_SECONDS,
+    MAX_DEADLINE_SECONDS,
+    MIN_DEADLINE_SECONDS,
+    ApplyGuard,
+    ApplyGuardContentionError,
+    ApplyGuardDeadlineError,
+    ApplyGuardError,
+    ApplyGuardOwnershipError,
+    ApplyGuardReleaseError,
+    ApplyGuardUnavailableError,
+    advisory_lock_key,
+    deadline_milliseconds,
+    dsn_secret_values,
+    hold_apply_guard,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+_BACKEND_PID = 4242
+_OTHER_BACKEND_PID = 9797
+_CONFIGURATION = "alpha"
+_ALPHA_KEY = -8187121688807872226
+
+# One canary per exception-graph carrier, each registered under a credential-shaped
+# environment variable so `collect_secret_values` treats it as a secret VALUE.
+_CANARY_ENVIRONMENT = {
+    "GUARD_CANARY_MESSAGE_PASSWORD": "canary-message-8a55",
+    "GUARD_CANARY_ARGUMENT_PASSWORD": "canary-argument-2f7a",
+    "GUARD_CANARY_NOTE_PASSWORD": "canary-note-9b41",
+    "GUARD_CANARY_CAUSE_PASSWORD": "canary-cause-4d08",
+    "GUARD_CANARY_CONTEXT_PASSWORD": "canary-context-6e2c",
+}
+
+
+class _Statement(NamedTuple):
+    sql: str
+    parameters: tuple[Any, ...]
+
+
+class _FakeCursor:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+class _FakeSession:
+    """One scripted direct-PostgreSQL session, recording every statement."""
+
+    def __init__(
+        self,
+        *,
+        held: bool = True,
+        released: bool = True,
+        ownership_pid: int = _BACKEND_PID,
+        release_pid: int = _BACKEND_PID,
+    ) -> None:
+        self.statements: list[_Statement] = []
+        self.close_calls = 0
+        self.held = held
+        self.released = released
+        self.ownership_pid = ownership_pid
+        self.release_pid = release_pid
+        self.failures: dict[str, BaseException] = {}
+        self.close_failure: BaseException | None = None
+
+    def execute(self, query: str, params: Sequence[Any] | None = None) -> _FakeCursor:
+        self.statements.append(_Statement(query, tuple(params or ())))
+        for fragment, error in self.failures.items():
+            if fragment in query:
+                raise error
+        return _FakeCursor(self._row(query))
+
+    def _row(self, query: str) -> tuple[Any, ...] | None:
+        if "pg_locks" in query:
+            return (self.ownership_pid, self.held)
+        if "pg_advisory_unlock" in query:
+            return (self.released, self.release_pid)
+        if "pg_advisory_lock" in query:
+            return (None,)
+        return ("configured",)
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_failure is not None:
+            raise self.close_failure
+
+    def executed(self, fragment: str) -> list[_Statement]:
+        return [statement for statement in self.statements if fragment in statement.sql]
+
+
+class _Hold:
+    """One complete guard hold, driven as a single statement inside `pytest.raises`.
+
+    Records the connect calls and the yielded guard so a test can assert what
+    happened after the hold failed, without nesting a context manager inside the
+    `pytest.raises` block.
+    """
+
+    def __init__(
+        self,
+        session: _FakeSession,
+        *,
+        configuration_id: str = _CONFIGURATION,
+        deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+        secrets: Sequence[str] = (),
+        connect_failure: BaseException | None = None,
+    ) -> None:
+        self.session = session
+        self.connect_calls: list[int] = []
+        self.guard: ApplyGuard | None = None
+        self._configuration_id = configuration_id
+        self._deadline_seconds = deadline_seconds
+        self._secrets = secrets
+        self._connect_failure = connect_failure
+
+    def run(self, action: Callable[[ApplyGuard], object] | None = None) -> None:
+        """Acquire, optionally run `action` under the hold, then release."""
+
+        def connect() -> _FakeSession:
+            self.connect_calls.append(1)
+            if self._connect_failure is not None:
+                raise self._connect_failure
+            return self.session
+
+        with hold_apply_guard(
+            self._configuration_id,
+            connect=connect,
+            deadline_seconds=self._deadline_seconds,
+            secrets=self._secrets,
+        ) as guard:
+            self.guard = guard
+            if action is not None:
+                action(guard)
+
+
+def _reachable_text(error: BaseException) -> str:
+    """Return every string reachable from an exception graph.
+
+    Covers what a traceback renderer shows AND what a result serializer can walk:
+    each link's text, its structured arguments, its notes, and both its `__cause__`
+    and `__context__` edges regardless of `__suppress_context__`.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    pending: list[BaseException] = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        parts.extend((str(current), repr(current.args)))
+        parts.extend(getattr(current, "__notes__", None) or [])
+        parts.extend(traceback.format_exception(type(current), current, current.__traceback__))
+        pending.extend(link for link in (current.__cause__, current.__context__) if link is not None)
+    return "\n".join(parts)
+
+
+def _hostile_driver_error(sqlstate: str | None = None) -> psycopg.Error:
+    """Return a driver error carrying a distinct canary in every graph carrier."""
+    context = RuntimeError(_CANARY_ENVIRONMENT["GUARD_CANARY_CONTEXT_PASSWORD"])
+    cause = ValueError(_CANARY_ENVIRONMENT["GUARD_CANARY_CAUSE_PASSWORD"])
+    cause.__context__ = context
+    error_type = psycopg.errors.LockNotAvailable if sqlstate == "55P03" else psycopg.OperationalError
+    error = error_type(
+        _CANARY_ENVIRONMENT["GUARD_CANARY_MESSAGE_PASSWORD"],
+        {"password": _CANARY_ENVIRONMENT["GUARD_CANARY_ARGUMENT_PASSWORD"]},
+    )
+    error.add_note(_CANARY_ENVIRONMENT["GUARD_CANARY_NOTE_PASSWORD"])
+    error.__cause__ = cause
+    return error
+
+
+def _leaked_canaries(error: BaseException) -> list[str]:
+    rendered = _reachable_text(error)
+    return [name for name, value in _CANARY_ENVIRONMENT.items() if value in rendered]
+
+
+# --------------------------------------------------------------------------- #
+# Advisory key derivation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("configuration_id", "expected"),
+    [
+        ("", 3890624961464930541),
+        ("alpha", -8187121688807872226),
+        ("beta", 2691780931179434137),
+        ("netbox-to-infrahub", -5804123439392766355),
+        ("0", -5102868248911540112),
+        ("01931f5c-6f4e-7a3b-9c2d-8e1f0a2b3c4d", -6484595175589399321),
+        ("é-uniçode", 1950900642927055419),
+    ],
+)
+def test_advisory_lock_key_matches_its_pinned_vectors(configuration_id: str, expected: int) -> None:
+    """Independent processes must derive the same signed 64-bit key.
+
+    The negative vectors pin the signed reading of the first eight SHA-256 bytes in
+    network byte order; an unsigned, little-endian, or differently namespaced
+    derivation fails here.
+    """
+    assert advisory_lock_key(configuration_id) == expected
+
+
+def test_advisory_lock_key_separates_configurations() -> None:
+    """Two configurations, including near-identical ones, must never share a key."""
+    identifiers = ("", "alpha", "beta", "netbox-to-infrahub", "0", "alpha ", "Alpha")
+
+    keys = [advisory_lock_key(identifier) for identifier in identifiers]
+
+    assert len(set(keys)) == len(identifiers)
+
+
+# --------------------------------------------------------------------------- #
+# Deadline bounds and conversion
+# --------------------------------------------------------------------------- #
+
+
+def test_the_deadline_default_and_accepted_bounds_are_the_documented_ones() -> None:
+    assert (DEFAULT_DEADLINE_SECONDS, MIN_DEADLINE_SECONDS, MAX_DEADLINE_SECONDS) == (30.0, 0.001, 300.0)
+    assert deadline_milliseconds(DEFAULT_DEADLINE_SECONDS) == 30_000
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0.001, 1),
+        (0.0010001, 2),
+        (0.029, 29),
+        (0.5, 500),
+        (1, 1000),
+        (1.0001, 1001),
+        (29.9999, 30_000),
+        (300.0, 300_000),
+    ],
+)
+def test_accepted_deadlines_convert_to_provider_milliseconds_by_ceiling(seconds: float, expected: int) -> None:
+    """Rounding must never reach zero, which PostgreSQL reads as "wait forever"."""
+    assert deadline_milliseconds(seconds) == expected
+
+
+@pytest.mark.parametrize("seconds", [0, -1, 0.0009, 300.001, float("inf"), float("-inf"), float("nan")])
+def test_rejected_deadlines_refuse_conversion(seconds: float) -> None:
+    """Zero, negatives, sub-millisecond, over-range, and non-finite values all refuse."""
+    with pytest.raises(ApplyGuardDeadlineError):
+        deadline_milliseconds(seconds)
+
+
+def test_a_rejected_deadline_refuses_before_any_session_is_opened() -> None:
+    """Deadline validation is deterministic and must precede provider contact."""
+    session = _FakeSession()
+    hold = _Hold(session, deadline_seconds=0)
+
+    with pytest.raises(ApplyGuardDeadlineError):
+        hold.run()
+
+    assert hold.connect_calls == []
+    assert session.statements == []
+
+
+# --------------------------------------------------------------------------- #
+# Acquisition on one dedicated session
+# --------------------------------------------------------------------------- #
+
+
+def test_acquisition_bounds_the_deadline_then_locks_then_proves_ownership() -> None:
+    """The exact statement order, arguments, and session count the provider receives."""
+    session = _FakeSession()
+    hold = _Hold(session, deadline_seconds=0.3)
+    acquisition: list[_Statement] = []
+
+    hold.run(lambda _: acquisition.extend(session.statements))
+
+    assert hold.connect_calls == [1]
+    assert hold.guard is not None
+    assert hold.guard.key == _ALPHA_KEY
+    assert len(acquisition) == 3
+    assert "set_config" in acquisition[0].sql
+    assert acquisition[0].parameters == ("300",)
+    assert "pg_advisory_lock" in acquisition[1].sql
+    assert acquisition[1].parameters == (_ALPHA_KEY,)
+    assert "pg_locks" in acquisition[2].sql
+    assert session.close_calls == 1
+
+
+def test_a_lock_timeout_is_reported_as_contention() -> None:
+    """`lock_timeout` aborts with SQLSTATE 55P03; that is contention, not unavailability."""
+    session = _FakeSession()
+    session.failures["pg_advisory_lock"] = psycopg.errors.LockNotAvailable("timed out")
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardContentionError):
+        hold.run()
+
+    assert hold.guard is None
+    assert session.close_calls == 1
+
+
+def test_a_driver_failure_that_is_not_a_lock_timeout_is_reported_as_unavailable() -> None:
+    """Mapping every driver error to contention would hide a broken deployment."""
+    session = _FakeSession()
+    session.failures["pg_advisory_lock"] = psycopg.OperationalError("server gone")
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardUnavailableError) as caught:
+        hold.run()
+
+    assert not isinstance(caught.value, ApplyGuardContentionError)
+    assert hold.guard is None
+    assert session.close_calls == 1
+
+
+def test_a_session_that_cannot_open_reports_unavailable_without_a_hold() -> None:
+    """A session that never opened is not a session to close."""
+    session = _FakeSession()
+    hold = _Hold(session, connect_failure=psycopg.OperationalError("connection refused"))
+
+    with pytest.raises(ApplyGuardUnavailableError):
+        hold.run()
+
+    assert hold.guard is None
+    assert session.close_calls == 0
+
+
+def test_acquisition_that_cannot_prove_its_own_lock_refuses_and_retires_the_session() -> None:
+    """A lock the guard cannot see in `pg_locks` is not a hold it may report."""
+    session = _FakeSession(held=False)
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardUnavailableError):
+        hold.run()
+
+    assert hold.guard is None
+    assert session.close_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# Ownership proof
+# --------------------------------------------------------------------------- #
+
+
+def test_the_ownership_proof_reads_pg_locks_for_the_exact_key_without_reacquiring() -> None:
+    """Reacquiring would stack a second session lock and mask a lost hold."""
+    session = _FakeSession()
+    hold = _Hold(session, configuration_id="beta")
+    beta_key = advisory_lock_key("beta")
+    proof: list[_Statement] = []
+
+    def prove(guard: ApplyGuard) -> None:
+        before = len(session.statements)
+        guard.require_ownership()
+        proof.extend(session.statements[before:])
+
+    hold.run(prove)
+
+    assert len(proof) == 1
+    assert "pg_locks" in proof[0].sql
+    assert "pg_backend_pid()" in proof[0].sql
+    assert "advisory_lock" not in proof[0].sql
+    assert proof[0].parameters == ((beta_key >> 32) & 0xFFFFFFFF, beta_key & 0xFFFFFFFF)
+
+
+@pytest.mark.parametrize("loss", ["backend-session", "lock-row", "driver"])
+def test_a_lost_or_uncertain_hold_refuses_ownership_and_retires_the_session(loss: str) -> None:
+    """A different backend, a missing lock row, and a dead session all refuse."""
+    session = _FakeSession()
+    hold = _Hold(session)
+
+    def lose_then_prove(guard: ApplyGuard) -> None:
+        if loss == "backend-session":
+            session.ownership_pid = _OTHER_BACKEND_PID
+        elif loss == "lock-row":
+            session.held = False
+        else:
+            session.failures["pg_locks"] = psycopg.OperationalError("session terminated")
+        guard.require_ownership()
+
+    with pytest.raises(ApplyGuardOwnershipError):
+        hold.run(lose_then_prove)
+
+    assert hold.guard is not None
+    assert hold.guard.retired is True
+    assert session.close_calls == 1
+    assert session.executed("pg_advisory_unlock") == []
+
+
+def test_a_retired_guard_refuses_ownership_and_release_without_touching_the_session() -> None:
+    """A retired session is never consulted again, and can never report success."""
+    session = _FakeSession()
+    guard = ApplyGuard(connection=session, key=_ALPHA_KEY, backend_pid=_BACKEND_PID, secrets=())
+
+    guard.retire()
+    with pytest.raises(ApplyGuardOwnershipError):
+        guard.require_ownership()
+    with pytest.raises(ApplyGuardReleaseError):
+        guard.release()
+
+    assert guard.retired is True
+    assert session.close_calls == 1
+    assert session.statements == []
+
+
+# --------------------------------------------------------------------------- #
+# Confirmed release
+# --------------------------------------------------------------------------- #
+
+
+def test_a_successful_hold_confirms_the_unlock_and_closes_the_session() -> None:
+    session = _FakeSession()
+
+    _Hold(session).run()
+
+    release = session.executed("pg_advisory_unlock")
+    assert len(release) == 1
+    assert release[0].parameters == (_ALPHA_KEY,)
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "session",
+    [
+        pytest.param(_FakeSession(released=False), id="unlock-returned-false"),
+        pytest.param(_FakeSession(release_pid=_OTHER_BACKEND_PID), id="different-backend-session"),
+    ],
+)
+def test_an_unconfirmed_unlock_fails_the_guard_use(session: _FakeSession) -> None:
+    """A body that succeeded is still a failed guard use without a confirmed release."""
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.run()
+
+    assert hold.guard is not None
+    assert session.close_calls == 1
+
+
+def test_a_release_driver_failure_fails_the_guard_use_and_retires_the_session() -> None:
+    session = _FakeSession()
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.run(lambda _: session.failures.update({"pg_advisory_unlock": psycopg.OperationalError("gone")}))
+
+    assert hold.guard is not None
+    assert hold.guard.retired is True
+    assert session.close_calls == 1
+
+
+def test_a_close_failure_after_a_confirmed_unlock_still_fails_the_guard_use() -> None:
+    """Cleanup is part of the guarantee: an unclosed dedicated session is a failure."""
+    session = _FakeSession()
+    session.close_failure = psycopg.OperationalError("close failed")
+    hold = _Hold(session)
+
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.run()
+
+    assert len(session.executed("pg_advisory_unlock")) == 1
+
+
+def test_an_explicit_release_inside_the_hold_is_confirmed_exactly_once() -> None:
+    """Callers must be able to confirm release before publishing any success."""
+    session = _FakeSession()
+    released_inside: list[int] = []
+
+    def release_early(guard: ApplyGuard) -> None:
+        guard.release()
+        released_inside.append(len(session.executed("pg_advisory_unlock")))
+
+    _Hold(session).run(release_early)
+
+    assert released_inside == [1]
+    assert len(session.executed("pg_advisory_unlock")) == 1
+    assert session.close_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# Body exception precedence over cleanup
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("body_error_type", [ValueError, KeyboardInterrupt])
+def test_a_body_exception_wins_over_a_cleanup_failure(body_error_type: type[BaseException]) -> None:
+    """Cancellation arrives as `BaseException`; neither kind may be replaced."""
+    session = _FakeSession(released=False)
+    session.close_failure = psycopg.OperationalError("close-canary")
+    message = "body-canary"
+
+    def fail_body(guard: ApplyGuard) -> None:
+        del guard
+        raise body_error_type(message)
+
+    with pytest.raises(body_error_type) as caught:
+        _Hold(session).run(fail_body)
+
+    assert not isinstance(caught.value, ApplyGuardError)
+    assert message in _reachable_text(caught.value)
+    assert "close-canary" not in _reachable_text(caught.value)
+    assert session.close_calls == 1
+
+
+def test_a_body_exception_retires_the_session_without_attempting_an_unlock() -> None:
+    """An interrupted hold's session is uncertain; closing it releases the lock."""
+    session = _FakeSession()
+    message = "body failed"
+
+    def fail_body(guard: ApplyGuard) -> None:
+        del guard
+        raise ValueError(message)
+
+    with pytest.raises(ValueError, match=message):
+        _Hold(session).run(fail_body)
+
+    assert session.executed("pg_advisory_unlock") == []
+    assert session.close_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# Exception-graph sanitization
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("site", "sqlstate", "expected"),
+    [
+        ("pg_advisory_lock", None, ApplyGuardUnavailableError),
+        ("pg_advisory_lock", "55P03", ApplyGuardContentionError),
+        ("pg_locks", None, ApplyGuardUnavailableError),
+        ("pg_advisory_unlock", None, ApplyGuardReleaseError),
+    ],
+)
+def test_no_guard_failure_graph_reaches_a_driver_canary(
+    monkeypatch: pytest.MonkeyPatch, site: str, sqlstate: str | None, expected: type[ApplyGuardError]
+) -> None:
+    """Arguments, notes, cause, and context must all be sanitized or unreachable."""
+    for name, value in _CANARY_ENVIRONMENT.items():
+        monkeypatch.setenv(name, value)
+    session = _FakeSession()
+    session.failures[site] = _hostile_driver_error(sqlstate)
+
+    with pytest.raises(expected) as caught:
+        _Hold(session).run()
+
+    assert _leaked_canaries(caught.value) == []
+
+
+def test_an_ownership_failure_graph_reaches_no_driver_canary(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name, value in _CANARY_ENVIRONMENT.items():
+        monkeypatch.setenv(name, value)
+    session = _FakeSession()
+
+    def lose_then_prove(guard: ApplyGuard) -> None:
+        session.failures["pg_locks"] = _hostile_driver_error()
+        guard.require_ownership()
+
+    with pytest.raises(ApplyGuardOwnershipError) as caught:
+        _Hold(session).run(lose_then_prove)
+
+    assert _leaked_canaries(caught.value) == []
+
+
+def test_a_guard_failure_exposes_a_sanitized_cause_and_no_reachable_context() -> None:
+    """`__suppress_context__` hides a raw context from a traceback but not from a walker."""
+    session = _FakeSession()
+    session.failures["pg_advisory_lock"] = psycopg.OperationalError("driver detail")
+
+    with pytest.raises(ApplyGuardUnavailableError) as caught:
+        _Hold(session).run()
+
+    assert caught.value.__context__ is None
+    assert caught.value.__suppress_context__ is True
+    assert isinstance(caught.value.__cause__, Exception)
+    assert not isinstance(caught.value.__cause__, psycopg.Error)
+
+
+def test_explicitly_supplied_secret_values_are_redacted_from_a_guard_failure() -> None:
+    """A keyword DSN's password is not in the environment; the caller supplies it."""
+    supplied = "supplied-guard-password-canary"
+    session = _FakeSession()
+    session.failures["pg_advisory_lock"] = psycopg.OperationalError(f"auth failed for {supplied}")
+
+    with pytest.raises(ApplyGuardUnavailableError) as caught:
+        _Hold(session, secrets=(supplied,)).run()
+
+    assert supplied not in _reachable_text(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected"),
+    [
+        ("host=127.0.0.1 dbname=sync password=guard-secret-value", ("guard-secret-value",)),
+        ("postgresql://sync:guard-secret-value@127.0.0.1/sync", ("guard-secret-value",)),
+        ("host=127.0.0.1 dbname=sync password=tiny", ()),
+        ("host=127.0.0.1 dbname=sync", ()),
+        ("not a dsn at all =", ()),
+    ],
+)
+def test_dsn_secret_values_collects_only_a_usable_password(dsn: str, expected: tuple[str, ...]) -> None:
+    """Short values are dropped: redacting them would shred unrelated diagnostics."""
+    assert dsn_secret_values(dsn) == expected

--- a/tests/service/test_apply_guard.py
+++ b/tests/service/test_apply_guard.py
@@ -418,18 +418,33 @@ def test_a_lost_or_uncertain_hold_refuses_ownership_and_retires_the_session(loss
     assert session.executed("pg_advisory_unlock") == []
 
 
-def test_a_failed_ownership_proof_retires_the_session_immediately() -> None:
+@pytest.mark.parametrize(
+    ("injected", "raised"),
+    [
+        pytest.param(None, ApplyGuardOwnershipError, id="lock-row"),
+        pytest.param(psycopg.OperationalError("driver"), ApplyGuardOwnershipError, id="driver-error"),
+        pytest.param(RuntimeError("ordinary"), ApplyGuardOwnershipError, id="ordinary-exception"),
+        pytest.param(KeyboardInterrupt("interrupt"), KeyboardInterrupt, id="base-exception"),
+    ],
+)
+def test_a_failed_ownership_proof_retires_the_session_immediately(
+    injected: BaseException | None, raised: type[BaseException]
+) -> None:
     """A caller that catches the refusal must not be able to keep using the session.
 
     Retiring only while the hold unwinds would leave a caught refusal followed by
-    another destination operation on a session that no longer owns the key.
+    another destination operation on a session that no longer owns the key. That
+    has to hold for every failure class, including a contained interrupt.
     """
     session = _FakeSession()
     hold = _Hold(session)
 
     def prove_twice(guard: ApplyGuard) -> None:
-        session.held = False
-        with pytest.raises(ApplyGuardOwnershipError):
+        if injected is None:
+            session.held = False
+        else:
+            session.failures["pg_locks"] = injected
+        with pytest.raises(raised):
             guard.require_ownership()
         assert guard.retired is True
         assert session.close_calls == 1
@@ -483,15 +498,24 @@ def test_a_successful_hold_confirms_the_unlock_and_closes_the_session() -> None:
         pytest.param(_FakeSession(release_pid=_OTHER_BACKEND_PID), id="different-backend-session"),
     ],
 )
-def test_an_unconfirmed_unlock_fails_the_guard_use(session: _FakeSession) -> None:
-    """A body that succeeded is still a failed guard use without a confirmed release."""
+def test_an_unconfirmed_unlock_fails_the_guard_use_and_retires_the_guard(session: _FakeSession) -> None:
+    """A body that succeeded is still a failed guard use without a confirmed release.
+
+    The guard must also report itself retired, so a caller that catches the failure
+    cannot read it as a usable hold or drive another unlock at the closed session.
+    """
     hold = _Hold(session)
 
     with pytest.raises(ApplyGuardReleaseError):
         hold.run()
 
     assert hold.guard is not None
+    assert hold.guard.retired is True
     assert session.close_calls == 1
+    unlocks = len(session.executed("pg_advisory_unlock"))
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.guard.release()
+    assert len(session.executed("pg_advisory_unlock")) == unlocks
 
 
 def test_a_release_driver_failure_fails_the_guard_use_and_retires_the_session() -> None:

--- a/tests/service/test_apply_guard.py
+++ b/tests/service/test_apply_guard.py
@@ -179,8 +179,8 @@ def _reachable_text(error: BaseException) -> str:
     return "\n".join(parts)
 
 
-def _hostile_driver_error(sqlstate: str | None = None) -> psycopg.Error:
-    """Return a driver error carrying a distinct canary in every graph carrier.
+def _hostile_error(error_type: type[BaseException]) -> BaseException:
+    """Return an `error_type` carrying a distinct canary in every graph carrier.
 
     All four carriers reach a rendered traceback: `str(error)` prints the whole
     argument tuple, and `__notes__` prints after the message line.
@@ -188,13 +188,20 @@ def _hostile_driver_error(sqlstate: str | None = None) -> psycopg.Error:
     context = RuntimeError(_CANARY_ENVIRONMENT["GUARD_CANARY_CONTEXT_PASSWORD"])
     cause = ValueError(_CANARY_ENVIRONMENT["GUARD_CANARY_CAUSE_PASSWORD"])
     cause.__context__ = context
-    error_type = psycopg.errors.LockNotAvailable if sqlstate == "55P03" else psycopg.OperationalError
     error = error_type(_CANARY_ENVIRONMENT["GUARD_CANARY_MESSAGE_PASSWORD"])
     error.args = (*error.args, {"password": _CANARY_ENVIRONMENT["GUARD_CANARY_ARGUMENT_PASSWORD"]})
     # `BaseException.add_note` exists from Python 3.11; the type gate targets 3.10.
     cast("Any", error).add_note(_CANARY_ENVIRONMENT["GUARD_CANARY_NOTE_PASSWORD"])
     error.__cause__ = cause
     return error
+
+
+def _inject(session: _FakeSession, site: str, error: BaseException) -> _Hold:
+    """Return one hold with `error` injected at one provider site."""
+    if site == "connect":
+        return _Hold(session, connect_failure=error)
+    session.failures[site] = error
+    return _Hold(session)
 
 
 def _leaked_canaries(error: BaseException) -> list[str]:
@@ -574,22 +581,22 @@ def test_a_body_exception_retires_the_session_without_attempting_an_unlock() -> 
 
 
 @pytest.mark.parametrize(
-    ("site", "sqlstate", "expected"),
+    ("site", "error_type", "expected"),
     [
-        ("pg_advisory_lock", None, ApplyGuardUnavailableError),
-        ("pg_advisory_lock", "55P03", ApplyGuardContentionError),
-        ("pg_locks", None, ApplyGuardUnavailableError),
-        ("pg_advisory_unlock", None, ApplyGuardReleaseError),
+        ("pg_advisory_lock", psycopg.OperationalError, ApplyGuardUnavailableError),
+        ("pg_advisory_lock", psycopg.errors.LockNotAvailable, ApplyGuardContentionError),
+        ("pg_locks", psycopg.OperationalError, ApplyGuardUnavailableError),
+        ("pg_advisory_unlock", psycopg.OperationalError, ApplyGuardReleaseError),
     ],
 )
 def test_no_guard_failure_graph_reaches_a_driver_canary(
-    monkeypatch: pytest.MonkeyPatch, site: str, sqlstate: str | None, expected: type[ApplyGuardError]
+    monkeypatch: pytest.MonkeyPatch, site: str, error_type: type[BaseException], expected: type[ApplyGuardError]
 ) -> None:
     """Arguments, notes, cause, and context must all be sanitized or unreachable."""
     for name, value in _CANARY_ENVIRONMENT.items():
         monkeypatch.setenv(name, value)
     session = _FakeSession()
-    session.failures[site] = _hostile_driver_error(sqlstate)
+    session.failures[site] = _hostile_error(error_type)
 
     with pytest.raises(expected) as caught:
         _Hold(session).run()
@@ -603,7 +610,7 @@ def test_an_ownership_failure_graph_reaches_no_driver_canary(monkeypatch: pytest
     session = _FakeSession()
 
     def lose_then_prove(guard: ApplyGuard) -> None:
-        session.failures["pg_locks"] = _hostile_driver_error()
+        session.failures["pg_locks"] = _hostile_error(psycopg.OperationalError)
         guard.require_ownership()
 
     with pytest.raises(ApplyGuardOwnershipError) as caught:
@@ -651,3 +658,176 @@ def test_explicitly_supplied_secret_values_are_redacted_from_a_guard_failure() -
 def test_dsn_secret_values_collects_only_a_usable_password(dsn: str, expected: tuple[str, ...]) -> None:
     """Short values are dropped: redacting them would shred unrelated diagnostics."""
     assert dsn_secret_values(dsn) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Provider and cleanup boundary containment
+# --------------------------------------------------------------------------- #
+
+_PROVIDER_SITES = ("connect", "pg_advisory_lock", "pg_locks", "pg_advisory_unlock")
+_CLEANUP_FAILURES = [
+    pytest.param(psycopg.OperationalError("close-canary"), id="driver-error"),
+    pytest.param(RuntimeError("close-canary"), id="ordinary-exception"),
+    pytest.param(KeyboardInterrupt("close-canary"), id="base-exception"),
+]
+
+
+@pytest.mark.parametrize(
+    ("site", "expected"),
+    [
+        ("connect", ApplyGuardUnavailableError),
+        ("pg_advisory_lock", ApplyGuardUnavailableError),
+        ("pg_locks", ApplyGuardUnavailableError),
+        ("pg_advisory_unlock", ApplyGuardReleaseError),
+    ],
+)
+def test_a_non_driver_provider_exception_becomes_a_sanitized_guard_failure(
+    monkeypatch: pytest.MonkeyPatch, site: str, expected: type[ApplyGuardError]
+) -> None:
+    """A connection, cursor, or protocol implementation may raise more than `psycopg.Error`."""
+    for name, value in _CANARY_ENVIRONMENT.items():
+        monkeypatch.setenv(name, value)
+    injected = _hostile_error(RuntimeError)
+    session = _FakeSession()
+    hold = _inject(session, site, injected)
+
+    with pytest.raises(expected) as caught:
+        hold.run()
+
+    assert caught.value.__cause__ is not injected
+    assert caught.value.__context__ is None
+    assert caught.value.__suppress_context__ is True
+    assert _leaked_canaries(caught.value) == []
+    assert session.close_calls == (0 if site == "connect" else 1)
+
+
+@pytest.mark.parametrize("site", _PROVIDER_SITES)
+def test_a_provider_base_exception_propagates_and_still_closes_the_session(site: str) -> None:
+    """Cancellation must not be converted, and must not leave the session uncertain."""
+    injected = KeyboardInterrupt("interrupt-canary")
+    session = _FakeSession()
+    hold = _inject(session, site, injected)
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        hold.run()
+
+    assert caught.value is injected
+    assert session.close_calls == (0 if site == "connect" else 1)
+
+
+def test_only_a_driver_lock_timeout_counts_as_contention() -> None:
+    """A non-driver error that merely carries a 55P03 attribute is not contention."""
+
+    class _ImpostorError(RuntimeError):
+        sqlstate = "55P03"
+
+    session = _FakeSession()
+    hold = _inject(session, "pg_advisory_lock", _ImpostorError("not a driver error"))
+
+    with pytest.raises(ApplyGuardUnavailableError) as caught:
+        hold.run()
+
+    assert not isinstance(caught.value, ApplyGuardContentionError)
+
+
+@pytest.mark.parametrize(
+    ("injected", "expected"),
+    [
+        pytest.param(psycopg.OperationalError("driver"), ApplyGuardOwnershipError, id="driver-error"),
+        pytest.param(RuntimeError("ordinary"), ApplyGuardOwnershipError, id="ordinary-exception"),
+        pytest.param(KeyboardInterrupt("interrupt"), KeyboardInterrupt, id="base-exception"),
+    ],
+)
+def test_an_ownership_proof_failure_of_any_class_retires_the_session(
+    injected: BaseException, expected: type[BaseException]
+) -> None:
+    """A proof that cannot complete leaves no usable session behind."""
+    session = _FakeSession()
+    hold = _Hold(session)
+
+    def prove(guard: ApplyGuard) -> None:
+        session.failures["pg_locks"] = injected
+        guard.require_ownership()
+
+    with pytest.raises(expected):
+        hold.run(prove)
+
+    assert hold.guard is not None
+    assert hold.guard.retired is True
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("close_error", _CLEANUP_FAILURES)
+def test_a_close_failure_of_any_class_never_replaces_the_body_exception(close_error: BaseException) -> None:
+    """Retiring a session must not be able to lose the caller's own failure."""
+    session = _FakeSession()
+    session.close_failure = close_error
+    message = "body-canary"
+
+    def fail_body(guard: ApplyGuard) -> None:
+        del guard
+        raise ValueError(message)
+
+    with pytest.raises(ValueError, match=message) as caught:
+        _Hold(session).run(fail_body)
+
+    assert "close-canary" not in _reachable_text(caught.value)
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("close_error", _CLEANUP_FAILURES)
+@pytest.mark.parametrize(
+    ("site", "expected"),
+    [
+        ("pg_advisory_lock", ApplyGuardUnavailableError),
+        ("pg_locks", ApplyGuardUnavailableError),
+        ("pg_advisory_unlock", ApplyGuardReleaseError),
+    ],
+)
+def test_a_close_failure_never_replaces_a_primary_provider_failure(
+    site: str, expected: type[ApplyGuardError], close_error: BaseException
+) -> None:
+    """The failure that caused the discard is the one the caller needs."""
+    session = _FakeSession()
+    session.close_failure = close_error
+    hold = _inject(session, site, psycopg.OperationalError("primary-failure"))
+
+    with pytest.raises(expected) as caught:
+        hold.run()
+
+    assert "close-canary" not in _reachable_text(caught.value)
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize("close_error", _CLEANUP_FAILURES)
+def test_retiring_a_guard_never_raises_whatever_the_session_does(close_error: BaseException) -> None:
+    session = _FakeSession()
+    session.close_failure = close_error
+    guard = ApplyGuard(connection=session, key=_ALPHA_KEY, backend_pid=_BACKEND_PID, secrets=())
+
+    guard.retire()
+
+    assert guard.retired is True
+    assert session.close_calls == 1
+
+
+def test_a_close_failure_after_a_confirmed_unlock_leaves_the_guard_permanently_retired() -> None:
+    """A caught release failure must not let the hold exit as a success.
+
+    The unlock was confirmed, but the dedicated session was never closed, so the
+    hold is not a clean release and a later confirmation must refuse.
+    """
+    session = _FakeSession()
+    session.close_failure = psycopg.OperationalError("close failed")
+    hold = _Hold(session)
+
+    def release_and_swallow(guard: ApplyGuard) -> None:
+        with pytest.raises(ApplyGuardReleaseError):
+            guard.release()
+
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.run(release_and_swallow)
+
+    assert hold.guard is not None
+    assert hold.guard.retired is True
+    assert session.close_calls == 1

--- a/tests/service/test_apply_guard.py
+++ b/tests/service/test_apply_guard.py
@@ -411,6 +411,32 @@ def test_a_lost_or_uncertain_hold_refuses_ownership_and_retires_the_session(loss
     assert session.executed("pg_advisory_unlock") == []
 
 
+def test_a_failed_ownership_proof_retires_the_session_immediately() -> None:
+    """A caller that catches the refusal must not be able to keep using the session.
+
+    Retiring only while the hold unwinds would leave a caught refusal followed by
+    another destination operation on a session that no longer owns the key.
+    """
+    session = _FakeSession()
+    hold = _Hold(session)
+
+    def prove_twice(guard: ApplyGuard) -> None:
+        session.held = False
+        with pytest.raises(ApplyGuardOwnershipError):
+            guard.require_ownership()
+        assert guard.retired is True
+        assert session.close_calls == 1
+        quiescent = len(session.statements)
+        with pytest.raises(ApplyGuardOwnershipError):
+            guard.require_ownership()
+        assert len(session.statements) == quiescent
+
+    with pytest.raises(ApplyGuardReleaseError):
+        hold.run(prove_twice)
+
+    assert session.close_calls == 1
+
+
 def test_a_retired_guard_refuses_ownership_and_release_without_touching_the_session() -> None:
     """A retired session is never consulted again, and can never report success."""
     session = _FakeSession()

--- a/tests/service/test_apply_guard.py
+++ b/tests/service/test_apply_guard.py
@@ -10,13 +10,14 @@ facts that fake assumes — that a session-level `lock_timeout` bounds
 from __future__ import annotations
 
 import traceback
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import pytest
 
 pytest.importorskip("psycopg")
 
 import psycopg
+
 from infrahub_sync.service.apply_guard import (
     DEFAULT_DEADLINE_SECONDS,
     MAX_DEADLINE_SECONDS,
@@ -179,16 +180,19 @@ def _reachable_text(error: BaseException) -> str:
 
 
 def _hostile_driver_error(sqlstate: str | None = None) -> psycopg.Error:
-    """Return a driver error carrying a distinct canary in every graph carrier."""
+    """Return a driver error carrying a distinct canary in every graph carrier.
+
+    All four carriers reach a rendered traceback: `str(error)` prints the whole
+    argument tuple, and `__notes__` prints after the message line.
+    """
     context = RuntimeError(_CANARY_ENVIRONMENT["GUARD_CANARY_CONTEXT_PASSWORD"])
     cause = ValueError(_CANARY_ENVIRONMENT["GUARD_CANARY_CAUSE_PASSWORD"])
     cause.__context__ = context
     error_type = psycopg.errors.LockNotAvailable if sqlstate == "55P03" else psycopg.OperationalError
-    error = error_type(
-        _CANARY_ENVIRONMENT["GUARD_CANARY_MESSAGE_PASSWORD"],
-        {"password": _CANARY_ENVIRONMENT["GUARD_CANARY_ARGUMENT_PASSWORD"]},
-    )
-    error.add_note(_CANARY_ENVIRONMENT["GUARD_CANARY_NOTE_PASSWORD"])
+    error = error_type(_CANARY_ENVIRONMENT["GUARD_CANARY_MESSAGE_PASSWORD"])
+    error.args = (*error.args, {"password": _CANARY_ENVIRONMENT["GUARD_CANARY_ARGUMENT_PASSWORD"]})
+    # `BaseException.add_note` exists from Python 3.11; the type gate targets 3.10.
+    cast("Any", error).add_note(_CANARY_ENVIRONMENT["GUARD_CANARY_NOTE_PASSWORD"])
     error.__cause__ = cause
     return error
 


### PR DESCRIPTION
## Problem\n\nManaged workers will not share a filesystem, so the existing local run lock cannot serialize writes to the same configuration across processes.\n\n## Solution\n\nAdd a configuration-scoped PostgreSQL session advisory guard with a bounded acquisition deadline, same-session ownership proofs, confirmed release, forced retirement after uncertain ownership, and secret-safe provider failures. The primitive is intentionally inert in this unit: no supported apply or sync path calls it yet.\n\nBefore: there was no cross-process write-guard primitive.\n\nAfter: the reviewed PostgreSQL primitive and its deployment contract exist, while runtime behavior remains unchanged until the follow-up integration unit.\n\n## Validation\n\n- 88 focused unit tests passed\n- 11 PostgreSQL 16 integration tests passed with zero skips\n- 3,372 non-integration tests passed; 52 skipped; 1 expected failure\n- format, lint, Ruff, Pylint, YAML, and ty passed\n- CLI help checks passed\n- docs generation, rumdl, Vale, and diff checks passed\n- 36/36 property mutations were killed\n- independent whole-diff review found one cleanup/containment defect family; the correction passed bounded independent re-review\n\nNo compatibility migration or fallback for earlier unshipped V3 candidate designs is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on configuration write protection, including deployment requirements, timing limits, lock ownership, failure handling, and testing.
  - Added a reference to the new configuration write-guard documentation in the knowledge guide.

- **Quality Improvements**
  - Expanded validation coverage for write-guard behavior, including contention, release, ownership, error handling, and concurrent operations.
  - Updated spelling validation to recognize additional technical terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->