### PR TITLE
Serialize managed writes on the PostgreSQL apply guard and record uncertain writes

### DIFF
--- a/dev/adr/0010-a-managed-write-ends-in-a-verdict-not-a-retry.md
+++ b/dev/adr/0010-a-managed-write-ends-in-a-verdict-not-a-retry.md
@@ -39,10 +39,16 @@ sidecar becomes product success. Managed sync acquires the guard before destinat
 extraction and holds it across plan, verify, and apply, so the plan it applies cannot go
 stale behind another writer.
 
-The ownership boundary is a required argument with no default, no `None`, and no no-op
-implementation. `Potenda.apply_plan`, `PlanApplier.apply_plan`, and
-`execute_run(operation="apply")` each refuse without one. Tests pass an explicit fake; a
-boundary that could be absent would be absent exactly when it mattered.
+The ownership boundary is required wherever an apply is assembled, and there is no no-op
+implementation to reach for. `Potenda.apply_plan` and `PlanApplier.apply_plan` declare it
+as a keyword with no default, so omitting it is a `TypeError` at the call. The shared
+`execute_run` serves four operations and only one of them writes, so requiring the keyword
+unconditionally would force plan and verify to carry a write-ownership value they have no
+use for; instead the `operation="apply"` overload declares it required and no other
+overload accepts `apply`, which is what makes the type checker in the repository's lint
+gate reject an unguarded apply. A runtime refusal stands behind that for a caller who
+ignores the type, and tests pass an explicit fake. A boundary that could be absent would
+be absent exactly when it mattered.
 
 One run admits one write. The reservation is decided inside a single store transaction on
 the run's own locked row, before either competitor can submit anything to Prefect: a write
@@ -52,14 +58,24 @@ run-execution-conflict` on its own receipt, so replaying its client key replays 
 Each execution names the unresolved receipt that appended it, uniquely, so the admitted
 receipt spends its admission exactly once.
 
-A write that may have started ends in a verdict. One in-memory Boolean, owned by the worker
-that ran the stage, separates a failure that certainly wrote nothing from one that may have.
-Before the first proven dispatch a failure is an ordinary failed run. After it, every
-non-success outcome — an adapter failure, a lost session, a failed final proof, a failed
-applied sidecar, cancellation, or losing the worker entirely — is `interrupted` /
-`ambiguous`, and `product_runs.reconciliation_required` is set in the same transaction that
-makes the execution terminal. That column is derived from the verdict and the execution's
-purpose rather than passed in, so no caller can write it false, and nothing clears it.
+A write that may have started ends in a verdict. The worker that ran the stage keeps two
+things for its own failure boundary: one in-memory Boolean separating a failure that
+certainly wrote nothing from one that may have, and the `ApplyRecord` of what the engine
+completed. The record is kept on that scope rather than on whichever exception is
+unwinding, because the window that needs it is wider than the engine call — a sidecar that
+cannot record the applied transition, an unlock that cannot be confirmed, and a product
+success that did not store are all failures after a dispatch, and none of them carries a
+record of its own.
+
+That gives the scope one exit. Before the first proven dispatch a failure is an ordinary
+failed run. After it, every non-success outcome — an adapter failure, a lost session, a
+failed final proof, a failed applied sidecar, a release that could not be confirmed, a product
+success that did not store, cancellation, or losing the worker entirely — is `interrupted` /
+`ambiguous`, committed together with the evidence, the record, and
+`product_runs.reconciliation_required`. That column is derived from the verdict and the
+execution's purpose rather than passed in, so no caller can write it false, and nothing
+clears it. A commit that succeeded but could not answer is not a failure: rereading the
+link is what tells a lost response from a lost write.
 
 The operator reconciles by planning again. An empty diff shows the desired state is already
 present; anything else is reviewed and applied as a new run.

--- a/dev/adr/0010-a-managed-write-ends-in-a-verdict-not-a-retry.md
+++ b/dev/adr/0010-a-managed-write-ends-in-a-verdict-not-a-retry.md
@@ -1,0 +1,110 @@
+# 10. A managed write holds one configuration guard and ends in a verdict, not a retry
+
+**Status**: Accepted
+**Date**: 2026-09-03
+**Source**: PH-3 apply-guard unit 1B
+
+## Context
+
+Two workers can hold destination credentials for the same registered configuration at the
+same time. Nothing in the engine stopped them writing that configuration concurrently, so
+a reviewed plan could be applied against a destination another writer was still changing —
+and the schema snapshot the plan was validated against could describe a destination that no
+longer existed by the time the first operation was dispatched.
+
+Failure made the same problem worse in the other direction. Applying one recorded operation
+is not one write: the base upsert precedes the relationship flush, so an operation can change
+the destination and belong to neither the applied nor the skipped set. A worker that fails,
+loses its session, is cancelled, or disappears entirely therefore cannot say what reached the
+destination. Recording that as an ordinary failure invites the obvious next step — apply
+again — which is exactly the step nobody can justify without looking.
+
+Serializing writers was only half the answer. Holding a lock proves nothing about whether
+the process still holds it: a session can die, an advisory key can be released by a stray
+unlock, and a caller that only checked at the start would keep writing regardless.
+
+## Decision
+
+A managed write holds one PostgreSQL advisory guard, keyed by the registered configuration
+it writes, for the whole write — and the engine proves that hold around every operation it
+dispatches.
+
+The order is fixed. Deterministic refusals settle first, outside the guard, so a request
+that was never going to succeed does not make another writer wait. The guard is acquired
+next. Everything destination-sensitive then happens inside it: the live schema read, the
+runtime models built from it, the comparison those models exist for, and every dispatch.
+Ownership is proven immediately before each dispatch and once after the last one, before
+anything may record the apply as complete. Release is confirmed before the local applied
+sidecar becomes product success. Managed sync acquires the guard before destination
+extraction and holds it across plan, verify, and apply, so the plan it applies cannot go
+stale behind another writer.
+
+The ownership boundary is a required argument with no default, no `None`, and no no-op
+implementation. `Potenda.apply_plan`, `PlanApplier.apply_plan`, and
+`execute_run(operation="apply")` each refuse without one. Tests pass an explicit fake; a
+boundary that could be absent would be absent exactly when it mattered.
+
+One run admits one write. The reservation is decided inside a single store transaction on
+the run's own locked row, before either competitor can submit anything to Prefect: a write
+needs the run quiet — no existing admission, no other unresolved submission, no unfinished
+execution — and a read needs a run that has admitted no write. The loser keeps a durable `409
+run-execution-conflict` on its own receipt, so replaying its client key replays the refusal.
+Each execution names the unresolved receipt that appended it, uniquely, so the admitted
+receipt spends its admission exactly once.
+
+A write that may have started ends in a verdict. One in-memory Boolean, owned by the worker
+that ran the stage, separates a failure that certainly wrote nothing from one that may have.
+Before the first proven dispatch a failure is an ordinary failed run. After it, every
+non-success outcome — an adapter failure, a lost session, a failed final proof, a failed
+applied sidecar, cancellation, or losing the worker entirely — is `interrupted` /
+`ambiguous`, and `product_runs.reconciliation_required` is set in the same transaction that
+makes the execution terminal. That column is derived from the verdict and the execution's
+purpose rather than passed in, so no caller can write it false, and nothing clears it.
+
+The operator reconciles by planning again. An empty diff shows the desired state is already
+present; anything else is reviewed and applied as a new run.
+
+Two mechanisms were removed rather than kept beside the guard. The managed write path no
+longer takes the local pipeline lock, because two correctness guards for one property means
+neither is the answer. The composed `execute_run(operation="sync")` writer is refused
+outright: it derives its own plan and applies it in one call, so it can offer no
+per-operation proof over a reviewed artifact, and keeping it would have left an unguarded
+write path in the package.
+
+## Consequences
+
+A configuration's writes are serialized across processes and hosts, and the guard is a
+provider fact rather than a repository convention: it requires a direct, session-mode
+PostgreSQL connection, and transaction-mode PgBouncer is unsupported.
+
+Contention is a clean refusal — nothing read, nothing written, no ambiguity — but its remedy
+is a new plan, because another writer may have changed the destination while this one waited.
+
+An uncertain run is terminal. There is no replay, no recovery service, and no endpoint that
+clears the reconciliation column; an operator inspects the destination and plans again.
+That is deliberate under-automation: every automatic answer requires knowing what reached
+the destination, which is exactly what an uncertain write does not know.
+
+The direct Prefect remote-run deployment is now plan-only. The Sync HTTP API is the
+supported write boundary.
+
+Pre-release V3 development databases are recreated rather than migrated across the new
+column and the receipt-owned execution link.
+
+## Alternatives considered
+
+**A write-attempt table with generations**, so a failed write could be retried under a new
+attempt. It answers the wrong question: the record would say how many attempts happened, not
+what reached the destination, and the retry it enables is the unsafe step.
+
+**Proving ownership once, at acquisition.** A session can die mid-write, so the proof would
+be stale exactly when it mattered — and the engine would keep dispatching against a key it
+no longer held.
+
+**An optional guard, defaulting to absent for existing callers.** Every unguarded write path
+that survived would be the one a deployment used, and the absence would be invisible until a
+concurrent write corrupted a destination.
+
+**Keeping the local pipeline lock alongside the guard.** A filesystem lock cannot serialize
+workers that share no filesystem, so it would have added failure modes without adding
+exclusion.

--- a/dev/adr/README.md
+++ b/dev/adr/README.md
@@ -1,7 +1,7 @@
-# Decision Records (ADRs)
+# Decision records
 
 MADR-format decision records. Name each file `nnnn-title.md`: a zero-padded 4-digit
-sequence and a lowercase kebab-case title, no `adr-` prefix (e.g. `0001-use-uv.md`).
+sequence and a lowercase kebab-case title, no `adr-` prefix, for example `0001-use-uv.md`.
 
 ## Current records
 
@@ -15,7 +15,7 @@ sequence and a lowercase kebab-case title, no `adr-` prefix (e.g. `0001-use-uv.m
   — why no whole-node re-render can flush a reconciled peer set, and the live test that pins the
   destination's replace semantics.
 - [0004 — Deletes are recorded but never executed](0004-deletes-are-recorded-but-never-executed.md)
-  — the delete contract and the knowability invariant that backs it.
+  — the delete contract and the rule that a plan may only record what it can know.
 - [0005 — Translate run failures only at the remote boundary](0005-translate-run-failures-only-at-the-remote-boundary.md)
   — how the shared execution surface gains typed sanitized failures without changing CLI
   behaviour.
@@ -24,11 +24,14 @@ sequence and a lowercase kebab-case title, no `adr-` prefix (e.g. `0001-use-uv.m
   the eager CLI lookup.
 - [0007 — A canonical plan fingerprint is the equivalence oracle between run paths](0007-canonical-plan-fingerprint-as-equivalence-oracle.md)
   — how "the remote path produced the same plan" becomes a testable claim.
-- [0008 — Declare redis directly instead of using the diffsync `[redis]` extra](0008-declare-redis-directly-instead-of-the-diffsync-extra.md)
+- [0008 — Declare Redis directly instead of using the diffsync extra](0008-declare-redis-directly-instead-of-the-diffsync-extra.md)
   — the dependency conflict that forced a base declaration change, and why the floor is
   permissive.
 - [0009 — Optional integrations live in their own package and are proven absent in CI](0009-optional-integrations-live-in-their-own-package.md)
   — the import boundary for an optional integration and the three mechanisms that enforce it.
+- [0010 — A managed write holds one configuration guard and ends in a verdict, not a retry](0010-a-managed-write-ends-in-a-verdict-not-a-retry.md)
+  — how a configuration's writes are serialized, why the ownership boundary is required rather
+  than optional, and why an uncertain write is terminal evidence instead of a retry.
 
 ## Related
 

--- a/docs/docs/reference/durable-product-records.mdx
+++ b/docs/docs/reference/durable-product-records.mdx
@@ -170,8 +170,18 @@ seams, not a public custom-provider compatibility contract.
 
 `ProductRun` owns the stable Sync `run_id`, requested operation, immutable configuration
 reference, actor and audit links, product phase and outcome, timings, summary and results,
-artifact references, and Prefect correlations. Relational child tables store artifact
-references and Prefect execution links separately from the compact run row.
+write-safety evidence, artifact references, and Prefect correlations. Relational child
+tables store artifact references and Prefect execution links separately from the compact
+run row.
+
+`reconciliation_required` is the run's one authoritative write-safety fact: a non-null
+Boolean, `false` on every new run, exposed directly on the public run resource rather than
+buried in `results`. It becomes `true` in the same transaction that makes a claimed apply or
+sync execution terminal as `interrupted` / `ambiguous` — whether that verdict is written by
+the worker itself, by liveness reconciliation, or by cancellation. The store derives the
+condition from the verdict and the execution's purpose rather than taking it as an argument,
+so no caller can write it `false`, and no result merge, replacement, or later terminal
+transition clears it.
 
 Each `PrefectExecutionLink` records:
 
@@ -184,8 +194,15 @@ Each `PrefectExecutionLink` records:
 Duplicate Sync run IDs and duplicate flow-run IDs within one record are rejected. A
 confirmed sync creates its own record. A reviewed-plan apply instead advances the original
 planning record and attaches its result artifacts to the same `run_id`; it does not create
-a second Sync identity. `add_prefect_execution` appends stage and retry links as they become
-known without changing the Sync record's identity.
+a second Sync identity. `add_prefect_execution` appends stage links as they become known
+without changing the Sync record's identity.
+
+Every execution link names the unresolved mutation receipt that appended it, through an
+internal uniquely-constrained column that appears in no public resource. That relation is
+the one-append rule: a receipt appends at most one execution, an execution belongs to a
+submission still in flight, a write append additionally requires the run's write-admission
+row to name that exact receipt and that exact operation, and a run holding a write admission
+accepts no further append at all.
 
 Mutations against a missing Sync run raise `RunNotFoundError`. Read operations continue
 to return `LookupResult` with `reason="run-not-found"`, so absence remains a normal,
@@ -200,7 +217,17 @@ Sync API mutations reserve a `MutationReceipt` unique by actor and SHA-256 diges
 client idempotency key. A receipt binds the operation, target, request fingerprint, reason,
 Sync run, opaque Prefect key, state, and exact accepted response. The raw client key is not
 stored. Run creation commits its receipt and unfinished product run in one relational
-transaction. `AuditEvent` records secret-safe actor, reason, operation, and outcome evidence
+transaction.
+
+Reserving a stage against an existing run arbitrates it in that same transaction, after
+locking the run's authoritative row: a write reservation requires no existing write
+admission, no other unresolved plan, verify, apply, or sync receipt, and no unfinished
+execution, while a plan or verify reservation requires only that no write has been admitted.
+A cancellation is deliberately outside this arbitration, so a claimed write stays
+cancellable. A losing request never reaches Prefect; its receipt is stored already answered,
+carrying `409 run-execution-conflict`, so replaying that client key replays the refusal. An
+accepted run receipt therefore carries a Prefect flow-run ID only when its stored response is
+a successful submission. `AuditEvent` records secret-safe actor, reason, operation, and outcome evidence
 for accepted mutations and refusals.
 
 `record_results` updates retained result evidence without changing product phase, outcome,

--- a/docs/docs/reference/prefect-remote-run.mdx
+++ b/docs/docs/reference/prefect-remote-run.mdx
@@ -2,9 +2,15 @@
 title: Prefect remote run
 ---
 
-`infrahub-sync` ships an optional Prefect integration that exposes one sync run as a
-Prefect deployment, so a plan or a sync can be started and observed over Prefect's own
-REST API instead of by shelling out to the CLI.
+`infrahub-sync` ships an optional Prefect integration that exposes one read-only plan run
+as a Prefect deployment, so a plan can be started and observed over Prefect's own REST API
+instead of by shelling out to the CLI.
+
+This deployment does not write. `operation="sync"` is refused, because a composed sync
+derives its own plan and applies it in one call and can therefore prove nothing about who
+owns the destination between its operations. Writes go through the
+[Sync HTTP API](./sync-http-api.mdx), which reviews a plan and then applies it while
+holding the registered configuration's write guard.
 
 The flow parameters, returned result fields, and summary log line form the remote-run
 contract. Changes may extend that contract, but must not silently reshape existing fields.
@@ -91,8 +97,8 @@ a credential, or an environment override.
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
 | `sync_name` | `str` | required | Logical name of a configuration in `INFRAHUB_SYNC_CONFIG_DIRECTORY`, matched by exact string equality. |
-| `operation` | `"plan"` or `"sync"` | `"plan"` | `plan` is read-only and maps to the CLI `diff` lifecycle; `sync` writes. |
-| `confirm_writes` | `bool` | `false` | Must be `true` for `operation="sync"`. Has no effect on a plan. |
+| `operation` | `"plan"` or `"sync"` | `"plan"` | Only `plan` runs here. It is read-only and maps to the CLI `diff` lifecycle. `sync` is refused; see below. |
+| `confirm_writes` | `bool` | `false` | Retained for the parameter contract. It has no effect on a plan, and cannot make `sync` runnable here. |
 | `branch` | `str` or `null` | `null` | Infrahub branch, forwarded exactly as the CLI `--branch` option. Used only when the configuration's own `settings.branch` is unset — a configured branch takes precedence over this parameter. With neither set, `main` is used. |
 
 Credentials and endpoints stay in the runner's environment. They are never accepted as
@@ -106,12 +112,13 @@ replaced, because replacing a shorter value can corrupt ordinary message text
 lab-grade `CISCO_APIC_PASSWORD=admin` — is therefore not redacted from a failure message.
 Use credentials of realistic length on any runner whose logs are not private.
 
-### The confirm-writes gate
+### The write gate
 
-`operation="sync"` without `confirm_writes=true` fails before either adapter is loaded
-and before anything is read or written: the flow run ends `FAILED` with a state message
-explaining that `confirm_writes=true` is required. The same gate applies to any
-programmatic caller of the shared execution surface, not only to remote runs.
+`operation="sync"` fails before either adapter is loaded and before anything is read or
+written, whatever `confirm_writes` says: the flow run ends `FAILED` with a state message
+saying the composed sync writer is not supported here and to compose plan, verify, and apply
+through the Sync API. The same gate applies to any programmatic caller of the shared
+execution surface, not only to remote runs.
 
 An `operation` value other than `plan` or `sync` is rejected by Prefect's parameter
 validation when the run is created — the API returns `409` and no flow run is created, so
@@ -132,25 +139,10 @@ A successful run returns exactly these fields:
 | `artifact_path` | `str` | Absolute path of the run directory **on the runner host** |
 
 `changed` is true exactly when `status` is not `no-change`, and exactly when the summary
-counts sum to more than zero. `status="planned"` occurs only for a plan and
-`status="applied"` only for a sync. `artifact_path` holds the ordinary sync artifacts
-(`run.json`, `plan.parquet`); those files are local to the runner and are not retrievable
-through Prefect.
-
-:::warning `changed` is not "the destination was written"
-
-`changed` reports what the run **materialized as plan rows**, not whether the destination
-was written. The two can disagree in one case: the engine gates a sync on a recursive
-difference check, while the plan materializes only the diff root's direct children. A
-difference that exists solely in nested child elements therefore lets the sync run — and
-write — while materializing zero rows, so the result comes back
-`status="no-change"`, `changed=false`, and an all-zero `summary`.
-
-Do not read `changed=false` as "the destination was not touched". For a definitive
-account of what a run did, read the artifacts under `artifact_path` on the runner host.
-This is a known limit of the direct Prefect deployment.
-
-:::
+counts sum to more than zero. A plan returns `planned` when it materialized rows and
+`no-change` when it did not. `artifact_path` holds the ordinary run artifacts (`run.json`,
+`plan.parquet`); those files are local to the runner and are not retrievable through
+Prefect.
 
 ### Reading the result remotely
 
@@ -173,8 +165,7 @@ originating logger name preserved.
 | Prefect state | `status` | `run.json` `status` | Meaning |
 |---|---|---|---|
 | `COMPLETED` | `planned` | `dry-run` | Plan with changes; nothing was written |
-| `COMPLETED` | `no-change` | `dry-run` (plan) or `applied` (sync) | The run materialized no plan rows — normally because the destination already matches the source, but see the `changed` warning above for the nested-difference case in which a sync writes and still reports `no-change` |
-| `COMPLETED` | `applied` | `applied` | Sync that wrote the changes |
+| `COMPLETED` | `no-change` | `dry-run` | The plan materialized no rows, normally because the destination already matches the source |
 | `FAILED` | no result returned | `failed`, or no run directory when the refusal precedes execution | Validation refusal or execution failure; the sanitized cause is the Prefect state message |
 
 ## Scope and limitations

--- a/docs/docs/reference/sync-http-api.mdx
+++ b/docs/docs/reference/sync-http-api.mdx
@@ -356,8 +356,56 @@ for a new intent.
 The first confirmed composed `sync` or reviewed `apply` permanently consumes that run's
 single write admission, including when the execution later fails, crashes, or is cancelled.
 Retry an uncertain request with its original idempotency key. To make another write attempt
-after a terminal failure or cancellation, create and review a new plan run; a new key on the
-old run returns `409 apply-already-admitted`.
+after a terminal failure or cancellation, create and review a new plan run.
+
+A run admits its one write only while nothing else is in flight on it: no other write
+admission, no other unresolved plan, verify, apply, or sync submission, and no unfinished
+execution. Whichever request wins is decided before either competitor is submitted to
+Prefect, so the loser never starts work. It is answered with `409 run-execution-conflict`
+stored on its own receipt, and replaying that idempotency key replays the refusal. Once a
+run has admitted its write, every later plan, verify, apply, and sync submission on that run
+gets the same refusal — including after the write becomes terminal, because terminal write
+evidence is not reopened.
+
+A submission stays unresolved until it has a stored response, a stored refusal included. If
+a client abandons one — the process dies before it reads the reply, and the key is never
+replayed — that run cannot admit another stage. There is no receipt-expiry mechanism; create
+a new plan or sync run instead.
+
+## Write safety and reconciliation
+
+A managed apply or sync holds one PostgreSQL advisory guard for the registered configuration
+it writes, so two workers cannot write the same configuration at once. The guard is held
+across the destination-sensitive checks and the whole write loop, and its release is
+confirmed before any success is published.
+
+Public run resources carry `reconciliation_required`. It is `false` on every new run and
+becomes `true` only when a write execution ends without proving what reached the
+destination. Nothing sets it back to `false`.
+
+| What happened | Durable outcome | Your next step |
+| --- | --- | --- |
+| Another writer held the guard for the whole deadline | `failed`; no destination was contacted and nothing was written | Create a new plan: the other writer may have changed the destination |
+| A destination-sensitive check failed under the guard | The existing specific refusal; nothing was written | Fix the cause and create a new plan |
+| The adapter failed after the first operation was dispatched | `interrupted` / `ambiguous`, `reconciliation_required: true`, with the partial `ApplyRecord` in the retained results | Inspect the destination, then create a new plan |
+| You cancelled a run whose worker already held the write | `interrupted` / `ambiguous`, `reconciliation_required: true`; the cancel request answers `409 cancellation-ambiguous` | Inspect the destination, then create a new plan |
+| The worker or its guard session was lost | `interrupted` / `ambiguous`, `reconciliation_required: true` | Inspect the destination, then create a new plan |
+| The run completed normally | The existing succeeded result | Nothing; this run accepts no further write |
+
+Cancellation is not a clean-stop guarantee for a write. A worker that has already begun
+dispatching may have changed the destination before the cancellation reached it, so Sync
+records the conservative answer rather than a cancelled one — unless the normal completion
+path won first.
+
+### Reconcile an uncertain write
+
+Sync never calls an adapter or infers success after an uncertain result, and there is no
+endpoint that clears `reconciliation_required`. Reconcile by planning again:
+
+1. create a new plan run on the same registered configuration;
+2. read its summary. An empty diff means the desired state is already present, and the
+   uncertain run in fact completed its work; and
+3. otherwise review the remaining operations and apply that new plan.
 
 ## Errors and retained state
 
@@ -380,7 +428,7 @@ Every error uses the same envelope:
 | `401` | Missing or invalid authentication. |
 | `403` | The actor does not own the mutation and is not an administrator. |
 | `404` | The Sync run or run-owned artifact does not exist. |
-| `409` | Idempotency conflict, missing confirmation, stale checksum, or non-cancellable execution. |
+| `409` | Idempotency conflict, missing confirmation, stale checksum, non-cancellable execution, a run that cannot admit another stage (`run-execution-conflict`), or a cancelled write whose outcome is uncertain (`cancellation-ambiguous`). |
 | `410` | The retained plan or artifact has expired. |
 | `422` | Invalid request schema, missing idempotency key, or a secret-bearing flow parameter. |
 | `503` | Submission, live orchestration detail, or retained data cannot be confirmed or retrieved. |

--- a/infrahub_sync/client/models.py
+++ b/infrahub_sync/client/models.py
@@ -187,6 +187,9 @@ class PublicRunResource(_ResourceModel):
     outcome: str | None = None
     summary: dict[str, Any] = Field(default_factory=dict)
     results: dict[str, Any] = Field(default_factory=dict)
+    # Exposed directly rather than through ``results``: an operator deciding whether a run
+    # needs reconciling must not have to parse failure evidence to find out.
+    reconciliation_required: bool = False
     artifact_refs: tuple[ArtifactReferenceResource, ...] = ()
     prefect_executions: tuple[PublicExecutionLink, ...] = ()
 

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -25,7 +25,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from timeit import default_timer as timer
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
@@ -58,8 +57,8 @@ from infrahub_sync.utils import PlanApplier, get_potenda_from_instance
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
-    from typing import NoReturn
 
+    from infrahub_sync.plan.ownership import WriteOwnership
     from infrahub_sync.plan.review import SavedPlan
     from infrahub_sync.potenda import Potenda
 
@@ -673,72 +672,6 @@ def _run_plan_lifecycle(*, ptd: Potenda, run_file: RunFile, print_diff: bool) ->
     return _summary_from_plan_write(write_result, lambda: ptd._diff_to_rows(mydiff))
 
 
-def _run_sync_lifecycle(
-    *,
-    ptd: Potenda,
-    run_file: RunFile,
-    print_diff: bool,
-    allow_rowcount_drop: bool,
-    serial_load_error: Callable[[ValueError], NoReturn] | None,
-    plan_committed: Callable[[], None] | None,
-) -> dict[ActionKey, int]:
-    """Reproduce the CLI serial `sync` lifecycle and return its live diff-row counts."""
-    try:
-        ptd.load_both_sides()
-    except ValueError as exc:
-        if serial_load_error is not None:
-            # CLI-only seam: the unprefixed abort fires at the site, exactly as
-            # cli.py:265-268 does today.
-            serial_load_error(exc)
-        raise
-    ptd.check_rowcount_guardrail(allow_drop=allow_rowcount_drop)
-    mydiff = ptd.diff()
-    write_result = ptd.write_plan(mydiff)
-    _validated_plan_write_summary(write_result)
-    if plan_committed is not None:
-        plan_committed()
-    if mydiff.has_diffs():
-        if print_diff:
-            logger.info("\n%s", mydiff.str())
-        start_synctime = timer()
-        ptd.sync(diff=mydiff)
-        end_synctime = timer()
-        logger.info("Sync: Completed in %s sec", end_synctime - start_synctime)
-    else:
-        logger.info("No difference found. Nothing to sync")
-    ptd.persist_baseline_counts()
-    run_file.summary = {"resources": len(ptd.top_level), "mode": "serial"}
-    run_file.status = "applied"
-    return _summarize_rows(ptd._diff_to_rows(mydiff))
-
-
-def _run_parallel_sync_lifecycle(
-    *,
-    ptd: Potenda,
-    run_file: RunFile,
-    allow_rowcount_drop: bool,
-    parallel_sync_error: Callable[[ValueError], NoReturn] | None,
-    plan_committed: Callable[[], None] | None,
-) -> dict[ActionKey, int]:
-    """Run the established tier-parallel lifecycle and return its plan counts."""
-    try:
-        if plan_committed is None:
-            summary = ptd.sync_in_tiers(parallel=True, allow_rowcount_drop=allow_rowcount_drop)
-        else:
-            summary = ptd.sync_in_tiers(
-                parallel=True,
-                allow_rowcount_drop=allow_rowcount_drop,
-                plan_committed=plan_committed,
-            )
-    except ValueError as exc:
-        if parallel_sync_error is not None:
-            parallel_sync_error(exc)
-        raise
-    run_file.summary = {"resources": len(ptd.top_level), "mode": "parallel"}
-    run_file.status = "applied"
-    return {action: summary[action] for action in ACTION_KEYS}
-
-
 def _require_a_free_run_id(*, sync_name: str, run_id: str | None) -> None:
     """Refuse a plan generation that would overwrite a committed saved plan."""
     if run_id is None:
@@ -885,7 +818,7 @@ def _read_verified_plan(*, sync_instance: SyncInstance, run_id: str) -> SavedPla
     return saved
 
 
-def _run_apply_lifecycle(
+def _run_apply_lifecycle(  # pylint: disable=too-many-arguments
     *,
     sync_instance: SyncInstance,
     run_id: str,
@@ -893,6 +826,7 @@ def _run_apply_lifecycle(
     verbosity: int,
     allow_destination_change: bool,
     expected_checksum: str | None,
+    ownership: WriteOwnership,
     _plan_applier_factory: Callable[..., PlanApplier] | None,
     run_directory: Path,
     sidecar_mode: Literal["sync", "apply"],
@@ -910,6 +844,7 @@ def _run_apply_lifecycle(
     _save_run_transition(run_directory, mode=sidecar_mode, status="running", run_file=run_file)
     try:
         record = applier.apply_plan(
+            ownership=ownership,
             allow_destination_change=allow_destination_change,
             expected_checksum=expected_checksum,
         )
@@ -927,8 +862,11 @@ def _run_apply_lifecycle(
 
     try:
         _save_run_transition(run_directory, mode=sidecar_mode, status="applied", record=record, run_file=run_file)
-    except BaseException:
+    except BaseException as exc:
+        # Everything the loop applied is already written; a sidecar that could not record
+        # that must not make the completed record unreadable to the failure boundary.
         _save_failed_run(run_directory, mode=sidecar_mode, record=record, run_file=run_file)
+        exc.apply_record = record  # ty: ignore[unresolved-attribute]
         raise
     return _build_result(
         sync_instance=sync_instance,
@@ -990,6 +928,7 @@ def _execute_apply_operation(
     verbosity: int,
     allow_destination_change: bool,
     expected_checksum: str | None,
+    ownership: WriteOwnership,
     plan_applier_factory: Callable[..., PlanApplier] | None,
     lock_timeout: float,
     lock_already_held: bool,
@@ -1015,22 +954,35 @@ def _execute_apply_operation(
             verbosity=verbosity,
             allow_destination_change=allow_destination_change,
             expected_checksum=expected_checksum,
+            ownership=ownership,
             _plan_applier_factory=plan_applier_factory,
             run_directory=run_directory,
             sidecar_mode=sidecar_mode,
         )
 
 
-def _validate_operation_request(*, operation: Operation, confirm_writes: bool, run_id: str | None) -> None:
+def _validate_operation_request(
+    *, operation: Operation, confirm_writes: bool, run_id: str | None, ownership: WriteOwnership | None
+) -> None:
     """Refuse invalid operation inputs before any adapter or run state is constructed."""
     if operation not in OPERATIONS:
         msg = f"Unsupported operation {operation!r} — expected one of {OPERATIONS!r}"
         raise RunValidationError(msg)
-    if operation in ("sync", "apply") and not confirm_writes:
+    if operation == "sync":
+        # The composed sync writer is not a supported entry point: it produces its own plan
+        # and applies it in one call, so it can offer no per-operation ownership proof over
+        # a reviewed artifact. The Sync HTTP API composes plan, verify, and apply instead,
+        # holding one configuration write guard across them.
+        msg = "operation=sync is not supported here; compose plan, verify, and apply through the Sync API"
+        raise RunValidationError(msg)
+    if operation == "apply" and not confirm_writes:
         msg = f"confirm_writes=true is required to run operation={operation}"
         raise RunValidationError(msg)
     if operation in ("verify", "apply") and run_id is None:
         msg = f"run_id is required to run operation={operation}"
+        raise RunValidationError(msg)
+    if operation == "apply" and ownership is None:
+        msg = "an explicit write-ownership boundary is required to run operation=apply"
         raise RunValidationError(msg)
 
 
@@ -1051,9 +1003,7 @@ def execute_run(
 
 
 @overload
-def execute_run(
-    sync_instance: SyncInstance, *, operation: Literal["plan", "sync", "apply"], **kwargs: Any
-) -> RunResult: ...
+def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan", "apply"], **kwargs: Any) -> RunResult: ...
 
 
 @overload
@@ -1072,37 +1022,39 @@ def execute_run(
     run_id: str | None = None,
     concurrent_load: bool = True,
     full_extract: bool = True,
-    allow_rowcount_drop: bool = False,
     continue_on_error: bool = False,
     print_diff: bool = True,
     potenda_factory: PotendaFactory | None = None,
-    parallel: bool = False,
     allow_destination_change: bool = False,
     expected_checksum: str | None = None,
+    ownership: WriteOwnership | None = None,
     # Private seams — not part of the remote contract; run_remote_request never sets them.
     _plan_applier_factory: Callable[..., PlanApplier] | None = None,
     _lock_timeout: float = 60.0,
-    _serial_load_error: Callable[[ValueError], NoReturn] | None = None,
-    _parallel_sync_error: Callable[[ValueError], NoReturn] | None = None,
     _lock_already_held: bool = False,
     _run_file_mode: Literal["diff", "sync"] | None = None,
     _require_verified: bool = False,
     _return_saved_plan: bool = False,
-    _plan_committed: Callable[[], None] | None = None,
 ) -> RunResult | SavedPlan:
     """Run one product operation against a resolved instance.
 
-    The core owns all write-capable locks and all run-sidecar transitions.  The
-    CLI remains responsible only for argument parsing and rendering, so the
-    existing command-specific failure shapes stay at that boundary.
+    The core owns all run-sidecar transitions.  The CLI remains responsible only
+    for argument parsing and rendering, so the existing command-specific failure
+    shapes stay at that boundary.
+
+    An apply writes to a destination, so it requires `ownership`: the boundary that
+    proves this process still holds the right to write this configuration. The
+    parameter is optional in the signature only because plan and verify do not write;
+    an apply without one is refused before anything is constructed.
 
     Raises:
         RunConcurrencyError: the same synchronization remains locked after the
             bounded wait, with advisory context from the latest running sidecar.
-        RunValidationError: an unsupported operation, a missing saved-plan id,
-            or an unconfirmed write (all refused before an adapter is built).
+        RunValidationError: an unsupported operation, a composed sync write, a
+            missing saved-plan id, an unconfirmed write, or an apply with no
+            write-ownership boundary (all refused before an adapter is built).
     """
-    _validate_operation_request(operation=operation, confirm_writes=confirm_writes, run_id=run_id)
+    _validate_operation_request(operation=operation, confirm_writes=confirm_writes, run_id=run_id, ownership=ownership)
 
     if operation == "verify":
         assert run_id is not None  # narrowed above; verification never allocates a run.
@@ -1115,6 +1067,7 @@ def execute_run(
 
     if operation == "apply":
         assert run_id is not None  # narrowed above; keeps the saved-plan boundary explicit.
+        assert ownership is not None  # narrowed above; an apply never runs unguarded.
         return _execute_apply_operation(
             sync_instance=sync_instance,
             run_id=run_id,
@@ -1122,25 +1075,24 @@ def execute_run(
             verbosity=verbosity,
             allow_destination_change=allow_destination_change,
             expected_checksum=expected_checksum,
+            ownership=ownership,
             plan_applier_factory=_plan_applier_factory,
             lock_timeout=_lock_timeout,
             lock_already_held=_lock_already_held,
             run_file_mode=_run_file_mode,
         )
 
-    if operation == "plan":
-        _require_a_free_run_id(sync_name=sync_instance.name, run_id=run_id)
+    _require_a_free_run_id(sync_name=sync_instance.name, run_id=run_id)
 
     run_lock: AbstractContextManager[None] = (
         nullcontext() if _lock_already_held else _run_lock(sync_instance.name, timeout=_lock_timeout)
     )
     with run_lock:
-        if operation == "plan":
-            # A plan may have been committed while this command waited for the lock.
-            _require_a_free_run_id(sync_name=sync_instance.name, run_id=run_id)
+        # A plan may have been committed while this command waited for the lock.
+        _require_a_free_run_id(sync_name=sync_instance.name, run_id=run_id)
         factory: PotendaFactory = potenda_factory if potenda_factory is not None else get_potenda_from_instance
         # Pinned call shape: all seven keyword arguments of
-        # utils.get_potenda_from_instance, always explicitly, for both operations.
+        # utils.get_potenda_from_instance, always explicitly.
         ptd = factory(
             sync_instance=sync_instance,
             branch=branch,
@@ -1154,7 +1106,7 @@ def execute_run(
         if ptd.run_dir is None:  # get_potenda_from_instance always allocates one
             msg = "get_potenda_from_instance did not allocate a run_dir"
             raise RuntimeError(msg)
-        run_mode: Literal["diff", "sync"] = _run_file_mode or ("diff" if operation == "plan" else "sync")
+        run_mode: Literal["diff", "sync"] = _run_file_mode or "diff"
         run_file = RunFile(
             path=ptd.run_dir / "run.json",
             status="running",
@@ -1164,31 +1116,8 @@ def execute_run(
 
         saved_plan: SavedPlan | None = None
         try:
-            if operation == "plan":
-                summary = _run_plan_lifecycle(ptd=ptd, run_file=run_file, print_diff=print_diff)
-            elif parallel and ptd.tiers:
-                summary = _run_parallel_sync_lifecycle(
-                    ptd=ptd,
-                    run_file=run_file,
-                    allow_rowcount_drop=allow_rowcount_drop,
-                    parallel_sync_error=_parallel_sync_error,
-                    plan_committed=_plan_committed,
-                )
-            else:
-                if parallel and not ptd.tiers:
-                    logger.warning(
-                        "--parallel ignored because order: is set in config.yml; "
-                        "remove order: to enable tier-by-tier execution",
-                    )
-                summary = _run_sync_lifecycle(
-                    ptd=ptd,
-                    run_file=run_file,
-                    print_diff=print_diff,
-                    allow_rowcount_drop=allow_rowcount_drop,
-                    serial_load_error=_serial_load_error,
-                    plan_committed=_plan_committed,
-                )
-            if operation == "plan" and _return_saved_plan:
+            summary = _run_plan_lifecycle(ptd=ptd, run_file=run_file, print_diff=print_diff)
+            if _return_saved_plan:
                 saved_plan = read_saved_plan(sync_name=sync_instance.name, run_id=str(ptd.run_id), config=sync_instance)
 
             run_file.finished_at = datetime.now(timezone.utc).isoformat()
@@ -1200,10 +1129,7 @@ def execute_run(
             # This broad except is that existing pattern, not new looseness.
             _save_failed_run(ptd.run_dir, mode=run_mode, run_file=run_file)
             raise
-        if operation == "plan":
-            logger.info("Cached run %s at %s", ptd.run_id, ptd.run_dir)
-        else:
-            logger.info("Sync run %s at %s", ptd.run_id, ptd.run_dir)
+        logger.info("Cached run %s at %s", ptd.run_id, ptd.run_dir)
         if saved_plan is not None:
             return saved_plan
         return _build_result(sync_instance=sync_instance, operation=operation, ptd=ptd, summary=summary)

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -721,13 +721,6 @@ def _run_lock(sync_name: str, *, timeout: float) -> Iterator[None]:
         yield
 
 
-@contextmanager
-def bounded_run_lock(sync_name: str, *, timeout: float = 60.0) -> Iterator[None]:
-    """Expose the shared bounded run lock to in-process product compositions."""
-    with _run_lock(sync_name, timeout=timeout):
-        yield
-
-
 def _require_applicable_plan(*, sync_name: str, run_id: str) -> Path:
     """Locate an existing saved plan before constructing an apply destination."""
     directory = require_stored_run(sync_name, run_id)

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
 import pydantic
 import yaml
@@ -97,6 +97,11 @@ class PotendaFactory(Protocol):
 
 
 OPERATIONS: tuple[Operation, ...] = ("plan", "sync", "verify", "apply")
+# The composed sync writer is not a supported entry point: it produces its own plan and
+# applies it in one call, so it can offer no per-operation ownership proof over a reviewed
+# artifact. The Sync HTTP API composes plan, verify, and apply instead, holding one
+# configuration write guard across them. Named because both entry points state it.
+SYNC_UNSUPPORTED = "operation=sync is not supported here; compose plan, verify, and apply through the Sync API"
 ACTION_KEYS: tuple[ActionKey, ...] = ("create", "update", "delete")
 
 REDACTED = "***"
@@ -978,12 +983,7 @@ def _validate_operation_request(
         msg = f"Unsupported operation {operation!r} — expected one of {OPERATIONS!r}"
         raise RunValidationError(msg)
     if operation == "sync":
-        # The composed sync writer is not a supported entry point: it produces its own plan
-        # and applies it in one call, so it can offer no per-operation ownership proof over
-        # a reviewed artifact. The Sync HTTP API composes plan, verify, and apply instead,
-        # holding one configuration write guard across them.
-        msg = "operation=sync is not supported here; compose plan, verify, and apply through the Sync API"
-        raise RunValidationError(msg)
+        raise RunValidationError(SYNC_UNSUPPORTED)
     if operation == "apply" and not confirm_writes:
         msg = f"confirm_writes=true is required to run operation={operation}"
         raise RunValidationError(msg)
@@ -1028,16 +1028,13 @@ def execute_run(
 # `apply` is deliberately absent from the remaining overloads: it is the only operation that
 # writes, so the type checker — not just the runtime refusal below — is what rejects an apply
 # with no write-ownership boundary.
+#
+# `sync` is absent for the same reason, one step further: it is accepted only to be refused,
+# so no overload can honestly name what it returns. Leaving it out makes the type checker say
+# so at the call site, and keeps the runtime refusal below as the answer for callers that are
+# not type-checked at all.
 @overload
 def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan"], **kwargs: Any) -> RunResult: ...
-
-
-# `sync` is accepted and then always refused, so `NoReturn` is the honest return type: this
-# call has no successful result to hand back. Stating it keeps `run_remote_request` able to
-# forward `sync` — its typed refusal is the intended behaviour — without the signature
-# promising a `RunResult` no caller can ever receive.
-@overload
-def execute_run(sync_instance: SyncInstance, *, operation: Literal["sync"], **kwargs: Any) -> NoReturn: ...
 
 
 def execute_run(
@@ -1255,22 +1252,26 @@ def run_remote_request(
     shared_secrets = _REMOTE_SECRET_VALUES.get()
     if shared_secrets is not None:
         shared_secrets[:] = secrets
+    if operation == "sync":
+        # Stated here as well as inside `execute_run`, because `sync` has no overload to
+        # forward to: this parameter still accepts it, and a remote caller that asks for one
+        # gets the same refusal it has always got. Ahead of the boundary rather than inside
+        # it because a `RunValidationError` crosses that boundary unchanged, and an
+        # unsupported request is refusable without resolving any configuration first.
+        raise RunValidationError(SYNC_UNSUPPORTED)
     try:
         sync_instance = resolve_sync_instance(sync_name, directory=config_directory)
         secrets = collect_secret_values(sync_instance)
         if shared_secrets is not None:
             shared_secrets[:] = secrets
-        return cast(
-            "RunResult",
-            execute_run(
-                sync_instance,
-                operation=operation,
-                confirm_writes=confirm_writes,
-                branch=branch,
-                show_progress=False,
-                potenda_factory=factory,
-                _lock_timeout=_lock_timeout,
-            ),
+        return execute_run(
+            sync_instance,
+            operation=operation,
+            confirm_writes=confirm_writes,
+            branch=branch,
+            show_progress=False,
+            potenda_factory=factory,
+            _lock_timeout=_lock_timeout,
         )
     except RunValidationError:
         raise

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -820,6 +820,7 @@ def _run_apply_lifecycle(  # pylint: disable=too-many-arguments
     allow_destination_change: bool,
     expected_checksum: str | None,
     ownership: WriteOwnership,
+    record_applied: Callable[[ApplyRecord], None],
     _plan_applier_factory: Callable[..., PlanApplier] | None,
     run_directory: Path,
     sidecar_mode: Literal["sync", "apply"],
@@ -855,8 +856,10 @@ def _run_apply_lifecycle(  # pylint: disable=too-many-arguments
 
     # Reported to the write scope before anything else can fail: the sidecar write, the
     # guard's release, and the product success commit all happen after this point, and each
-    # of them is a failure after a dispatch that still has to say what was written.
-    ownership.record_applied(record)
+    # of them is a failure after a dispatch that still has to say what was written. The sink
+    # is separate from `ownership` on purpose — that boundary authorizes the write, and
+    # saying what the write did is not its question to answer.
+    record_applied(record)
     try:
         _save_run_transition(run_directory, mode=sidecar_mode, status="applied", record=record, run_file=run_file)
     except BaseException as exc:
@@ -926,6 +929,7 @@ def _execute_apply_operation(
     allow_destination_change: bool,
     expected_checksum: str | None,
     ownership: WriteOwnership,
+    record_applied: Callable[[ApplyRecord], None],
     plan_applier_factory: Callable[..., PlanApplier] | None,
     lock_timeout: float,
     lock_already_held: bool,
@@ -952,6 +956,7 @@ def _execute_apply_operation(
             allow_destination_change=allow_destination_change,
             expected_checksum=expected_checksum,
             ownership=ownership,
+            record_applied=record_applied,
             _plan_applier_factory=plan_applier_factory,
             run_directory=run_directory,
             sidecar_mode=sidecar_mode,
@@ -959,7 +964,12 @@ def _execute_apply_operation(
 
 
 def _validate_operation_request(
-    *, operation: Operation, confirm_writes: bool, run_id: str | None, ownership: WriteOwnership | None
+    *,
+    operation: Operation,
+    confirm_writes: bool,
+    run_id: str | None,
+    ownership: WriteOwnership | None,
+    record_applied: Callable[[ApplyRecord], None] | None,
 ) -> None:
     """Refuse invalid operation inputs before any adapter or run state is constructed."""
     if operation not in OPERATIONS:
@@ -980,6 +990,9 @@ def _validate_operation_request(
         raise RunValidationError(msg)
     if operation == "apply" and ownership is None:
         msg = "an explicit write-ownership boundary is required to run operation=apply"
+        raise RunValidationError(msg)
+    if operation == "apply" and record_applied is None:
+        msg = "a completion sink is required to run operation=apply"
         raise RunValidationError(msg)
 
 
@@ -1005,6 +1018,7 @@ def execute_run(
     *,
     operation: Literal["apply"],
     ownership: WriteOwnership,
+    record_applied: Callable[[ApplyRecord], None],
     **kwargs: Any,
 ) -> RunResult: ...
 
@@ -1038,6 +1052,7 @@ def execute_run(
     allow_destination_change: bool = False,
     expected_checksum: str | None = None,
     ownership: WriteOwnership | None = None,
+    record_applied: Callable[[ApplyRecord], None] | None = None,
     # Private seams — not part of the remote contract; run_remote_request never sets them.
     _plan_applier_factory: Callable[..., PlanApplier] | None = None,
     _lock_timeout: float = 60.0,
@@ -1064,7 +1079,13 @@ def execute_run(
             missing saved-plan id, an unconfirmed write, or an apply with no
             write-ownership boundary (all refused before an adapter is built).
     """
-    _validate_operation_request(operation=operation, confirm_writes=confirm_writes, run_id=run_id, ownership=ownership)
+    _validate_operation_request(
+        operation=operation,
+        confirm_writes=confirm_writes,
+        run_id=run_id,
+        ownership=ownership,
+        record_applied=record_applied,
+    )
 
     if operation == "verify":
         assert run_id is not None  # narrowed above; verification never allocates a run.
@@ -1078,6 +1099,7 @@ def execute_run(
     if operation == "apply":
         assert run_id is not None  # narrowed above; keeps the saved-plan boundary explicit.
         assert ownership is not None  # narrowed above; an apply never runs unguarded.
+        assert record_applied is not None  # narrowed above; an apply always reports what it did.
         return _execute_apply_operation(
             sync_instance=sync_instance,
             run_id=run_id,
@@ -1086,6 +1108,7 @@ def execute_run(
             allow_destination_change=allow_destination_change,
             expected_checksum=expected_checksum,
             ownership=ownership,
+            record_applied=record_applied,
             plan_applier_factory=_plan_applier_factory,
             lock_timeout=_lock_timeout,
             lock_already_held=_lock_already_held,

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, cast, overload
 
 import pydantic
 import yaml
@@ -854,17 +854,19 @@ def _run_apply_lifecycle(  # pylint: disable=too-many-arguments
         _save_failed_run(run_directory, mode=sidecar_mode, record=partial, run_file=run_file)
         raise
 
-    # Reported to the write scope before anything else can fail: the sidecar write, the
-    # guard's release, and the product success commit all happen after this point, and each
-    # of them is a failure after a dispatch that still has to say what was written. The sink
-    # is separate from `ownership` on purpose — that boundary authorizes the write, and
-    # saying what the write did is not its question to answer.
-    record_applied(record)
     try:
+        # Reported to the write scope before anything else can fail: the sidecar write, the
+        # guard's release, and the product success commit all happen after this point, and
+        # each of them is a failure after a dispatch that still has to say what was written.
+        # Inside this `try` so a sink that raises is itself such a failure, and reaches the
+        # same boundary carrying the same record. The sink is separate from `ownership` on
+        # purpose — that boundary authorizes the write, and saying what the write did is not
+        # its question to answer.
+        record_applied(record)
         _save_run_transition(run_directory, mode=sidecar_mode, status="applied", record=record, run_file=run_file)
     except BaseException as exc:
-        # Everything the loop applied is already written; a sidecar that could not record
-        # that must not make the completed record unreadable to the failure boundary.
+        # Everything the loop applied is already written; a sink or a sidecar that could not
+        # record that must not make the completed record unreadable to the failure boundary.
         _save_failed_run(run_directory, mode=sidecar_mode, record=record, run_file=run_file)
         exc.apply_record = record  # ty: ignore[unresolved-attribute]
         raise
@@ -1030,8 +1032,12 @@ def execute_run(
 def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan"], **kwargs: Any) -> RunResult: ...
 
 
+# `sync` is accepted and then always refused, so `NoReturn` is the honest return type: this
+# call has no successful result to hand back. Stating it keeps `run_remote_request` able to
+# forward `sync` — its typed refusal is the intended behaviour — without the signature
+# promising a `RunResult` no caller can ever receive.
 @overload
-def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan", "sync"], **kwargs: Any) -> RunResult: ...
+def execute_run(sync_instance: SyncInstance, *, operation: Literal["sync"], **kwargs: Any) -> NoReturn: ...
 
 
 def execute_run(

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -853,6 +853,10 @@ def _run_apply_lifecycle(  # pylint: disable=too-many-arguments
         _save_failed_run(run_directory, mode=sidecar_mode, record=partial, run_file=run_file)
         raise
 
+    # Reported to the write scope before anything else can fail: the sidecar write, the
+    # guard's release, and the product success commit all happen after this point, and each
+    # of them is a failure after a dispatch that still has to say what was written.
+    ownership.record_applied(record)
     try:
         _save_run_transition(run_directory, mode=sidecar_mode, status="applied", record=record, run_file=run_file)
     except BaseException as exc:
@@ -996,11 +1000,24 @@ def execute_run(
 
 
 @overload
-def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan", "apply"], **kwargs: Any) -> RunResult: ...
+def execute_run(
+    sync_instance: SyncInstance,
+    *,
+    operation: Literal["apply"],
+    ownership: WriteOwnership,
+    **kwargs: Any,
+) -> RunResult: ...
+
+
+# `apply` is deliberately absent from the remaining overloads: it is the only operation that
+# writes, so the type checker — not just the runtime refusal below — is what rejects an apply
+# with no write-ownership boundary.
+@overload
+def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan"], **kwargs: Any) -> RunResult: ...
 
 
 @overload
-def execute_run(sync_instance: SyncInstance, *, operation: Operation, **kwargs: Any) -> RunResult | SavedPlan: ...
+def execute_run(sync_instance: SyncInstance, *, operation: Literal["plan", "sync"], **kwargs: Any) -> RunResult: ...
 
 
 def execute_run(
@@ -1162,7 +1179,7 @@ def _missing_credential_hint(detail: str) -> str:
 
 def run_remote_request(
     sync_name: str,
-    operation: Operation = "plan",
+    operation: Literal["plan", "sync"] = "plan",
     confirm_writes: bool = False,
     branch: str | None = None,
     *,

--- a/infrahub_sync/plan/ownership.py
+++ b/infrahub_sync/plan/ownership.py
@@ -18,6 +18,11 @@ apply that returns cleanly can still fail while writing its sidecar, while relea
 guard, or while committing product success, and every one of those is a failure after a
 dispatch. Keeping the record on the scope, rather than on whichever exception happens to
 be unwinding, is what lets one exit path report all of them the same way.
+
+`WriteOwnership` deliberately stays two operations wide. It answers one question — does
+this process still hold the right to write — and reporting a result is a different
+concern; an apply hands its completed record to `WriteDispatchTracker.record_applied`
+through a separate sink, not through the interface that authorizes it.
 """
 
 from __future__ import annotations
@@ -42,9 +47,6 @@ class WriteOwnership(Protocol):
 
     def after_final_operation(self) -> None:
         """Prove the hold once more, after the last operation and before any success."""
-
-    def record_applied(self, record: ApplyRecord) -> None:
-        """Keep what the engine completed, for a failure that happens after it returns."""
 
 
 class WriteDispatchTracker:
@@ -94,7 +96,3 @@ class ProvenWriteOwnership:
     def after_final_operation(self) -> None:
         """Prove the hold after the last operation; this alone is not a dispatch."""
         self._prove()
-
-    def record_applied(self, record: ApplyRecord) -> None:
-        """Hand the engine's completed record to the scope's failure boundary."""
-        self._tracker.record_applied(record)

--- a/infrahub_sync/plan/ownership.py
+++ b/infrahub_sync/plan/ownership.py
@@ -7,10 +7,17 @@ dispatches and once after the last one. There is no default, no `None`, and no n
 implementation: an apply assembled without a boundary is refused where it is called,
 because a boundary that could be absent would be absent exactly when it mattered.
 
-`WriteDispatchTracker` is the one in-memory Boolean that separates "this failure certainly
-wrote nothing" from "this failure may have written something". It is process-local
-diagnostic state for one worker's own failure boundary — never a receipt, a durable row, a
-state machine, or an authority to replay anything.
+`WriteDispatchTracker` is what one worker's own failure boundary reads: the Boolean that
+separates "this failure certainly wrote nothing" from "this failure may have written
+something", and the `ApplyRecord` of what the engine actually did. Both are process-local
+diagnostic state — never a receipt, a durable row, a state machine, or an authority to
+replay anything.
+
+The record lives here because the window that needs it is wider than the engine call. An
+apply that returns cleanly can still fail while writing its sidecar, while releasing the
+guard, or while committing product success, and every one of those is a failure after a
+dispatch. Keeping the record on the scope, rather than on whichever exception happens to
+be unwinding, is what lets one exit path report all of them the same way.
 """
 
 from __future__ import annotations
@@ -19,6 +26,8 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from infrahub_sync.plan.models import ApplyRecord
 
 
 class WriteOwnership(Protocol):
@@ -34,21 +43,34 @@ class WriteOwnership(Protocol):
     def after_final_operation(self) -> None:
         """Prove the hold once more, after the last operation and before any success."""
 
+    def record_applied(self, record: ApplyRecord) -> None:
+        """Keep what the engine completed, for a failure that happens after it returns."""
+
 
 class WriteDispatchTracker:
-    """One worker's process-local record that a destination dispatch may have begun."""
+    """What one worker's failure boundary knows about its own destination writes."""
 
     def __init__(self) -> None:
         self._dispatch_started = False
+        self._applied_record: ApplyRecord | None = None
 
     @property
     def dispatch_started(self) -> bool:
         """Whether a proven dispatch has started, so a later failure is uncertain."""
         return self._dispatch_started
 
+    @property
+    def applied_record(self) -> ApplyRecord | None:
+        """What the engine completed, if it returned before anything else failed."""
+        return self._applied_record
+
     def record_dispatch(self) -> None:
         """Record that one destination operation is about to be dispatched."""
         self._dispatch_started = True
+
+    def record_applied(self, record: ApplyRecord) -> None:
+        """Keep the completed record so a later failure can still report it."""
+        self._applied_record = record
 
 
 class ProvenWriteOwnership:
@@ -72,3 +94,7 @@ class ProvenWriteOwnership:
     def after_final_operation(self) -> None:
         """Prove the hold after the last operation; this alone is not a dispatch."""
         self._prove()
+
+    def record_applied(self, record: ApplyRecord) -> None:
+        """Hand the engine's completed record to the scope's failure boundary."""
+        self._tracker.record_applied(record)

--- a/infrahub_sync/plan/ownership.py
+++ b/infrahub_sync/plan/ownership.py
@@ -1,0 +1,74 @@
+"""The write-ownership boundary every planned destination dispatch passes through.
+
+An apply executes a reviewed plan against a destination that another writer may also be
+holding. The engine cannot answer whether this process still owns that right — the answer
+belongs to whatever serializes writers — so it asks, immediately before every operation it
+dispatches and once after the last one. There is no default, no `None`, and no no-op
+implementation: an apply assembled without a boundary is refused where it is called,
+because a boundary that could be absent would be absent exactly when it mattered.
+
+`WriteDispatchTracker` is the one in-memory Boolean that separates "this failure certainly
+wrote nothing" from "this failure may have written something". It is process-local
+diagnostic state for one worker's own failure boundary — never a receipt, a durable row, a
+state machine, or an authority to replay anything.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class WriteOwnership(Protocol):
+    """The proof surface the apply engine requires around its destination dispatches."""
+
+    def before_operation(self) -> None:
+        """Prove this process still holds the write right, then record the dispatch.
+
+        Raises whatever the underlying hold raises. A failure here means the operation
+        about to be dispatched was not dispatched.
+        """
+
+    def after_final_operation(self) -> None:
+        """Prove the hold once more, after the last operation and before any success."""
+
+
+class WriteDispatchTracker:
+    """One worker's process-local record that a destination dispatch may have begun."""
+
+    def __init__(self) -> None:
+        self._dispatch_started = False
+
+    @property
+    def dispatch_started(self) -> bool:
+        """Whether a proven dispatch has started, so a later failure is uncertain."""
+        return self._dispatch_started
+
+    def record_dispatch(self) -> None:
+        """Record that one destination operation is about to be dispatched."""
+        self._dispatch_started = True
+
+
+class ProvenWriteOwnership:
+    """The engine boundary: prove an external hold, then record the dispatch it allows.
+
+    Proving first is what makes the tracker truthful. A proof that fails leaves the
+    tracker untouched, so a hold lost before the first dispatch stays a known
+    pre-dispatch failure, while a hold lost before the second dispatch is already
+    uncertain because of the first.
+    """
+
+    def __init__(self, *, prove: Callable[[], None], tracker: WriteDispatchTracker) -> None:
+        self._prove = prove
+        self._tracker = tracker
+
+    def before_operation(self) -> None:
+        """Prove the hold, then record that a destination operation may start."""
+        self._prove()
+        self._tracker.record_dispatch()
+
+    def after_final_operation(self) -> None:
+        """Prove the hold after the last operation; this alone is not a dispatch."""
+        self._prove()

--- a/infrahub_sync/potenda/__init__.py
+++ b/infrahub_sync/potenda/__init__.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
 
     from infrahub_sync import SyncInstance
     from infrahub_sync.plan.models import PlanManifest, VerificationFailure
+    from infrahub_sync.plan.ownership import WriteOwnership
     from infrahub_sync.plan.reader import RawPlanArtifact
 
 
@@ -594,6 +595,7 @@ class Potenda:
     def apply_plan(
         self,
         *,
+        ownership: WriteOwnership,
         config_version: str | None = None,
         artifact: RawPlanArtifact | None = None,
         expected_checksum: str | None = None,
@@ -625,6 +627,11 @@ class Potenda:
         single writer and merges `as_summary_keys()` into `run_file.summary` before saving.
 
         Args:
+            ownership: The write-ownership boundary this apply dispatches through. It is
+                proven immediately before every operation the loop dispatches and once
+                after the last one, so a hold lost mid-apply stops the next write instead
+                of being discovered afterwards. It is required and has no default: an
+                apply that could run without one would run without one.
             config_version: The comparison value for the configuration-version check,
                 compared for equality and never parsed. `None` recomputes it from the
                 parsed configuration by the default rule (FR-011, AD013).
@@ -731,6 +738,18 @@ class Potenda:
                 skipped_deletes.append(operation.operation_id)
                 continue
             try:
+                ownership.before_operation()
+            except BaseException as exc:
+                # A lost hold dispatched nothing, so this operation is named in neither
+                # set and is **not** recorded as possibly half-written.
+                # The suppression is not masking a defect — no annotation can declare an
+                # attribute on an exception type this module does not own.
+                exc.apply_record = ApplyRecord(  # ty: ignore[unresolved-attribute]
+                    applied_operations=tuple(applied),
+                    skipped_delete_operations=tuple(skipped_deletes),
+                )
+                raise
+            try:
                 destination.apply_planned_operation(operation=operation, peers=peers)
             except BaseException as exc:
                 # The partial record travels on the error so the CLI can merge what was
@@ -764,6 +783,15 @@ class Potenda:
             applied_operations=tuple(applied),
             skipped_delete_operations=tuple(skipped_deletes),
         )
+
+        # The closing proof, before anything may record this apply as complete: a hold
+        # lost after the last operation means nobody can say the destination was left as
+        # the plan describes, so it must not become a success.
+        try:
+            ownership.after_final_operation()
+        except BaseException as exc:
+            exc.apply_record = completed  # ty: ignore[unresolved-attribute]
+            raise
 
         # AFTER the loop and off the rejection path (AD069): a partial apply breaks both
         # clauses by construction, so checking unconditionally would replace a clear

--- a/infrahub_sync/product_store/models.py
+++ b/infrahub_sync/product_store/models.py
@@ -177,6 +177,10 @@ class ProductRun(BaseModel):
     outcome: str | None = None
     summary: dict[str, Any] = Field(default_factory=dict)
     results: dict[str, Any] = Field(default_factory=dict)
+    # The run's one authoritative write-safety fact, never carried in ``results``: a write
+    # execution ended without proving what reached the destination, so an operator must
+    # inspect it and plan again. Nothing sets it back to false.
+    reconciliation_required: bool = False
     artifact_refs: tuple[ArtifactReference, ...] = ()
     prefect_executions: tuple[PrefectExecutionLink, ...] = ()
 
@@ -298,12 +302,19 @@ class MutationReceipt(BaseModel):
         ):
             msg = "a configuration mutation receipt cannot carry run or Prefect identifiers"
             raise ValueError(msg)
-        if self.state == "accepted" and (
-            self.response_status is None
-            or self.response_body is None
-            or (self.resource_kind == "run" and self.flow_run_id is None)
+        if self.state == "accepted" and (self.response_status is None or self.response_body is None):
+            msg = "an accepted mutation receipt requires its stored status and response"
+            raise ValueError(msg)
+        # A run receipt answered with a refusal never reached Prefect, so it has no
+        # flow-run ID to carry; only an accepted submission does.
+        if (
+            self.state == "accepted"
+            and self.resource_kind == "run"
+            and self.flow_run_id is None
+            and self.response_status is not None
+            and self.response_status < 400
         ):
-            msg = "an accepted mutation receipt requires its status, response, and Prefect flow-run ID"
+            msg = "an accepted run mutation receipt requires its Prefect flow-run ID"
             raise ValueError(msg)
         if self.state in {"reserved", "processing"} and any(value is not None for value in accepted_values):
             msg = "an incomplete mutation receipt cannot carry an accepted response"

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -40,7 +40,8 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS product_runs (
     run_id TEXT PRIMARY KEY, operation TEXT NOT NULL, configuration_reference TEXT NOT NULL,
     actor TEXT, audit_links TEXT NOT NULL, started_at TEXT NOT NULL, finished_at TEXT,
-    phase TEXT NOT NULL, outcome TEXT, summary TEXT NOT NULL, results TEXT NOT NULL
+    phase TEXT NOT NULL, outcome TEXT, summary TEXT NOT NULL, results TEXT NOT NULL,
+    reconciliation_required BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE TABLE IF NOT EXISTS artifact_refs (
     run_id TEXT NOT NULL, artifact_id TEXT NOT NULL, kind TEXT NOT NULL, media_type TEXT NOT NULL,
@@ -48,18 +49,6 @@ CREATE TABLE IF NOT EXISTS artifact_refs (
     manifest_key TEXT NOT NULL UNIQUE, created_at TEXT NOT NULL, expires_at TEXT, published INTEGER NOT NULL,
     PRIMARY KEY (run_id, artifact_id), FOREIGN KEY (run_id) REFERENCES product_runs(run_id)
 );
-CREATE TABLE IF NOT EXISTS prefect_executions (
-    run_id TEXT NOT NULL, flow_run_id TEXT NOT NULL, deployment_id TEXT, purpose TEXT NOT NULL,
-    attempt INTEGER NOT NULL, last_observed_state TEXT, last_observed_at TEXT, submitted_at TEXT,
-    claimed_at TEXT, claiming_worker_id TEXT, stalled_at TEXT, cancellation_requested_at TEXT,
-    cancellation_recovery_deadline_at TEXT, cancellation_receipt_id TEXT, cancellation_acknowledged_at TEXT,
-    terminal_at TEXT, terminal_state TEXT, terminal_outcome TEXT, position INTEGER NOT NULL,
-    PRIMARY KEY (run_id, flow_run_id), FOREIGN KEY (run_id) REFERENCES product_runs(run_id)
-);
-CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_position
-    ON prefect_executions (run_id, position);
-CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_purpose_attempt
-    ON prefect_executions (run_id, purpose, attempt);
 CREATE TABLE IF NOT EXISTS mutation_receipts (
     receipt_id TEXT PRIMARY KEY, actor TEXT NOT NULL, key_digest TEXT NOT NULL,
     operation TEXT NOT NULL, target_run_id TEXT, request_fingerprint TEXT NOT NULL,
@@ -68,6 +57,20 @@ CREATE TABLE IF NOT EXISTS mutation_receipts (
     created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
     UNIQUE (actor, key_digest)
 );
+CREATE TABLE IF NOT EXISTS prefect_executions (
+    run_id TEXT NOT NULL, flow_run_id TEXT NOT NULL, deployment_id TEXT, purpose TEXT NOT NULL,
+    attempt INTEGER NOT NULL, last_observed_state TEXT, last_observed_at TEXT, submitted_at TEXT,
+    claimed_at TEXT, claiming_worker_id TEXT, stalled_at TEXT, cancellation_requested_at TEXT,
+    cancellation_recovery_deadline_at TEXT, cancellation_receipt_id TEXT, cancellation_acknowledged_at TEXT,
+    terminal_at TEXT, terminal_state TEXT, terminal_outcome TEXT, position INTEGER NOT NULL,
+    mutation_receipt_id TEXT UNIQUE,
+    PRIMARY KEY (run_id, flow_run_id), FOREIGN KEY (run_id) REFERENCES product_runs(run_id),
+    FOREIGN KEY (mutation_receipt_id) REFERENCES mutation_receipts(receipt_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_position
+    ON prefect_executions (run_id, position);
+CREATE UNIQUE INDEX IF NOT EXISTS prefect_executions_run_purpose_attempt
+    ON prefect_executions (run_id, purpose, attempt);
 CREATE TABLE IF NOT EXISTS write_admissions (
     run_id TEXT PRIMARY KEY, receipt_id TEXT NOT NULL UNIQUE, operation TEXT NOT NULL,
     FOREIGN KEY (run_id) REFERENCES product_runs(run_id),
@@ -221,6 +224,23 @@ _POSTGRESQL_DUPLICATE_COLUMN_CODE = "42701"
 # are the whole set of readable answers.
 _CATALOG_NULLABILITY_ROW_WIDTH = 2
 _CATALOG_NULLABILITY_VALUES = frozenset({"YES", "NO"})
+# The stages one run's admission arbitrates against each other. Cancellation is
+# deliberately outside the set: it targets the execution a write already owns and never
+# reserves a stage of its own, so a claimed write stays cancellable.
+_ARBITRATED_OPERATIONS = ("plan", "verify", "apply", "sync")
+# The two stages that reach a destination. The store's SQL spells them literally; this is
+# the Python-side membership test for the same pair.
+_WRITE_OPERATIONS = ("apply", "sync")
+_RUN_EXECUTION_CONFLICT = "run-execution-conflict"
+_RUN_EXECUTION_CONFLICT_MESSAGE = (
+    "this Sync run already has a write admission, an unresolved submission, or a running "
+    "execution; review the run and create a new plan or sync run"
+)
+_ADMITTED_APPEND_REFUSED = (
+    "appending a write execution requires the mutation receipt that holds this run's write admission"
+)
+_UNRESOLVED_APPEND_REFUSED = "appending an execution requires an unresolved mutation receipt for this run"
+_REPEATED_APPEND_REFUSED = "this mutation receipt has already appended its one execution"
 _PREFECT_POSITION_ATTEMPTS = 3
 _RESULT_MERGE_ATTEMPTS = 5
 _SCHEMA_INITIALIZATION_ATTEMPTS = 2
@@ -250,10 +270,10 @@ _SELECT_NEXT_CONFIGURATION_VERSION = (
 )
 
 _INSERT_PRODUCT_RUN = """INSERT INTO product_runs (run_id, operation, configuration_reference, config_id,
-registry_version, package_checksum, actor, audit_links, started_at, finished_at, phase, outcome, summary, results)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+registry_version, package_checksum, actor, audit_links, started_at, finished_at, phase, outcome, summary, results,
+reconciliation_required) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _SELECT_PRODUCT_RUN = """SELECT run_id, operation, configuration_reference, actor, audit_links, started_at,
-finished_at, phase, outcome, summary, results, config_id, registry_version, package_checksum
+finished_at, phase, outcome, summary, results, config_id, registry_version, package_checksum, reconciliation_required
 FROM product_runs WHERE run_id = ?"""
 _SELECT_RUN_ARTIFACT_REFERENCES = """SELECT run_id, artifact_id, kind, media_type, digest, size, object_key,
 manifest_key, created_at, expires_at, published FROM artifact_refs WHERE run_id = ? AND published = 1 ORDER BY artifact_id"""
@@ -268,7 +288,8 @@ terminal_outcome, position FROM prefect_executions WHERE run_id = ? ORDER BY pos
 _INSERT_PREFECT_EXECUTION = """INSERT INTO prefect_executions (run_id, flow_run_id, deployment_id, purpose, attempt,
 last_observed_state, last_observed_at, submitted_at, claimed_at, claiming_worker_id, stalled_at,
 cancellation_requested_at, cancellation_recovery_deadline_at, cancellation_receipt_id, cancellation_acknowledged_at,
-terminal_at, terminal_state, terminal_outcome, position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+terminal_at, terminal_state, terminal_outcome, position, mutation_receipt_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _INSERT_MUTATION_RECEIPT = """INSERT INTO mutation_receipts (receipt_id, actor, key_digest, operation,
 target_run_id, request_fingerprint, reason, resource_kind, resource_id, run_id, prefect_key, state, response_status, response_body,
 flow_run_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
@@ -303,7 +324,7 @@ class DuplicatePrefectExecutionError(ValueError):
 
 
 class WriteAdmissionConflictError(ValueError):
-    """A product run already owns its one durable write-capable admission."""
+    """A product run cannot admit another execution while a cancellation is in flight."""
 
 
 class ArtifactUnavailableError(RuntimeError):
@@ -368,7 +389,7 @@ class _RunStore(Protocol):  # pylint: disable=too-many-public-methods
     def has_pending_artifacts(self, run_id: str) -> bool: ...
 
     def add_prefect_execution(
-        self, run_id: str, link: PrefectExecutionLink, *, allocate_attempt: bool = False
+        self, run_id: str, link: PrefectExecutionLink, *, receipt_id: str, allocate_attempt: bool = False
     ) -> PrefectExecutionLink: ...
 
     def observe_prefect_execution(
@@ -398,8 +419,8 @@ class _RunStore(Protocol):  # pylint: disable=too-many-public-methods
         *,
         worker_id: str,
         terminal_at: datetime,
-        terminal_state: Literal["completed", "failed"],
-        terminal_outcome: Literal["succeeded", "failed"],
+        terminal_state: Literal["completed", "failed", "interrupted"],
+        terminal_outcome: Literal["succeeded", "failed", "ambiguous"],
         writeback: ExecutionWriteback,
     ) -> bool: ...
 
@@ -757,6 +778,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 run.outcome,
                 _json(run.summary),
                 _json(run.results),
+                run.reconciliation_required,
             ),
         )
 
@@ -891,6 +913,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         run_id: str,
         link: PrefectExecutionLink,
         *,
+        receipt_id: str,
         allocate_attempt: bool = False,
     ) -> PrefectExecutionLink:
         last_conflict: BaseException | None = None
@@ -912,6 +935,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     )
                     if cursor.fetchone() is not None:
                         _raise_active_cancellation_conflict(run_id)
+                    self._require_append_owner(cursor, run_id, receipt_id, purpose=link.purpose)
                     cursor.execute(
                         self._sql("SELECT COALESCE(MAX(position) + 1, 0) FROM prefect_executions WHERE run_id = ?"),
                         (run_id,),
@@ -930,7 +954,9 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                         attempt_row = cursor.fetchone()
                         ordinal = int(attempt_row[0]) if attempt_row is not None else 1
                         allocated_link = link.model_copy(update={"attempt": ordinal})
-                    self._insert_prefect_execution(cursor, run_id, allocated_link, position)
+                    self._insert_prefect_execution(
+                        cursor, run_id, allocated_link, position, mutation_receipt_id=receipt_id
+                    )
                     connection.commit()
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     # DB-API drivers do not share an integrity-error base class;
@@ -955,8 +981,44 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         msg = "Prefect execution allocation loop exited unexpectedly"
         raise AssertionError(msg)
 
+    def _require_append_owner(self, cursor: _Cursor, run_id: str, receipt_id: str, *, purpose: str) -> None:
+        """Refuse an execution append that no unresolved receipt of this run owns.
+
+        A receipt is unresolved until it carries a stored response, refusals included, so
+        the append belongs to a submission still in flight, and it appends at most once. A
+        write append additionally requires the run's write-admission row to name this exact
+        receipt and this exact operation: the admission is what one request won, and nothing
+        else may spend it. A run holding a write admission accepts no read append at all.
+        """
+        cursor.execute(
+            self._sql("SELECT 1 FROM mutation_receipts WHERE receipt_id = ? AND run_id = ? AND state <> 'accepted'"),
+            (receipt_id, run_id),
+        )
+        if cursor.fetchone() is None:
+            raise ValueError(_UNRESOLVED_APPEND_REFUSED)
+        cursor.execute(
+            self._sql("SELECT 1 FROM prefect_executions WHERE mutation_receipt_id = ?"),
+            (receipt_id,),
+        )
+        if cursor.fetchone() is not None:
+            raise ValueError(_REPEATED_APPEND_REFUSED)
+        cursor.execute(self._sql("SELECT receipt_id, operation FROM write_admissions WHERE run_id = ?"), (run_id,))
+        admission = cursor.fetchone()
+        if purpose in _WRITE_OPERATIONS:
+            if admission is None or (str(admission[0]), str(admission[1])) != (receipt_id, purpose):
+                raise ValueError(_ADMITTED_APPEND_REFUSED)
+            return
+        if admission is not None:
+            raise ValueError(_ADMITTED_APPEND_REFUSED)
+
     def _insert_prefect_execution(
-        self, cursor: _Cursor, run_id: str, link: PrefectExecutionLink, position: int
+        self,
+        cursor: _Cursor,
+        run_id: str,
+        link: PrefectExecutionLink,
+        position: int,
+        *,
+        mutation_receipt_id: str | None = None,
     ) -> None:
         cursor.execute(
             self._sql(_INSERT_PREFECT_EXECUTION),
@@ -980,6 +1042,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 link.terminal_state,
                 link.terminal_outcome,
                 position,
+                mutation_receipt_id,
             ),
         )
 
@@ -1092,8 +1155,8 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         *,
         worker_id: str,
         terminal_at: datetime,
-        terminal_state: Literal["completed", "failed"],
-        terminal_outcome: Literal["succeeded", "failed"],
+        terminal_state: Literal["completed", "failed", "interrupted"],
+        terminal_outcome: Literal["succeeded", "failed", "ambiguous"],
         writeback: ExecutionWriteback,
     ) -> bool:
         """Commit one claimed worker verdict and its business writeback together."""
@@ -1162,6 +1225,13 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                         flow_run_id=flow_run_id,
                         updated_at=terminal_at,
                     )
+                self._record_write_ambiguity(
+                    cursor,
+                    run_id,
+                    flow_run_id,
+                    terminal_state=terminal_state,
+                    terminal_outcome=terminal_outcome,
+                )
                 connection.commit()
             except Exception:
                 connection.rollback()
@@ -1261,7 +1331,8 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.execute(
                     self._sql(
                         "SELECT claimed_at, cancellation_recovery_deadline_at, cancellation_receipt_id, "
-                        "cancellation_acknowledged_at FROM prefect_executions WHERE run_id = ? AND flow_run_id = ?"
+                        "cancellation_acknowledged_at, purpose FROM prefect_executions "
+                        "WHERE run_id = ? AND flow_run_id = ?"
                     ),
                     (run_id, flow_run_id),
                 )
@@ -1270,10 +1341,14 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     connection.commit()
                     return False
                 receipt_id = str(row[2])
-                if acknowledged_at >= datetime.fromisoformat(str(row[1])):
+                claimed = row[0] is not None
+                # A claimed apply or sync may already have reached the destination, so
+                # acknowledgement cannot promise a clean stop however early it arrives.
+                claimed_write = claimed and str(row[4]) in _WRITE_OPERATIONS
+                if claimed_write or acknowledged_at >= datetime.fromisoformat(str(row[1])):
                     state, outcome, phase = (
                         ("interrupted", "ambiguous", "interrupted")
-                        if row[0] is not None
+                        if claimed
                         else ("abandoned", "abandoned", "abandoned")
                     )
                     cursor.execute(
@@ -1291,11 +1366,19 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                         self._sql(_UPDATE_LATEST_EXECUTION_TERMINAL),
                         (phase, outcome, acknowledged_at.isoformat(), run_id, flow_run_id),
                     )
+                    self._record_write_ambiguity(
+                        cursor, run_id, flow_run_id, terminal_state=state, terminal_outcome=outcome
+                    )
+                    refusal = (
+                        _cancellation_ambiguous_response(run_id, receipt_id)
+                        if claimed_write
+                        else _cancellation_unconfirmed_response(run_id, receipt_id)
+                    )
                     self._complete_receipt_row(
                         cursor,
                         receipt_id,
-                        response_status=503,
-                        response_body=_cancellation_unconfirmed_response(run_id, receipt_id),
+                        response_status=int(refusal["error"]["status"]),
+                        response_body=refusal,
                         flow_run_id=flow_run_id,
                         updated_at=acknowledged_at,
                     )
@@ -1415,6 +1498,9 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     self._sql(_UPDATE_LATEST_EXECUTION_TERMINAL),
                     (phase, outcome, terminal_at.isoformat(), run_id, flow_run_id),
                 )
+                self._record_write_ambiguity(
+                    cursor, run_id, flow_run_id, terminal_state=state, terminal_outcome=outcome
+                )
                 if not acknowledged:
                     receipt_id = str(row[2])
                     self._complete_receipt_row(
@@ -1473,6 +1559,34 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         finally:
             connection.close()
 
+    def _record_write_ambiguity(
+        self,
+        cursor: _Cursor,
+        run_id: str,
+        flow_run_id: str,
+        *,
+        terminal_state: str,
+        terminal_outcome: str,
+    ) -> None:
+        """Record durable write ambiguity in the transaction that made it terminal.
+
+        The condition is derived from the verdict and the execution's own purpose rather
+        than passed in, so no caller can write the column false and no write-uncertain
+        terminal path can forget it. `interrupted` / `ambiguous` is only ever written to a
+        claimed execution, so an apply or sync bearing it is a worker that may already have
+        reached the destination.
+        """
+        if (terminal_state, terminal_outcome) != ("interrupted", "ambiguous"):
+            return
+        cursor.execute(
+            self._sql(
+                "UPDATE product_runs SET reconciliation_required = TRUE WHERE run_id = ? AND EXISTS "
+                "(SELECT 1 FROM prefect_executions WHERE run_id = ? AND flow_run_id = ? "
+                "AND purpose IN ('apply', 'sync'))"
+            ),
+            (run_id, run_id, flow_run_id),
+        )
+
     def _terminalize_execution(
         self,
         run_id: str,
@@ -1509,6 +1623,13 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     self._sql(_UPDATE_LATEST_EXECUTION_TERMINAL),
                     (phase, outcome, terminal_at.isoformat(), run_id, flow_run_id),
                 )
+                self._record_write_ambiguity(
+                    cursor,
+                    run_id,
+                    flow_run_id,
+                    terminal_state=terminal_state,
+                    terminal_outcome=terminal_outcome,
+                )
                 connection.commit()
             except Exception:
                 connection.rollback()
@@ -1527,16 +1648,24 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         *,
         admit_write: bool = False,
     ) -> tuple[MutationReceipt, bool]:
-        """Atomically reserve actor/key and optionally create its product run."""
+        """Atomically arbitrate one run stage, reserve actor/key, and create any new run.
+
+        The arbitration and the reservation are one transaction on purpose: whichever
+        request wins a run's single write admission is decided here, before either
+        competitor can submit anything to Prefect. A loser is answered durably, by a stored
+        refusal on its own receipt, so replaying its client key replays the refusal rather
+        than racing again.
+        """
         connection = self._connect()
         try:
             cursor = connection.cursor()
             try:
                 try:
-                    cursor.execute(self._sql(_INSERT_MUTATION_RECEIPT), _receipt_values(receipt))
+                    stored = self._arbitrate_reservation(cursor, receipt, run, admit_write=admit_write)
+                    cursor.execute(self._sql(_INSERT_MUTATION_RECEIPT), _receipt_values(stored))
                     if run is not None:
                         self._insert_product_run(cursor, run)
-                    if admit_write:
+                    if admit_write and stored.state != "accepted":
                         cursor.execute(
                             self._sql("INSERT INTO write_admissions (run_id, receipt_id, operation) VALUES (?, ?, ?)"),
                             (receipt.run_id, receipt.receipt_id, receipt.operation),
@@ -1549,11 +1678,6 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                     existing = self.lookup_mutation(receipt.actor, receipt.key_digest)
                     if existing.value is not None:
                         return existing.value, False
-                    if admit_write:
-                        assert receipt.run_id is not None
-                        if self._write_admission_exists(receipt.run_id):
-                            msg = f"Sync run {receipt.run_id!r} already has a write-capable admission"
-                            raise WriteAdmissionConflictError(msg) from exc
                     if run is not None and self.exists(run.run_id):
                         msg = f"Sync run ID {run.run_id!r} already exists"
                         raise DuplicateRunError(msg) from exc
@@ -1562,19 +1686,68 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                 cursor.close()
         finally:
             connection.close()
-        return receipt, True
+        return stored, True
 
-    def _write_admission_exists(self, run_id: str) -> bool:
-        connection = self._connect()
-        try:
-            cursor = connection.cursor()
-            try:
-                cursor.execute(self._sql("SELECT 1 FROM write_admissions WHERE run_id = ?"), (run_id,))
-                return cursor.fetchone() is not None
-            finally:
-                cursor.close()
-        finally:
-            connection.close()
+    def _arbitrate_reservation(
+        self,
+        cursor: _Cursor,
+        receipt: MutationReceipt,
+        run: ProductRun | None,
+        *,
+        admit_write: bool,
+    ) -> MutationReceipt:
+        """Return the receipt to store: the request itself, or its stored refusal.
+
+        A run being created cannot lose: its own insert is the serialization point and it
+        has no records to arbitrate against. For an existing run, the run's authoritative
+        row is locked with the store's write-first pattern before anything is read, so two
+        competing reservations cannot both observe the same unadmitted run.
+        """
+        if run is not None or receipt.resource_kind != "run" or receipt.operation not in _ARBITRATED_OPERATIONS:
+            return receipt
+        run_id = receipt.run_id
+        assert run_id is not None  # a run receipt carries its run ID (MutationReceipt invariant).
+        cursor.execute(self._sql("UPDATE product_runs SET run_id = run_id WHERE run_id = ?"), (run_id,))
+        if not self._reservation_refused(cursor, run_id, receipt.receipt_id, admit_write=admit_write):
+            return receipt
+        return receipt.model_copy(
+            update={
+                "state": "accepted",
+                "response_status": 409,
+                "response_body": _run_execution_conflict_response(run_id, receipt.receipt_id),
+            }
+        )
+
+    def _reservation_refused(self, cursor: _Cursor, run_id: str, receipt_id: str, *, admit_write: bool) -> bool:
+        """Answer whether this run may still admit the requested stage.
+
+        A run that has admitted its one write never admits another stage of any kind, even
+        after that write becomes terminal: terminal write evidence is immutable and the
+        operator's next step is a new run. A write additionally needs the run quiet — no
+        other unresolved submission and no unfinished execution — so an apply cannot race
+        a verify that has reserved but not yet submitted.
+        """
+        cursor.execute(self._sql("SELECT 1 FROM write_admissions WHERE run_id = ?"), (run_id,))
+        if cursor.fetchone() is not None:
+            return True
+        if not admit_write:
+            return False
+        # Every stage a run arbitrates is every run mutation except cancellation, which
+        # targets the execution a write already owns rather than reserving a stage.
+        cursor.execute(
+            self._sql(
+                "SELECT 1 FROM mutation_receipts WHERE run_id = ? AND receipt_id <> ? AND state <> 'accepted' "
+                "AND operation <> 'cancel'"
+            ),
+            (run_id, receipt_id),
+        )
+        if cursor.fetchone() is not None:
+            return True
+        cursor.execute(
+            self._sql("SELECT 1 FROM prefect_executions WHERE run_id = ? AND terminal_at IS NULL"),
+            (run_id,),
+        )
+        return cursor.fetchone() is not None
 
     def lookup_mutation(self, actor: str, key_digest: str) -> LookupResult[MutationReceipt]:
         connection = self._connect()
@@ -2258,10 +2431,15 @@ class ProductProjection:  # pylint: disable=too-many-public-methods
         run_id: str,
         link: PrefectExecutionLink,
         *,
+        receipt_id: str,
         allocate_attempt: bool = False,
         secrets: Sequence[str] = (),
     ) -> PrefectExecutionLink:
-        """Append one purpose-labelled execution, optionally allocating its ordinal atomically."""
+        """Append the one execution `receipt_id` owns, allocating its ordinal atomically.
+
+        `receipt_id` is the exact unresolved mutation receipt this submission reserved. It
+        is the store's internal owner relation and appears in no public resource.
+        """
         if link.submitted_at is None:
             msg = "new Prefect execution requires submitted_at"
             raise ValueError(msg)
@@ -2269,7 +2447,9 @@ class ProductProjection:  # pylint: disable=too-many-public-methods
             msg = f"Cannot link a Prefect execution to unavailable Sync run ID {run_id!r}"
             raise RunNotFoundError(msg)
         sanitized = PrefectExecutionLink.model_validate(_redact_value(link.model_dump(mode="json"), secrets))
-        return self._records.add_prefect_execution(run_id, sanitized, allocate_attempt=allocate_attempt)
+        return self._records.add_prefect_execution(
+            run_id, sanitized, receipt_id=redact(receipt_id, secrets), allocate_attempt=allocate_attempt
+        )
 
     def observe_prefect_execution(
         self,
@@ -2335,20 +2515,29 @@ class ProductProjection:  # pylint: disable=too-many-public-methods
         *,
         worker_id: str,
         terminal_at: datetime,
-        terminal_state: Literal["completed", "failed"],
-        terminal_outcome: Literal["succeeded", "failed"],
+        terminal_state: Literal["completed", "failed", "interrupted"],
+        terminal_outcome: Literal["succeeded", "failed", "ambiguous"],
         writeback: ExecutionWriteback,
         secrets: Sequence[str] = (),
     ) -> bool:
-        """Atomically commit one claimed verdict and its business writeback."""
+        """Atomically commit one claimed verdict and its business writeback.
+
+        A live worker that may already have reached the destination commits
+        `interrupted` / `ambiguous`; the same transaction records that the run requires
+        reconciliation, so the verdict and its safety evidence cannot come apart.
+        """
         if not _is_canonical_uuid(worker_id):
             raise ValueError(_INVALID_SERVICE_WORKER_ID)
-        if (terminal_state, terminal_outcome) not in {("completed", "succeeded"), ("failed", "failed")}:
+        if (terminal_state, terminal_outcome) not in {
+            ("completed", "succeeded"),
+            ("failed", "failed"),
+            ("interrupted", "ambiguous"),
+        }:
             msg = "claimed execution terminal verdict is invalid"
             raise ValueError(msg)
         _require_execution_timestamp(terminal_at)
         if isinstance(writeback, ExecutionFinishWriteback):
-            if writeback.outcome != "failed" and self._records.has_pending_artifacts(run_id):
+            if terminal_state == "completed" and self._records.has_pending_artifacts(run_id):
                 msg = f"Sync run ID {run_id!r} has an incomplete artifact publication"
                 raise ArtifactUnavailableError(msg)
             run = self.lookup_run(run_id).value
@@ -2756,6 +2945,8 @@ def _run_from_rows(
             "config_id": row[11],
             "registry_version": row[12],
             "package_checksum": row[13],
+            # SQLite stores a BOOLEAN column as 0/1; PostgreSQL returns a bool.
+            "reconciliation_required": bool(row[14]),
             "artifact_refs": [_reference_from_row(item).model_dump() for item in references],
             "prefect_executions": [
                 {
@@ -2827,6 +3018,34 @@ def _receipt_from_row(row: Sequence[Any]) -> MutationReceipt:
             "updated_at": row[16],
         }
     )
+
+
+def _run_execution_conflict_response(run_id: str, receipt_id: str) -> dict[str, Any]:
+    """The one refusal a losing plan/verify/apply/sync reservation stores on its receipt."""
+    return {
+        "error": {
+            "code": _RUN_EXECUTION_CONFLICT,
+            "message": _RUN_EXECUTION_CONFLICT_MESSAGE,
+            "status": 409,
+            "run_id": run_id,
+            "mutation_id": receipt_id,
+        }
+    }
+
+
+def _cancellation_ambiguous_response(run_id: str, receipt_id: str) -> dict[str, Any]:
+    """The answer to cancelling a claimed write: terminal, and possibly already written."""
+    return {
+        "error": {
+            "code": "cancellation-ambiguous",
+            "message": (
+                "the cancelled write may already have reached the destination; inspect it and create a new plan run"
+            ),
+            "status": 409,
+            "run_id": run_id,
+            "mutation_id": receipt_id,
+        }
+    }
 
 
 def _cancellation_terminal_response(run_id: str, receipt_id: str) -> dict[str, Any]:

--- a/infrahub_sync/product_store/store.py
+++ b/infrahub_sync/product_store/store.py
@@ -745,7 +745,11 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
                         raise DuplicateRunError(msg) from exc
                     raise
                 for position, link in enumerate(run.prefect_executions):
-                    self._insert_prefect_execution(cursor, run.run_id, link, position)
+                    # A link embedded in the run being created has no receipt to own it:
+                    # `reserve_mutation` is what mints one, and it runs against a run that
+                    # already exists. Stated rather than defaulted so a caller that does
+                    # have a receipt cannot append without naming it.
+                    self._insert_prefect_execution(cursor, run.run_id, link, position, mutation_receipt_id=None)
                 connection.commit()
             except Exception:
                 connection.rollback()
@@ -758,7 +762,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
     def _insert_product_run(self, cursor: _Cursor, run: ProductRun) -> None:
         self._insert_product_run_row(cursor, run)
         for position, link in enumerate(run.prefect_executions):
-            self._insert_prefect_execution(cursor, run.run_id, link, position)
+            self._insert_prefect_execution(cursor, run.run_id, link, position, mutation_receipt_id=None)
 
     def _insert_product_run_row(self, cursor: _Cursor, run: ProductRun) -> None:
         cursor.execute(
@@ -1018,7 +1022,7 @@ class _RelationalRunStore:  # pylint: disable=too-many-public-methods
         link: PrefectExecutionLink,
         position: int,
         *,
-        mutation_receipt_id: str | None = None,
+        mutation_receipt_id: str | None,
     ) -> None:
         cursor.execute(
             self._sql(_INSERT_PREFECT_EXECUTION),

--- a/infrahub_sync/service/flow.py
+++ b/infrahub_sync/service/flow.py
@@ -81,6 +81,9 @@ _UNREGISTERED_WRITE_REFUSED = (
     "guard serializes writers per registered configuration"
 )
 _WORKER_PAGE_SIZE = 200
+# The stages the managed write scope covers. A read stage has nothing to be uncertain
+# about, so it keeps its own deliberate handling where the two differ.
+_WRITE_STAGES = ("apply", "sync")
 
 
 def _raise_writeback_refused() -> None:
@@ -587,15 +590,23 @@ def _failure_evidence(
     exc: Exception,
     *,
     outcome: str,
+    record: ApplyRecord | None,
 ) -> dict[str, Any]:
+    """Describe one failure, with whatever is known about what it wrote.
+
+    A failure raised by the engine carries its own partial record; a failure raised after
+    the engine returned — a sidecar write, the guard's release, the product commit — carries
+    none, and the scope's record is what that one wrote.
+    """
     evidence: dict[str, Any] = {
         "stage": stage,
         "outcome": outcome,
         "error_type": type(exc).__name__,
     }
-    apply_record = getattr(exc, "apply_record", None)
-    if isinstance(apply_record, ApplyRecord):
-        evidence.update(apply_record.as_summary_keys())
+    carried = getattr(exc, "apply_record", None)
+    written = carried if isinstance(carried, ApplyRecord) else record
+    if written is not None:
+        evidence.update(written.as_summary_keys())
     return evidence
 
 
@@ -610,6 +621,7 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
     worker_id: str,
     *,
     dispatch_started: bool,
+    record: ApplyRecord | None,
 ) -> None:
     """Best-effort durable product evidence without masking the worker failure.
 
@@ -624,7 +636,7 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
         if stored is None:
             return
         terminal_state, terminal_outcome = ("interrupted", "ambiguous") if dispatch_started else ("failed", "failed")
-        evidence = _failure_evidence(stage, exc, outcome=terminal_outcome)
+        evidence = _failure_evidence(stage, exc, outcome=terminal_outcome, record=record)
         results: dict[str, Any] = {f"{stage}_failure": evidence}
         if stage == "verify":
             writeback: ExecutionWriteback = ExecutionMergeWriteback(results=results)
@@ -704,24 +716,58 @@ def service_sync_run(  # pylint: disable=too-many-positional-arguments
                 tracker=tracker,
             )
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # Rebuilt after the original exception context exits.
-        _record_failure(
-            run_id,
-            stage,
-            exc,
-            run_logger,
-            secrets,
-            projection,
-            flow_run_id,
-            worker_id,
-            dispatch_started=tracker.dispatch_started,
-        )
-        failure = sanitize_exception_chain(exc, secrets)
+        failure = exc
+    record_terminal = True
+    if failure is None:
+        try:
+            _commit_success(projection, run_id, flow_run_id, worker_id=worker_id, writeback=writeback, secrets=secrets)
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            failure = exc
+            # A read stage whose success did not store stays nonterminal on purpose: it
+            # wrote nothing, so reconciliation decides it rather than this worker.
+            record_terminal = stage in _WRITE_STAGES
     if failure is not None:
+        # The one exit for the whole managed write scope. Everything after the first proven
+        # dispatch reaches it — a failed operation, a lost hold, a sidecar that could not
+        # record the applied transition, a release that could not be confirmed, and a
+        # product commit that did not store its success — so all of them commit the same
+        # ambiguous verdict, the same evidence, the record the scope kept, and
+        # `reconciliation_required` together.
+        if record_terminal:
+            _record_failure(
+                run_id,
+                stage,
+                failure,
+                run_logger,
+                secrets,
+                projection,
+                flow_run_id,
+                worker_id,
+                dispatch_started=tracker.dispatch_started,
+                record=tracker.applied_record,
+            )
+        # Rebuilt after the original exception context exits.
+        sanitized = sanitize_exception_chain(failure, secrets)
         secrets.clear()
-        raise failure
+        raise sanitized
+    return result
 
-    persistence_failure: Exception | None = None
+
+def _commit_success(
+    projection: ProductProjection,
+    run_id: str,
+    flow_run_id: str,
+    *,
+    worker_id: str,
+    writeback: ExecutionWriteback,
+    secrets: Sequence[str],
+) -> None:
+    """Commit this stage's success, tolerating only a commit that actually landed.
+
+    A commit can succeed and still fail to answer. Rereading the link is what tells those
+    apart: a stored success is this stage's success whatever the call reported, and
+    anything else is a failure the scope's one exit path has to handle.
+    """
     try:
         if not projection.commit_claimed_execution(
             run_id,
@@ -734,22 +780,24 @@ def service_sync_run(  # pylint: disable=too-many-positional-arguments
             secrets=secrets,
         ):
             _raise_writeback_refused()
-    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        try:
-            stored = projection.lookup_run(run_id).value
-            link = (
-                None
-                if stored is None
-                else next(
-                    (candidate for candidate in stored.prefect_executions if candidate.flow_run_id == flow_run_id),
-                    None,
-                )
+    except Exception:
+        if _stored_success(projection, run_id, flow_run_id):
+            return
+        raise
+
+
+def _stored_success(projection: ProductProjection, run_id: str, flow_run_id: str) -> bool:
+    """Answer whether this execution's success is already durable."""
+    try:
+        stored = projection.lookup_run(run_id).value
+        link = (
+            None
+            if stored is None
+            else next(
+                (candidate for candidate in stored.prefect_executions if candidate.flow_run_id == flow_run_id),
+                None,
             )
-        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            link = None
-        if link is None or (link.terminal_state, link.terminal_outcome) != ("completed", "succeeded"):
-            persistence_failure = sanitize_exception_chain(exc, secrets)
-    if persistence_failure is not None:
-        secrets.clear()
-        raise persistence_failure
-    return result
+        )
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        return False
+    return link is not None and (link.terminal_state, link.terminal_outcome) == ("completed", "succeeded")

--- a/infrahub_sync/service/flow.py
+++ b/infrahub_sync/service/flow.py
@@ -683,9 +683,8 @@ def service_sync_run(  # pylint: disable=too-many-positional-arguments
     config_directory, projection = _runtime()
     flow_run_id, worker_id = _claim_current_execution(projection, run_id)
     secrets[:] = collect_secret_values()
-    # Owned here so the failure boundary can read it however the stage ended. Process-local
-    # diagnostic state for this one worker: never a receipt, a durable row, or an authority
-    # to replay anything.
+    # Owned here rather than by the stage, so the failure boundary can read it however the
+    # stage ended.
     tracker = WriteDispatchTracker()
     try:
         with _remote_log_bridge(run_logger, prefect_context=prefect_context, secrets=secrets):

--- a/infrahub_sync/service/flow.py
+++ b/infrahub_sync/service/flow.py
@@ -8,7 +8,7 @@
 import logging
 import os
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -25,7 +25,6 @@ from infrahub_sync.configuration.runtime import resolve_runtime_instance
 from infrahub_sync.execution import (
     ACTION_KEYS,
     RunResult,
-    bounded_run_lock,
     collect_secret_values,
     execute_run,
     redact,
@@ -42,6 +41,7 @@ from infrahub_sync.orchestration.flow import (
 from infrahub_sync.plan.config_version import resolve_config_version
 from infrahub_sync.plan.errors import PlanSchemaChangedError
 from infrahub_sync.plan.models import ApplyRecord, PlanManifest
+from infrahub_sync.plan.ownership import ProvenWriteOwnership, WriteDispatchTracker
 from infrahub_sync.plan.reader import parse_plan_artifact, read_plan_artifact_bytes
 from infrahub_sync.plan.review import SavedPlan, resolve_run_directory
 from infrahub_sync.plan.verify import verify_plan
@@ -53,11 +53,12 @@ from infrahub_sync.product_store import (
 )
 from infrahub_sync.runtime_schema import STAGE_RUNTIME_MODEL_SCOPE, RuntimeModelPlan, build_runtime_model_plan
 
+from .apply_guard import ApplyGuard, hold_apply_guard
 from .liveness import LivenessPolicy
 from .models import PlanResource
 from .orchestration import SERVICE_FLOW_NAME
 from .service import PLAN_ARTIFACT_ID
-from .storage import service_product_projection
+from .storage import service_guard_secrets, service_guard_session, service_product_projection
 
 CONFIG_DIR_ENV = "INFRAHUB_SYNC_CONFIG_DIRECTORY"
 RUN_CACHE_ENV = "INFRAHUB_SYNC_CACHE_DIR"
@@ -75,6 +76,10 @@ _WORKER_EXECUTION_REFUSED = "service worker execution claim was refused"
 _WORKER_EXECUTION_ID_INVALID = "service worker execution identity is invalid"
 _WORKER_EXECUTION_IDENTITY_UNAVAILABLE = "service worker execution identity is unavailable"
 _WORKER_EXECUTION_WRITEBACK_REFUSED = "service worker execution writeback was refused"
+_UNREGISTERED_WRITE_REFUSED = (
+    "a managed write requires a complete registered configuration binding, because the write "
+    "guard serializes writers per registered configuration"
+)
 _WORKER_PAGE_SIZE = 200
 
 
@@ -178,7 +183,6 @@ def _plan(
         run_id=run_id,
         show_progress=False,
         print_diff=False,
-        _lock_already_held=composed_sync,
         _run_file_mode="sync" if composed_sync else None,
         _return_saved_plan=True,
     )
@@ -394,6 +398,27 @@ def _worker_execution_context(
     return projection, instance, package.configuration.name
 
 
+def _configuration_write_guard(configuration_id: str) -> AbstractContextManager[ApplyGuard]:
+    """Return the hold of one registered configuration's write guard.
+
+    Everything destination-sensitive belongs inside that hold: the live schema read, the
+    runtime models built from it, and every operation dispatched against them. A snapshot
+    taken before a contended wait describes a destination another writer may still have
+    been changing, so it cannot gate a write that happens after the wait.
+
+    The dedicated session it opens is the guard's alone. It is never handed to an adapter
+    or to the product store.
+    """
+    return hold_apply_guard(configuration_id, connect=service_guard_session, secrets=service_guard_secrets())
+
+
+def _require_registered_write(binding: tuple[str, int, str] | None) -> str:
+    """Return the configuration ID a managed write is guarded by, or refuse the write."""
+    if binding is None:
+        raise ValueError(_UNREGISTERED_WRITE_REFUSED)
+    return binding[0]
+
+
 def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-statements
     run_id: str,
     stage: Literal["plan", "verify", "apply", "sync"],
@@ -408,9 +433,22 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
     secrets: list[str],
     config_directory: str,
     projection: ProductProjection,
+    tracker: WriteDispatchTracker,
 ) -> tuple[dict[str, Any], ExecutionWriteback]:
     """Resolve and execute one service stage within the sanitized worker boundary."""
     parameter_binding = _worker_binding(config_id, registry_version, package_checksum)
+    if stage in ("apply", "sync"):
+        if not confirm_writes:
+            msg = f"confirm_writes=true is required for service stage={stage}"
+            raise ValueError(msg)
+        # Before anything is resolved: the guard serializes writers per registered
+        # configuration, so a run that names none cannot be serialized against them.
+        _require_registered_write(parameter_binding)
+    if stage == "apply" and expected_checksum is None:
+        msg = "expected_checksum is required for service stage=apply"
+        raise ValueError(msg)
+    # A write defers its live schema read until the guard is held, so no destination
+    # snapshot it validates against can predate a contended wait.
     projection, instance, sync_name = _worker_execution_context(
         run_id,
         parameter_binding,
@@ -418,14 +456,8 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         projection=projection,
         run_branch=branch,
         stage=stage,
-        build_models=stage != "apply",
+        build_models=stage not in ("apply", "sync"),
     )
-    if stage in ("apply", "sync") and not confirm_writes:
-        msg = f"confirm_writes=true is required for service stage={stage}"
-        raise ValueError(msg)
-    if stage == "apply" and expected_checksum is None:
-        msg = "expected_checksum is required for service stage=apply"
-        raise ValueError(msg)
 
     secrets[:] = collect_secret_values(instance)
     result: dict[str, Any]
@@ -455,15 +487,19 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
         }
         writeback = ExecutionMergeWriteback(results={"verification": result})
     elif stage == "apply":
+        # Deterministic first, and outside the guard: a run whose retained artifact does
+        # not match its binding or the operator's approved checksum is refused without
+        # making another writer wait.
         manifest = _verify_registered_apply(
             instance=instance,
             run_id=run_id,
             binding=parameter_binding,
             expected_checksum=expected_checksum,
         )
-        if parameter_binding is not None:
-            # The live schema read, and the comparison it exists for, both before any
-            # adapter is constructed: the registered pre-write gate.
+        with _configuration_write_guard(_require_registered_write(parameter_binding)) as guard:
+            ownership = ProvenWriteOwnership(prove=guard.require_ownership, tracker=tracker)
+            # The live schema read, and the comparison it exists for, both under the guard
+            # and both before any adapter is constructed: the registered pre-write gate.
             _, instance, sync_name = _worker_execution_context(
                 run_id,
                 parameter_binding,
@@ -473,14 +509,16 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 stage=stage,
             )
             _require_planned_schema(run_id=run_id, manifest=manifest, models=instance._runtime_models)
-        applied = execute_run(
-            instance,
-            operation="apply",
-            run_id=run_id,
-            branch=branch,
-            expected_checksum=expected_checksum,
-            confirm_writes=True,
-        )
+            applied = execute_run(
+                instance,
+                operation="apply",
+                run_id=run_id,
+                branch=branch,
+                expected_checksum=expected_checksum,
+                confirm_writes=True,
+                ownership=ownership,
+                _lock_already_held=True,
+            )
         assert isinstance(applied, RunResult)
         result = _result_data(applied)
         writeback = ExecutionFinishWriteback(
@@ -491,14 +529,24 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
             results=result,
         )
     else:
-        with bounded_run_lock(instance.name, timeout=60.0):
+        # One guard across planning, verification, and the write it approves: a plan
+        # generated outside it could go stale behind another writer before being applied.
+        with _configuration_write_guard(_require_registered_write(parameter_binding)) as guard:
+            ownership = ProvenWriteOwnership(prove=guard.require_ownership, tracker=tracker)
+            _, instance, sync_name = _worker_execution_context(
+                run_id,
+                parameter_binding,
+                config_directory=config_directory,
+                projection=projection,
+                run_branch=branch,
+                stage=stage,
+            )
             saved = _plan(instance, run_id=run_id, branch=branch, composed_sync=True)
             _publish_plan(projection, run_id, saved, secrets)
             verified = execute_run(
                 instance,
                 operation="verify",
                 run_id=run_id,
-                _lock_already_held=True,
                 _run_file_mode="sync",
                 _require_verified=True,
             )
@@ -509,8 +557,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 binding=parameter_binding,
                 expected_checksum=verified.manifest.plan_checksum,
             )
-            if parameter_binding is not None:
-                _require_planned_schema(run_id=run_id, manifest=manifest, models=instance._runtime_models)
+            _require_planned_schema(run_id=run_id, manifest=manifest, models=instance._runtime_models)
             applied = execute_run(
                 instance,
                 operation="apply",
@@ -518,6 +565,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 branch=branch,
                 expected_checksum=verified.manifest.plan_checksum,
                 confirm_writes=True,
+                ownership=ownership,
                 _lock_already_held=True,
                 _run_file_mode="sync",
             )
@@ -537,10 +585,12 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
 def _failure_evidence(
     stage: Literal["plan", "verify", "apply", "sync"],
     exc: Exception,
+    *,
+    outcome: str,
 ) -> dict[str, Any]:
     evidence: dict[str, Any] = {
         "stage": stage,
-        "outcome": "failed",
+        "outcome": outcome,
         "error_type": type(exc).__name__,
     }
     apply_record = getattr(exc, "apply_record", None)
@@ -549,7 +599,7 @@ def _failure_evidence(
     return evidence
 
 
-def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     run_id: str,
     stage: Literal["plan", "verify", "apply", "sync"],
     exc: Exception,
@@ -558,13 +608,23 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
     projection: ProductProjection,
     flow_run_id: str,
     worker_id: str,
+    *,
+    dispatch_started: bool,
 ) -> None:
-    """Best-effort durable product evidence without masking the worker failure."""
+    """Best-effort durable product evidence without masking the worker failure.
+
+    `dispatch_started` is the one thing this boundary cannot re-derive: only the stage
+    that ran knows whether it proved its hold and began a destination operation. Before
+    that point a failure is an ordinary failed run; after it, nothing can claim the
+    destination was left untouched, so the verdict is interrupted/ambiguous and the store
+    records that the run requires reconciliation in the same transaction.
+    """
     try:
         stored = projection.lookup_run(run_id).value
         if stored is None:
             return
-        evidence = _failure_evidence(stage, exc)
+        terminal_state, terminal_outcome = ("interrupted", "ambiguous") if dispatch_started else ("failed", "failed")
+        evidence = _failure_evidence(stage, exc, outcome=terminal_outcome)
         results: dict[str, Any] = {f"{stage}_failure": evidence}
         if stage == "verify":
             writeback: ExecutionWriteback = ExecutionMergeWriteback(results=results)
@@ -581,8 +641,8 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
                 if key in evidence
             }
             writeback = ExecutionFinishWriteback(
-                phase=f"{stage}-failed",
-                outcome="failed",
+                phase=f"{stage}-interrupted" if dispatch_started else f"{stage}-failed",
+                outcome=terminal_outcome,
                 finished_at=datetime.now(timezone.utc),
                 summary={**stored.summary, "failed_stage": stage, **partial},
                 results={**stored.results, **results},
@@ -592,8 +652,8 @@ def _record_failure(  # pylint: disable=too-many-arguments,too-many-positional-a
             flow_run_id,
             worker_id=worker_id,
             terminal_at=datetime.now(timezone.utc),
-            terminal_state="failed",
-            terminal_outcome="failed",
+            terminal_state=terminal_state,
+            terminal_outcome=terminal_outcome,
             writeback=writeback,
             secrets=secrets,
         )
@@ -623,6 +683,10 @@ def service_sync_run(  # pylint: disable=too-many-positional-arguments
     config_directory, projection = _runtime()
     flow_run_id, worker_id = _claim_current_execution(projection, run_id)
     secrets[:] = collect_secret_values()
+    # Owned here so the failure boundary can read it however the stage ended. Process-local
+    # diagnostic state for this one worker: never a receipt, a durable row, or an authority
+    # to replay anything.
+    tracker = WriteDispatchTracker()
     try:
         with _remote_log_bridge(run_logger, prefect_context=prefect_context, secrets=secrets):
             result, writeback = _execute_stage(
@@ -638,10 +702,21 @@ def service_sync_run(  # pylint: disable=too-many-positional-arguments
                 secrets=secrets,
                 config_directory=config_directory,
                 projection=projection,
+                tracker=tracker,
             )
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         # Rebuilt after the original exception context exits.
-        _record_failure(run_id, stage, exc, run_logger, secrets, projection, flow_run_id, worker_id)
+        _record_failure(
+            run_id,
+            stage,
+            exc,
+            run_logger,
+            secrets,
+            projection,
+            flow_run_id,
+            worker_id,
+            dispatch_started=tracker.dispatch_started,
+        )
         failure = sanitize_exception_chain(exc, secrets)
     if failure is not None:
         secrets.clear()

--- a/infrahub_sync/service/flow.py
+++ b/infrahub_sync/service/flow.py
@@ -520,6 +520,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 expected_checksum=expected_checksum,
                 confirm_writes=True,
                 ownership=ownership,
+                record_applied=tracker.record_applied,
                 _lock_already_held=True,
             )
         assert isinstance(applied, RunResult)
@@ -569,6 +570,7 @@ def _execute_stage(  # pylint: disable=too-many-arguments,too-many-positional-ar
                 expected_checksum=verified.manifest.plan_checksum,
                 confirm_writes=True,
                 ownership=ownership,
+                record_applied=tracker.record_applied,
                 _lock_already_held=True,
                 _run_file_mode="sync",
             )

--- a/infrahub_sync/service/models.py
+++ b/infrahub_sync/service/models.py
@@ -11,9 +11,10 @@ it, instead of publishing it silently.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import UnionType
+from typing import TYPE_CHECKING, Any, Union, cast, get_args, get_origin
 
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict
 
 from infrahub_sync.client.models import (
     ApplyRunRequest,
@@ -69,9 +70,76 @@ __all__ = [
 ]
 
 
+_EMITTED_CONFIG = ConfigDict(extra="ignore", frozen=True, str_strip_whitespace=True)
+
+
+def _bounded_annotation(annotation: Any, bounded: dict[type[BaseModel], type[BaseModel]]) -> Any:
+    """Rewrite one field annotation so every model inside it is bounded too.
+
+    Bounding a resource one level deep is not bounding it: the leak simply moves into the
+    first nested model that still accepts what it was not declared. So the rewrite walks
+    the annotation — through unions, tuples, and anything else generic — and swaps each
+    model it finds for that model's bounded twin.
+    """
+    origin = get_origin(annotation)
+    if origin is None:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return _bounded_model(annotation, bounded)
+        return annotation
+    arguments = tuple(_bounded_annotation(argument, bounded) for argument in get_args(annotation))
+    if origin in (Union, UnionType):
+        return Union[arguments]
+    return origin[arguments]
+
+
+def _bounded_model(model: type[BaseModel], bounded: dict[type[BaseModel], type[BaseModel]]) -> type[BaseModel]:
+    """Return the variant of `model` the server emits, bounded all the way down.
+
+    The twin subclasses the original, so it stays assignable wherever the declared type is
+    used and its fields cannot drift from the contract. Only the model-typed fields are
+    redeclared, carrying their own `FieldInfo` so defaults and constraints come with them.
+    """
+    existing = bounded.get(model)
+    if existing is not None:
+        return existing
+    annotations: dict[str, Any] = {}
+    namespace: dict[str, Any] = {
+        "model_config": _EMITTED_CONFIG,
+        "__doc__": f"The bounded variant of `{model.__name__}` the server emits.",
+    }
+    bounded[model] = model  # guards a self-referential field while this twin is being built
+    for name, field in model.model_fields.items():
+        rewritten = _bounded_annotation(field.annotation, bounded)
+        if rewritten is not field.annotation:
+            annotations[name] = rewritten
+            namespace[name] = field
+    namespace["__annotations__"] = annotations
+    twin = type(f"Emitted{model.__name__}", (model,), namespace)
+    bounded[model] = twin
+    return twin
+
+
+def bounded_emitted_model(model: type[BaseModel]) -> type[BaseModel]:
+    """Return the bounded variant of one resource the server emits."""
+    return _bounded_model(model, {})
+
+
+EmittedRunResource = cast("type[PublicRunResource]", bounded_emitted_model(PublicRunResource))
+EmittedPlanResource = cast("type[PlanResource]", bounded_emitted_model(PlanResource))
+
+# What the server builds out of data it did not write literally, and therefore what the
+# boundedness check in the test suite walks.
+EMITTED_RESOURCES: tuple[type[BaseModel], ...] = (EmittedRunResource, EmittedPlanResource)
+# The run resource declares its executions as bounded, so the projection has to build them
+# that way; a parent-class instance is not one of these.
+_EmittedExecutionLink = cast(
+    "type[PublicExecutionLink]", EmittedRunResource.model_fields["prefect_executions"].annotation.__args__[0]
+)
+
+
 def public_execution_link(link: PrefectExecutionLink) -> PublicExecutionLink:
     """Project one persistence record without internal worker identities."""
-    return PublicExecutionLink.model_validate(
+    return _EmittedExecutionLink.model_validate(
         link.model_dump(
             include={
                 "flow_run_id",
@@ -85,19 +153,7 @@ def public_execution_link(link: PrefectExecutionLink) -> PublicExecutionLink:
     )
 
 
-class EmittedRunResource(PublicRunResource):
-    """The run resource the server emits: only its declared fields may appear."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
-
-
-class EmittedPlanResource(PlanResource):
-    """The plan resource the server emits, read back from a retained artifact."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
-
-
-def public_run_resource(run: ProductRun) -> EmittedRunResource:
+def public_run_resource(run: ProductRun) -> PublicRunResource:
     """Project a store run into the self-contained public wire resource.
 
     The projection copies the record's fields wholesale, so the strict variant is what

--- a/infrahub_sync/service/models.py
+++ b/infrahub_sync/service/models.py
@@ -1,8 +1,19 @@
-"""Server projections into the neutral Sync HTTP contract."""
+"""Server projections into the neutral Sync HTTP contract.
+
+The client's resource models tolerate fields they do not declare, so a client stays
+readable against a newer server. The server may not: what it emits is an operator-facing
+surface, and it has to own everything that can appear in there. So every resource the
+server *builds* from data it did not write literally — a store record's fields, a retained
+artifact's bytes — is validated through a strict variant of the same model. Adding an
+internal field to a durable record therefore forces an explicit decision about publishing
+it, instead of publishing it silently.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
+from pydantic import ConfigDict
 
 from infrahub_sync.client.models import (
     ApplyRunRequest,
@@ -74,9 +85,26 @@ def public_execution_link(link: PrefectExecutionLink) -> PublicExecutionLink:
     )
 
 
-def public_run_resource(run: ProductRun) -> PublicRunResource:
-    """Project a store run into the self-contained public wire resource."""
-    return PublicRunResource.model_validate(
+class EmittedRunResource(PublicRunResource):
+    """The run resource the server emits: only its declared fields may appear."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+
+class EmittedPlanResource(PlanResource):
+    """The plan resource the server emits, read back from a retained artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+
+def public_run_resource(run: ProductRun) -> EmittedRunResource:
+    """Project a store run into the self-contained public wire resource.
+
+    The projection copies the record's fields wholesale, so the strict variant is what
+    keeps a future internal field from reaching an operator without anyone choosing to
+    publish it.
+    """
+    return EmittedRunResource.model_validate(
         {
             **run.model_dump(exclude={"prefect_executions"}),
             "prefect_executions": tuple(public_execution_link(link) for link in run.prefect_executions),

--- a/infrahub_sync/service/service.py
+++ b/infrahub_sync/service/service.py
@@ -28,6 +28,7 @@ from .models import (
     ArtifactListResource,
     CancelRunRequest,
     CreateRunRequest,
+    EmittedPlanResource,
     OrchestrationSummary,
     PlanResource,
     ResultsResource,
@@ -820,7 +821,7 @@ class RunService:
                 raise self._error(410, "artifact-expired", "the retained plan has expired", run_id=run_id)
             raise self._error(503, "plan-unavailable", "the retained plan cannot be retrieved", run_id=run_id)
         try:
-            return PlanResource.model_validate_json(result.value)
+            return EmittedPlanResource.model_validate_json(result.value)
         except (ValidationError, ValueError):
             raise self._error(503, "plan-unavailable", "the retained plan is invalid", run_id=run_id) from None
 

--- a/infrahub_sync/service/service.py
+++ b/infrahub_sync/service/service.py
@@ -49,8 +49,8 @@ PLAN_ARTIFACT_ID = "plan-review"
 
 def _reservation_outcome(receipt: MutationReceipt) -> str:
     """Name what an already-answered receipt is: a replay, or this run's stored refusal."""
-    status = receipt.response_status
-    return "replayed" if status is None or status < 400 else "refused-run-execution-conflict"
+    assert receipt.response_status is not None  # an accepted receipt always stores its status.
+    return "replayed" if receipt.response_status < 400 else "refused-run-execution-conflict"
 
 
 def _service_status(snapshot: PoolStatus) -> ServiceStatusResource:

--- a/infrahub_sync/service/service.py
+++ b/infrahub_sync/service/service.py
@@ -20,7 +20,6 @@ from infrahub_sync.product_store import (
     PrefectExecutionLink,
     ProductProjection,
     ProductRun,
-    WriteAdmissionConflictError,
 )
 
 from .liveness import CancellationSelectionUnavailableError, select_cancellable_execution
@@ -46,6 +45,12 @@ if TYPE_CHECKING:
     from .auth import Principal
 
 PLAN_ARTIFACT_ID = "plan-review"
+
+
+def _reservation_outcome(receipt: MutationReceipt) -> str:
+    """Name what an already-answered receipt is: a replay, or this run's stored refusal."""
+    status = receipt.response_status
+    return "replayed" if status is None or status < 400 else "refused-run-execution-conflict"
 
 
 def _service_status(snapshot: PoolStatus) -> ServiceStatusResource:
@@ -294,30 +299,15 @@ class RunService:
                 "expected_checksum does not match the retained reviewed plan",
                 run_id=run_id,
             )
-        try:
-            receipt = self._reserve_existing(
-                run,
-                principal,
-                idempotency_key,
-                operation="apply",
-                reason=request.reason,
-                body=body,
-                admit_write=True,
-            )
-        except WriteAdmissionConflictError:
-            self._audit(
-                run_id,
-                actor=principal.actor,
-                operation="apply",
-                reason=request.reason,
-                outcome="refused-apply-admission",
-            )
-            raise self._error(
-                409,
-                "apply-already-admitted",
-                "a write-capable apply stage is already admitted for this Sync run",
-                run_id=run_id,
-            ) from None
+        receipt = self._reserve_existing(
+            run,
+            principal,
+            idempotency_key,
+            operation="apply",
+            reason=request.reason,
+            body=body,
+            admit_write=True,
+        )
         return await self._resume_or_replay(receipt, parameters, principal, request.reason)
 
     async def cancel_run(  # noqa: PLR0911  # pylint: disable=too-many-branches,too-many-return-statements,too-many-statements
@@ -640,6 +630,7 @@ class RunService:
             self._projection.add_prefect_execution(
                 receipt.run_id,
                 link,
+                receipt_id=receipt.receipt_id,
                 allocate_attempt=True,
                 secrets=self._secrets,
             )
@@ -739,7 +730,7 @@ class RunService:
                 actor=principal.actor,
                 operation=receipt.operation,
                 reason=reason,
-                outcome="replayed",
+                outcome=_reservation_outcome(receipt),
             )
             return self._stored_response(receipt)
         return await self._submit(receipt, parameters, principal, reason)

--- a/infrahub_sync/service/storage.py
+++ b/infrahub_sync/service/storage.py
@@ -17,6 +17,7 @@ from infrahub_sync.product_store import (
     ProductStoreProviderError,
     production_product_projection,
 )
+from infrahub_sync.service.apply_guard import connect_guard_session, dsn_secret_values
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -163,6 +164,29 @@ def _database_url(values: Mapping[str, str]) -> str:
         msg = f"{DATABASE_URL_ENV} must be a PostgreSQL connection string"
         raise ValueError(msg) from None
     return database_url
+
+
+def service_guard_session(*, environ: Mapping[str, str] | None = None) -> psycopg.Connection[Any]:
+    """Open the configuration write guard's own direct PostgreSQL session.
+
+    The guard holds a session-level advisory lock across a whole write, so it needs a
+    dedicated direct session rather than a product-store connection. It reuses the one
+    service database setting: there is no separate guard connection string, and this
+    session is never handed to an adapter or to the product store.
+    """
+    values: Mapping[str, str] = os.environ if environ is None else environ
+    return connect_guard_session(_database_url(values))
+
+
+def service_guard_secrets(*, environ: Mapping[str, str] | None = None) -> tuple[str, ...]:
+    """Return the redaction values the service database setting itself carries.
+
+    A keyword connection string is not URL-shaped, so the environment collector cannot see
+    its password; without this, a driver message could carry it out through a guard
+    failure's cause chain.
+    """
+    values: Mapping[str, str] = os.environ if environ is None else environ
+    return dsn_secret_values(_database_url(values))
 
 
 def _endpoint(values: Mapping[str, str]) -> str | None:

--- a/infrahub_sync/utils.py
+++ b/infrahub_sync/utils.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.schema import GenericSchema, NodeSchema
 
     from infrahub_sync.plan.models import ApplyRecord
+    from infrahub_sync.plan.ownership import WriteOwnership
     from infrahub_sync.plan.reader import RawPlanArtifact
     from infrahub_sync.runtime_schema import RuntimeModelPlan
 
@@ -418,6 +419,7 @@ class PlanApplier:
     def apply_plan(
         self,
         *,
+        ownership: WriteOwnership,
         config_version: str | None = None,
         allow_destination_change: bool = False,
         expected_checksum: str | None = None,
@@ -437,6 +439,9 @@ class PlanApplier:
 
         `expected_checksum` travels to the engine rather than being answered here, so the
         operator's approval is decided against the artifact the apply loop consumes.
+        `ownership` travels with it, required and without a default, because this seam
+        assembles the apply and an apply assembled without a write-ownership boundary is
+        an unguarded write.
 
         Raises:
             PlanVerificationError: the plan was computed against a different destination
@@ -445,7 +450,10 @@ class PlanApplier:
         artifact = read_plan_artifact_bytes(self.run_dir)
         self._require_recorded_destination(artifact=artifact, allow_destination_change=allow_destination_change)
         return self.engine.apply_plan(
-            config_version=config_version, artifact=artifact, expected_checksum=expected_checksum
+            ownership=ownership,
+            config_version=config_version,
+            artifact=artifact,
+            expected_checksum=expected_checksum,
         )
 
     def _require_recorded_destination(self, *, artifact: RawPlanArtifact, allow_destination_change: bool) -> None:

--- a/tests/adapters/test_infrahub_planned_write.py
+++ b/tests/adapters/test_infrahub_planned_write.py
@@ -59,6 +59,7 @@ from infrahub_sync.plan.review import read_saved_plan
 from infrahub_sync.plan.write_surface import PlannedWriteDestination
 from infrahub_sync.potenda import Potenda
 from tests.plan.artifact_fixtures import CONFIG_VERSION, SYNC_NAME, operation_record, write_artifact
+from tests.plan.ownership_fixtures import granted_ownership
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -1153,7 +1154,7 @@ def apply_and_record_state(engine: Potenda) -> tuple[str, ApplyRecord | Exceptio
     fails, rather than an inference from the absence of an exception (AD055).
     """
     try:
-        record = engine.apply_plan(config_version=CONFIG_VERSION)
+        record = engine.apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
     except Exception as exc:  # noqa: BLE001 — the CLI catches exactly this broadly
         return "failed", exc
     return "applied", record
@@ -1511,7 +1512,7 @@ def test_a_graphql_query_and_variables_never_reach_the_operator_message(tmp_path
 
     with pytest.raises(OperationApplyFailedError) as caught:
         engine_over(directory, RecordingApplyDestination(reject_at=0, rejection=rejection)).apply_plan(
-            config_version=CONFIG_VERSION
+            ownership=granted_ownership(), config_version=CONFIG_VERSION
         )
 
     assert secret not in str(caught.value)

--- a/tests/cache/test_apply_plan.py
+++ b/tests/cache/test_apply_plan.py
@@ -37,6 +37,7 @@ from infrahub_sync.plan.reader import parse_plan_artifact
 from infrahub_sync.plan.verify import GATED_CHECKS
 from infrahub_sync.potenda import Potenda
 from tests.plan.artifact_fixtures import CONFIG_VERSION, operation_record, write_artifact
+from tests.plan.ownership_fixtures import granted_ownership
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -113,7 +114,7 @@ def test_apply_plan_executes_the_stored_operations_in_stored_order(tmp_path: Pat
     assert stored_order != sorted(stored_order), "the fixture must not already be in sorted order"
 
     destination = RecordingDestination()
-    record = _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+    record = _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert destination.dispatched == stored_order
     assert record.applied_operations == tuple(stored_order)
@@ -133,7 +134,9 @@ def test_apply_plan_writes_no_run_file(tmp_path: Path) -> None:
     run_file = directory / "run.json"
     run_file.write_text(SENTINEL_RUN_FILE, encoding="utf-8")
 
-    record = _potenda(directory, RecordingDestination()).apply_plan(config_version=CONFIG_VERSION)
+    record = _potenda(directory, RecordingDestination()).apply_plan(
+        ownership=granted_ownership(), config_version=CONFIG_VERSION
+    )
 
     assert run_file.read_text(encoding="utf-8") == SENTINEL_RUN_FILE
     assert record.as_summary_keys() == {
@@ -151,7 +154,9 @@ def test_a_destination_without_the_write_surface_is_refused_before_any_write(tmp
     write_artifact(directory, [operation_record()], run_id=RUN_ID, source_snapshot=[])
 
     with pytest.raises(PlanVerificationError) as caught:
-        _potenda(directory, SurfacelessDestination()).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, SurfacelessDestination()).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION
+        )
 
     message = str(caught.value)
     assert "write_surface" in message
@@ -168,7 +173,9 @@ def test_a_recorded_delete_is_collected_and_never_dispatched(tmp_path: Path, cap
 
     destination = RecordingDestination()
     with caplog.at_level(logging.DEBUG, logger="infrahub_sync.potenda"):
-        record = _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        record = _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION
+        )
 
     assert destination.dispatched == [create["operation_id"]]
     assert record.applied_operations == (create["operation_id"],)
@@ -193,7 +200,7 @@ def test_an_action_outside_the_vocabulary_fails_before_any_dispatch(tmp_path: Pa
 
     destination = RecordingDestination()
     with pytest.raises(UnsupportedOperationActionError) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert destination.dispatched == [], "Nothing is dispatched: the refusal precedes the first write."
     message = str(caught.value)
@@ -211,7 +218,9 @@ def test_a_changed_configuration_version_refuses_the_apply(tmp_path: Path) -> No
 
     destination = RecordingDestination()
     with pytest.raises(PlanVerificationError) as caught:
-        _potenda(directory, destination).apply_plan(config_version="a-different-configuration-version")
+        _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version="a-different-configuration-version"
+        )
 
     assert "config_version" in str(caught.value)
     assert destination.dispatched == []
@@ -231,7 +240,7 @@ def test_an_approved_checksum_matching_the_artifact_applies(tmp_path: Path) -> N
 
     destination = RecordingDestination()
     applied = _potenda(directory, destination).apply_plan(
-        config_version=CONFIG_VERSION, expected_checksum=_recorded_checksum(directory)
+        ownership=granted_ownership(), config_version=CONFIG_VERSION, expected_checksum=_recorded_checksum(directory)
     )
 
     assert destination.dispatched == [record_written["operation_id"]]
@@ -251,7 +260,9 @@ def test_an_unapproved_artifact_is_refused_by_the_engine_before_any_dispatch(tmp
 
     destination = RecordingDestination()
     with pytest.raises(PlanVerificationError) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION, expected_checksum="0" * 64)
+        _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION, expected_checksum="0" * 64
+        )
 
     assert destination.dispatched == [], "nothing may be dispatched for a plan no approval named"
     message = str(caught.value)
@@ -269,7 +280,9 @@ def test_an_unhashable_artifact_refuses_an_approval_rather_than_passing_it(tmp_p
 
     destination = RecordingDestination()
     with pytest.raises(PlanVerificationError):
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION, expected_checksum="0" * 64)
+        _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION, expected_checksum="0" * 64
+        )
 
     assert destination.dispatched == []
 
@@ -283,7 +296,7 @@ def test_no_configuration_and_no_supplied_version_refuses_before_any_write(tmp_p
     with pytest.raises(
         ValueError, match="needs a configuration version to compare the plan artifact against"
     ) as caught:
-        _potenda(directory, destination).apply_plan()
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership())
 
     message = str(caught.value)
     assert "construct Potenda with a parsed configuration, or pass `config_version`" in message, message
@@ -298,13 +311,17 @@ def test_an_empty_plan_applies_as_a_successful_no_op(tmp_path: Path) -> None:
     directory = _run_dir(tmp_path)
     write_artifact(directory, [], run_id=RUN_ID, source_snapshot=[])
 
-    record = _potenda(directory, RecordingDestination()).apply_plan(config_version=CONFIG_VERSION)
+    record = _potenda(directory, RecordingDestination()).apply_plan(
+        ownership=granted_ownership(), config_version=CONFIG_VERSION
+    )
 
     assert record.applied_operations == ()
     assert record.skipped_delete_count == 0
 
     with pytest.raises(PlanVerificationError):
-        _potenda(directory, SurfacelessDestination()).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, SurfacelessDestination()).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION
+        )
 
 
 # ======================================================================================
@@ -320,7 +337,7 @@ def test_an_identity_value_disagreement_refuses_the_apply_before_any_destination
     destination = RecordingDestination()
 
     with pytest.raises(PlanArtifactTornError):
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert destination.dispatched == []
 
@@ -333,7 +350,9 @@ def test_a_tear_and_a_config_version_mismatch_are_both_reported_by_one_apply_att
     destination = RecordingDestination()
 
     with pytest.raises(PlanVerificationError) as caught:
-        _potenda(directory, destination).apply_plan(config_version="a-different-configuration-version")
+        _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version="a-different-configuration-version"
+        )
 
     message = str(caught.value)
     assert "torn_operations" in message
@@ -349,7 +368,9 @@ def test_the_format_version_gate_tells_the_operator_what_it_did_not_evaluate(tmp
     destination = RecordingDestination()
 
     with pytest.raises(PlanVerificationError) as caught:
-        _potenda(directory, destination).apply_plan(config_version="a-different-configuration-version")
+        _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version="a-different-configuration-version"
+        )
 
     message = str(caught.value)
     assert "1 pre-apply check(s) failed" in message
@@ -366,7 +387,7 @@ def test_a_run_holding_no_plan_artifact_keeps_its_own_verdict(tmp_path: Path) ->
     destination = RecordingDestination()
 
     with pytest.raises(PlanFormatV1Error) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert "holds no plan artifact" in str(caught.value)
     assert destination.dispatched == []
@@ -393,7 +414,9 @@ def test_an_artifact_substituted_after_verification_is_not_what_gets_applied(tmp
 
     destination = RecordingDestination()
     with patch("infrahub_sync.plan.verify.verify_plan", _substituting_verify):
-        record = _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        record = _potenda(directory, destination).apply_plan(
+            ownership=granted_ownership(), config_version=CONFIG_VERSION
+        )
 
     assert destination.dispatched == [verified[0]["operation_id"]]
     assert record.applied_operations == (verified[0]["operation_id"],)
@@ -429,7 +452,7 @@ def test_a_failure_after_the_base_write_names_the_operation_and_marks_the_partia
     destination = PartiallyWritingDestination()
 
     with pytest.raises(OperationApplyFailedError) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     failing_id = str(records[1]["operation_id"])
     assert destination.base_writes == [str(records[0]["operation_id"]), failing_id], (
@@ -489,7 +512,7 @@ def test_a_known_destination_failure_is_wrapped_with_the_operation_and_run_conte
     destination = DefectiveDestination(rejection)
 
     with pytest.raises(OperationApplyFailedError) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     message = str(caught.value)
     assert str(records[1]["operation_id"]) in message, "the refusal names the operation that failed"
@@ -526,7 +549,7 @@ def test_a_code_defect_escapes_the_apply_unchanged_and_still_carries_the_partial
     destination = DefectiveDestination(defect)
 
     with pytest.raises(type(defect)) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert caught.value is defect, "the defect reached the caller as itself, not as a copy or a wrapper"
     carried = getattr(caught.value, "apply_record", None)
@@ -553,7 +576,7 @@ def test_an_interrupt_mid_apply_propagates_as_itself_and_carries_the_partial_rec
     destination = InterruptingDestination()
 
     with pytest.raises(KeyboardInterrupt) as caught:
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert destination.dispatched == [records[0]["operation_id"]]
     partial = getattr(caught.value, "apply_record", None)
@@ -582,7 +605,7 @@ def test_the_invariant_error_carries_the_record_of_what_was_actually_written(tmp
         patch("infrahub_sync.plan.reader.parse_plan_artifact", _inflated_count),
         pytest.raises(ApplyRecordInvariantError) as caught,
     ):
-        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)
+        _potenda(directory, destination).apply_plan(ownership=granted_ownership(), config_version=CONFIG_VERSION)
 
     assert destination.dispatched == list(applied_ids)
     assert caught.value.apply_record.applied_operations == applied_ids

--- a/tests/integration/test_managed_write_guard_integration.py
+++ b/tests/integration/test_managed_write_guard_integration.py
@@ -1,0 +1,277 @@
+"""Opt-in proof that the managed write path serializes real workers on real PostgreSQL.
+
+The unit suites drive the managed composition against a scripted session. What they
+cannot show is the fact the whole design rests on: that two *independent worker
+processes*, each opening its own direct session from the service database setting,
+cannot both hold one configuration's write key — and that a worker whose backend dies
+mid-apply cannot dispatch its next operation.
+
+WARNING: point the DSN only at a disposable, single-purpose database. These tests
+terminate backends on it.
+
+Opt in with ``-m integration`` and a reachable ``APPLY_GUARD_TEST_POSTGRESQL_DSN``::
+
+    docker run -d --rm --name ph3-pg16 -e POSTGRES_PASSWORD=probe -e POSTGRES_DB=guardprobe \\
+        -p 127.0.0.1:55433:5432 postgres:16-alpine
+    APPLY_GUARD_TEST_POSTGRESQL_DSN="host=127.0.0.1 port=55433 user=postgres password=probe dbname=guardprobe" \\
+        uv run pytest -m integration tests/integration/test_managed_write_guard_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # noqa: S404 - the worker processes run a fixed interpreter and inline script.
+import sys
+import textwrap
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+psycopg: Any = pytest.importorskip("psycopg")
+pytest.importorskip("prefect")
+
+# Imported after the skip: these modules import psycopg and prefect themselves, so a
+# static import here would raise instead of skipping where an extra is absent.
+from infrahub_sync.plan.errors import OperationApplyFailedError  # noqa: E402
+from infrahub_sync.potenda import Potenda  # noqa: E402
+from infrahub_sync.service.apply_guard import (  # noqa: E402
+    ApplyGuardOwnershipError,
+    advisory_lock_key,
+    connect_guard_session,
+    hold_apply_guard,
+)
+from tests.plan.artifact_fixtures import CONFIG_VERSION, operation_record, write_artifact  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from infrahub_sync.plan.models import PlannedOperation
+
+pytestmark = pytest.mark.integration
+
+_Session = psycopg.Connection[Any]
+
+_DSN_ENVIRONMENT_NAME = "APPLY_GUARD_TEST_POSTGRESQL_DSN"
+_ALPHA = "managed-write-alpha"
+_BETA = "managed-write-beta"
+_RUN_ID = "20260903T1100-7ac31d04"
+_CHILD_TIMEOUT_SECONDS = 60
+
+# The managed composition itself, not a re-derivation of it: the child resolves the
+# service database setting and opens the guard exactly as a worker stage does.
+_WORKER_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    from infrahub_sync.plan.ownership import WriteDispatchTracker
+    from infrahub_sync.service.flow import _managed_write_guard
+
+    configuration_id = sys.argv[1]
+    with _managed_write_guard(configuration_id, tracker=WriteDispatchTracker()) as ownership:
+        print("HELD", flush=True)
+        sys.stdin.readline()
+        ownership.after_final_operation()
+    print("RELEASED", flush=True)
+    """
+)
+
+_ADVISORY_HOLDERS = """
+SELECT pid FROM pg_locks
+WHERE locktype = 'advisory' AND granted
+  AND classid::bigint = %s AND objid::bigint = %s AND objsubid = 1
+"""
+_TERMINATE = "SELECT pg_terminate_backend(%s)"
+
+
+def _dsn_or_skip() -> str:
+    """Return a reachable disposable DSN, or skip before any server is contacted."""
+    dsn = os.environ.get(_DSN_ENVIRONMENT_NAME)
+    if not dsn:
+        pytest.skip(f"the managed write-guard integration tests require {_DSN_ENVIRONMENT_NAME}")
+    try:
+        with psycopg.connect(dsn, connect_timeout=5) as probe:
+            probe.execute("SELECT 1")
+    except psycopg.Error:
+        pytest.skip(f"{_DSN_ENVIRONMENT_NAME} is not reachable")
+    return dsn
+
+
+@pytest.fixture(name="dsn")
+def dsn_fixture() -> str:
+    return _dsn_or_skip()
+
+
+@pytest.fixture(name="admin")
+def admin_fixture(dsn: str) -> Iterator[_Session]:
+    """One independent observer session that never holds a managed write key."""
+    with psycopg.connect(dsn, autocommit=True) as connection:
+        yield connection
+
+
+def _advisory_holders(admin: _Session, key: int) -> list[int]:
+    rows = admin.execute(_ADVISORY_HOLDERS, ((key >> 32) & 0xFFFFFFFF, key & 0xFFFFFFFF)).fetchall()
+    return sorted(row[0] for row in rows)
+
+
+def _worker(dsn: str, configuration_id: str) -> subprocess.Popen[str]:
+    """Start one independent worker process holding the managed write guard."""
+    environment = {**os.environ, "INFRAHUB_SYNC_DATABASE_URL": dsn}
+    return subprocess.Popen(  # noqa: S603 - fixed interpreter, fixed inline script.
+        [sys.executable, "-c", _WORKER_SCRIPT, configuration_id],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=environment,
+    )
+
+
+def _await_held(worker: subprocess.Popen[str]) -> None:
+    assert worker.stdout is not None
+    line = worker.stdout.readline().strip()
+    if line != "HELD":
+        stderr = "" if worker.stderr is None else worker.stderr.read()
+        pytest.fail(f"the managed worker never reported its hold: {line!r}; {stderr}")
+
+
+def _release(worker: subprocess.Popen[str]) -> str:
+    assert worker.stdin is not None
+    assert worker.stdout is not None
+    worker.stdin.write("\n")
+    worker.stdin.flush()
+    worker.wait(timeout=_CHILD_TIMEOUT_SECONDS)
+    return worker.stdout.read().strip()
+
+
+def _terminate(worker: subprocess.Popen[str]) -> None:
+    worker.kill()
+    worker.wait(timeout=_CHILD_TIMEOUT_SECONDS)
+
+
+@pytest.mark.parametrize("stage_configuration", [_ALPHA, _BETA])
+def test_two_managed_workers_for_one_configuration_serialize(
+    dsn: str, admin: _Session, stage_configuration: str
+) -> None:
+    """The second worker cannot enter the write path while the first one owns the key."""
+    key = advisory_lock_key(stage_configuration)
+    first = _worker(dsn, stage_configuration)
+    try:
+        _await_held(first)
+        assert len(_advisory_holders(admin, key)) == 1
+
+        second = _worker(dsn, stage_configuration)
+        try:
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                assert second.poll() is None or second.returncode != 0, "the blocked worker must not enter"
+                if len(_advisory_holders(admin, key)) != 1:
+                    pytest.fail("two independent managed workers held one configuration's write key")
+                time.sleep(0.1)
+
+            assert _release(first) == "RELEASED"
+            _await_held(second)
+            assert _release(second) == "RELEASED"
+        finally:
+            if second.poll() is None:
+                _terminate(second)
+    finally:
+        if first.poll() is None:
+            _terminate(first)
+
+    assert _advisory_holders(admin, key) == []
+
+
+def test_two_configurations_write_concurrently(dsn: str, admin: _Session) -> None:
+    """Serialization is per configuration; unrelated configurations must not block."""
+    alpha = _worker(dsn, _ALPHA)
+    beta = _worker(dsn, _BETA)
+    try:
+        _await_held(alpha)
+        _await_held(beta)
+
+        assert len(_advisory_holders(admin, advisory_lock_key(_ALPHA))) == 1
+        assert len(_advisory_holders(admin, advisory_lock_key(_BETA))) == 1
+
+        assert _release(alpha) == "RELEASED"
+        assert _release(beta) == "RELEASED"
+    finally:
+        for worker in (alpha, beta):
+            if worker.poll() is None:
+                _terminate(worker)
+
+
+class _RecordingDestination:
+    """A destination implementing the planned-write surface that records each dispatch."""
+
+    def __init__(self) -> None:
+        self.dispatched: list[str] = []
+
+    def new_peer_resolver(self) -> object:  # noqa: PLR6301
+        """The per-apply resolver factory; nothing below this double's surface reads it."""
+        return object()
+
+    def apply_planned_operation(self, *, operation: PlannedOperation, peers: Any) -> str:  # noqa: ANN401
+        _ = peers
+        self.dispatched.append(operation.operation_id)
+        return "node"
+
+
+def _two_operation_plan(tmp_path: Path) -> tuple[Path, list[str]]:
+    directory = tmp_path / _RUN_ID
+    directory.mkdir(parents=True, exist_ok=True)
+    records = [
+        operation_record(identity={"name": "first"}),
+        operation_record(identity={"name": "second"}),
+    ]
+    write_artifact(directory, records, run_id=_RUN_ID, source_snapshot=[])
+    return directory, [str(record["operation_id"]) for record in records]
+
+
+def test_a_lost_backend_after_the_first_operation_prevents_the_second(
+    dsn: str, admin: _Session, tmp_path: Path
+) -> None:
+    """A guard whose backend dies mid-apply cannot let the engine keep writing."""
+    from infrahub_sync.plan.ownership import (  # pylint: disable=import-outside-toplevel
+        ProvenWriteOwnership,
+        WriteDispatchTracker,
+    )
+
+    directory, operations = _two_operation_plan(tmp_path)
+    destination = _RecordingDestination()
+    key = advisory_lock_key(_ALPHA)
+
+    def apply_under_a_dying_session() -> None:
+        with hold_apply_guard(_ALPHA, connect=lambda: connect_guard_session(dsn)) as guard:
+            holders = _advisory_holders(admin, key)
+            assert len(holders) == 1
+
+            class _KillAfterFirst:
+                def __init__(self) -> None:
+                    self.calls = 0
+
+                def __call__(self) -> None:
+                    self.calls += 1
+                    if self.calls == 2:
+                        admin.execute(_TERMINATE, (holders[0],))
+                    guard.require_ownership()
+
+            Potenda(
+                source=SimpleNamespace(top_level=[]),  # ty: ignore[invalid-argument-type]
+                destination=destination,  # ty: ignore[invalid-argument-type]
+                config=None,  # ty: ignore[invalid-argument-type]
+                top_level=["BuiltinTag"],
+                run_dir=directory,
+                run_id=_RUN_ID,
+            ).apply_plan(
+                config_version=CONFIG_VERSION,
+                ownership=ProvenWriteOwnership(prove=_KillAfterFirst(), tracker=WriteDispatchTracker()),
+            )
+
+    with pytest.raises((ApplyGuardOwnershipError, OperationApplyFailedError)):
+        apply_under_a_dying_session()
+
+    assert destination.dispatched == [operations[0]]
+    assert _advisory_holders(admin, key) == []

--- a/tests/integration/test_managed_write_guard_integration.py
+++ b/tests/integration/test_managed_write_guard_integration.py
@@ -66,11 +66,12 @@ _WORKER_SCRIPT = textwrap.dedent(
     """
     import sys
 
-    from infrahub_sync.plan.ownership import WriteDispatchTracker
-    from infrahub_sync.service.flow import _managed_write_guard
+    from infrahub_sync.plan.ownership import ProvenWriteOwnership, WriteDispatchTracker
+    from infrahub_sync.service.flow import _configuration_write_guard
 
     configuration_id = sys.argv[1]
-    with _managed_write_guard(configuration_id, tracker=WriteDispatchTracker()) as ownership:
+    with _configuration_write_guard(configuration_id) as guard:
+        ownership = ProvenWriteOwnership(prove=guard.require_ownership, tracker=WriteDispatchTracker())
         print("HELD", flush=True)
         sys.stdin.readline()
         ownership.after_final_operation()

--- a/tests/integration/test_managed_write_guard_live.py
+++ b/tests/integration/test_managed_write_guard_live.py
@@ -30,7 +30,10 @@ lock readings distinguish serialization from luck, which is why every leg also r
 an observed waiting request.
 
 These legs need the live preview stack (`invoke preview.up` plus `invoke preview.seed`).
-They skip, naming what is missing, only when it is absent.
+An absent stack is the only thing they skip for, and the skip names the missing service.
+Psycopg is imported outright rather than skipped past: it ships with the service profile
+these legs exercise, so a missing driver is a broken environment, not a reason to report
+green.
 """
 
 from __future__ import annotations
@@ -43,16 +46,16 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from itertools import pairwise
+from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import psycopg
 import pytest
 from typing_extensions import Self
 
-psycopg: Any = pytest.importorskip("psycopg")
-
-from infrahub_sync.service.apply_guard import advisory_lock_key  # noqa: E402
-from tasks.preview import (  # noqa: E402
+from infrahub_sync.service.apply_guard import advisory_lock_key
+from tasks.preview import (
     SHARED_DEVICE_NAME,
     SMOKE_BRANCH,
     SMOKE_KIND,
@@ -429,6 +432,34 @@ def _assert_serialized(observations: KeyObservations, *, holder_pid: int) -> lis
     return worker_holds
 
 
+def _assert_each_plan_had_its_own_hold(first_published: dict[str, float], worker_holds: list[_Hold]) -> None:
+    """Require each published plan to sit in a hold of its own, in order.
+
+    "Inside some hold" is not the property: with holds `[10, 20]` and `[21, 30]`, two plans
+    published at 15 and 16 both sit inside a hold and both were nonetheless produced while
+    the *first* worker held the key — the exact violation this leg exists to exclude. Each
+    publication therefore has to claim a distinct hold, and because the holds are disjoint
+    and time-ordered, that is the same as saying no worker extracted or planned while
+    another held the key.
+
+    A contender that lost the key publishes nothing, so there are never more publications
+    than holds; requiring the counts to match is what stops a silent second publication
+    inside one hold from passing.
+    """
+    ordered = sorted(first_published.items(), key=itemgetter(1))
+    assert ordered, "no sync published a plan while sampled"
+    assert len(ordered) == len(worker_holds), (
+        f"{len(ordered)} plan publication(s) against {len(worker_holds)} worker hold(s): "
+        f"{ordered} versus {[(hold.pid, hold.first_seen, hold.last_seen) for hold in worker_holds]}"
+    )
+    for (run_id, published_at), hold in zip(ordered, worker_holds, strict=True):
+        assert hold.first_seen <= published_at <= hold.last_seen, (
+            f"run {run_id} published its reviewed plan at {published_at}, outside the hold it must "
+            f"have used — pid {hold.pid} [{hold.first_seen}, {hold.last_seen}] — so it extracted and "
+            f"planned while another worker held the configuration's key, or held none at all"
+        )
+
+
 def _assert_write_verdict(label: str, record: dict[str, Any]) -> bool:
     """Require one live write to have either run its stage or lost the key cleanly.
 
@@ -568,11 +599,33 @@ def test_two_live_sync_workers_serialize_extraction_and_planning(api: httpx.Clie
     completed = [label for label, record in records.items() if _assert_write_verdict(label, record)]
     assert completed, f"neither sync held the key long enough to run its write stage: {records}"
 
-    assert observations.first_published, "no sync published a plan while sampled"
-    for run_id, published_at in observations.first_published.items():
-        inside = [hold for hold in worker_holds if hold.first_seen <= published_at <= hold.last_seen]
-        assert inside, (
-            f"run {run_id} published its reviewed plan at {published_at}, outside every observed hold "
-            f"{[(hold.pid, hold.first_seen, hold.last_seen) for hold in worker_holds]} — so it extracted "
-            f"and planned without holding the configuration's key"
-        )
+    _assert_each_plan_had_its_own_hold(observations.first_published, worker_holds)
+
+
+def test_publications_must_claim_distinct_holds_in_order() -> None:
+    """The predicate the sync leg rests on, exercised on readings it must reject.
+
+    Two plans published at 15 and 16, against holds `[10, 20]` and `[21, 30]`, both sit
+    inside *a* hold — and both were produced while the first worker held the key, which is
+    the violation the leg exists to exclude. Requiring each publication to claim a hold of
+    its own, in order, is what tells that apart from the correct interleaving.
+
+    This case needs no stack: the predicate is pure, and its readings are the ones a broken
+    guard would produce.
+    """
+    holds = [_Hold(pid=1, first_seen=10.0, last_seen=20.0), _Hold(pid=2, first_seen=21.0, last_seen=30.0)]
+
+    with pytest.raises(AssertionError, match="outside the hold it must have used"):
+        _assert_each_plan_had_its_own_hold({"run-a": 15.0, "run-b": 16.0}, holds)
+
+    _assert_each_plan_had_its_own_hold({"run-a": 15.0, "run-b": 25.0}, holds)
+
+
+def test_a_contender_that_never_held_the_key_must_have_published_nothing() -> None:
+    """One worker holding means one plan: the loser extracted and planned nothing."""
+    holds = [_Hold(pid=1, first_seen=10.0, last_seen=20.0)]
+
+    _assert_each_plan_had_its_own_hold({"run-a": 15.0}, holds)
+
+    with pytest.raises(AssertionError, match="plan publication"):
+        _assert_each_plan_had_its_own_hold({"run-a": 15.0, "run-b": 16.0}, holds)

--- a/tests/integration/test_managed_write_guard_live.py
+++ b/tests/integration/test_managed_write_guard_live.py
@@ -50,7 +50,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 
 import httpx
-import psycopg
+import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
 import pytest
 from typing_extensions import Self
 

--- a/tests/integration/test_managed_write_guard_live.py
+++ b/tests/integration/test_managed_write_guard_live.py
@@ -31,9 +31,14 @@ an observed waiting request.
 
 These legs need the live preview stack (`invoke preview.up` plus `invoke preview.seed`).
 An absent stack is the only thing they skip for, and the skip names the missing service.
-Psycopg is imported outright rather than skipped past: it ships with the service profile
-these legs exercise, so a missing driver is a broken environment, not a reason to report
-green.
+
+Psycopg and the guard's key derivation are imported inside the functions that use them,
+never at module scope. The service extra installs psycopg only on the Python versions the
+Sync service supports, while this module is collected on every version the project
+supports — a module-scope import would make the whole suite uncollectable on the others,
+where these `integration`-marked legs are deselected anyway. What it is *not* is a
+dependency skip: a missing driver here raises, so it can never masquerade as an absent
+stack.
 """
 
 from __future__ import annotations
@@ -50,11 +55,9 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 
 import httpx
-import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
 import pytest
 from typing_extensions import Self
 
-from infrahub_sync.service.apply_guard import advisory_lock_key
 from tasks.preview import (
     SHARED_DEVICE_NAME,
     SMOKE_BRANCH,
@@ -111,6 +114,9 @@ class LiveStack:
 @pytest.fixture(name="live_stack", scope="session")
 def live_stack_fixture() -> LiveStack:
     """Return the running preview stack, or skip naming exactly what is missing."""
+    # pylint: disable-next=import-outside-toplevel
+    import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
     try:
         values = load_preview_env()
     except PreviewError as exc:
@@ -298,6 +304,9 @@ class _KeySampler:
     """
 
     def __init__(self, database_url: str, configuration_id: str, run_ids: list[str] | None = None) -> None:
+        # pylint: disable-next=import-outside-toplevel
+        from infrahub_sync.service.apply_guard import advisory_lock_key
+
         key = advisory_lock_key(configuration_id)
         self._columns = ((key >> 32) & 0xFFFFFFFF, key & 0xFFFFFFFF)
         self._database_url = database_url
@@ -317,6 +326,9 @@ class _KeySampler:
         self._thread.join(timeout=10)
 
     def _run(self) -> None:
+        # pylint: disable-next=import-outside-toplevel
+        import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
         with psycopg.connect(self._database_url, autocommit=True) as connection:
             while not self._stop.is_set():
                 rows = connection.execute(_HELD_KEY_SAMPLE, self._columns).fetchall()
@@ -360,6 +372,12 @@ class _KeyHolder:
     """
 
     def __init__(self, database_url: str, configuration_id: str) -> None:
+        # pylint: disable-next=import-outside-toplevel
+        import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
+        # pylint: disable-next=import-outside-toplevel
+        from infrahub_sync.service.apply_guard import advisory_lock_key
+
         self._key = advisory_lock_key(configuration_id)
         self._connection = psycopg.connect(database_url, autocommit=True)
         row = self._connection.execute(_TAKE_KEY, (self._key,)).fetchone()

--- a/tests/integration/test_managed_write_guard_live.py
+++ b/tests/integration/test_managed_write_guard_live.py
@@ -1,0 +1,578 @@
+"""Two live workers, one registered configuration: the guard is what serializes them.
+
+These legs contend from **two different runs of the same configuration**, which is the
+only shape that puts the advisory guard under test. Two writes on one run are refused by
+the store's admission arbitration long before a worker starts, so a test built that way
+would prove the admission rule and say nothing about the lock. Admission is per run, so
+both runs here are admitted, both reach a worker, and what has to keep them apart is the
+PostgreSQL advisory key derived from their shared `config_id`.
+
+The evidence is read from the service database's own `pg_locks`: which backends held that
+exact key, when, and whether they had to wait for it. A run that merely happened to start
+after another proves nothing about serialization — measured here, two workers submitted
+together were staggered by start-up alone often enough to make an incidental overlap
+useless as evidence. So each leg takes the configuration's key itself first, releases it
+only once **both** workers are observed blocked on that exact key, and then reads what the
+two of them do with it. Both being blocked at once is the fact that makes what follows
+serialization rather than luck.
+
+The composed-sync leg adds the half of the property that is easy to lose: its second
+worker must perform no destination extraction and no planning until the first releases.
+A sync publishes its reviewed plan from inside the guarded region, after extracting both
+sides, so the leg reads each run's plan publication against the hold windows — the second
+run must have published nothing while the first still held the key, and its own
+publication must fall inside its own hold.
+
+Run outcomes are deliberately *not* evidence here. Measured against two unrelated
+configurations, which the guard does not serialize at all, the pair still came back
+`applied` and `no-change`, because worker start-up staggered them on its own. Only the
+lock readings distinguish serialization from luck, which is why every leg also requires
+an observed waiting request.
+
+These legs need the live preview stack (`invoke preview.up` plus `invoke preview.seed`).
+They skip, naming what is missing, only when it is absent.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import pytest
+from typing_extensions import Self
+
+psycopg: Any = pytest.importorskip("psycopg")
+
+from infrahub_sync.service.apply_guard import advisory_lock_key  # noqa: E402
+from tasks.preview import (  # noqa: E402
+    SHARED_DEVICE_NAME,
+    SMOKE_BRANCH,
+    SMOKE_KIND,
+    PreviewError,
+    load_preview_env,
+    preview_urls,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.integration
+
+_MAPPED_FIELDS = ("name", "type")
+_SAMPLE_INTERVAL_SECONDS = 0.02
+_PHASE_TIMEOUT_SECONDS = 420
+_PHASE_POLL_SECONDS = 2
+_HOLDER_COUNT = 2
+_BLOCKED_WORKERS = 2
+# How long both submitted writes may take to reach the guard. This is Prefect worker
+# start-up — queue poll plus a fresh interpreter — and it is unrelated to the guard, so it
+# gets a generous budget. Waiting this long deliberately outlasts the guard's own
+# 30-second acquisition deadline for whichever worker blocked first, which is why these
+# legs accept that worker taking the specified contention result instead of the key.
+_BOTH_BLOCKED_TIMEOUT_SECONDS = 180
+_BLOCKED_POLL_SECONDS = 0.1
+_CONTENTION_ERROR = "ApplyGuardContentionError"
+# A write stage that ran to completion reports what its plan did. `no-change` is a success:
+# the second contender often plans after the first has already written, and finds the
+# destination converged.
+_COMPLETED_OUTCOMES = frozenset({"applied", "no-change"})
+
+_HELD_KEY_SAMPLE = (
+    "SELECT pid, granted FROM pg_locks "
+    "WHERE locktype = 'advisory' AND classid::bigint = %s AND objid::bigint = %s AND objsubid = 1"
+)
+_PUBLISHED_PLANS = "SELECT run_id FROM artifact_refs WHERE run_id = ANY(%s) AND published = 1"
+_TAKE_KEY = "SELECT pg_advisory_lock(%s), pg_backend_pid()"
+_DROP_KEY = "SELECT pg_advisory_unlock(%s)"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveStack:
+    """The reachable preview endpoints one leg drives."""
+
+    sync_api: str
+    infrahub: str
+    infrahub_token: str
+    bearer_token: str
+    database_url: str
+
+
+@pytest.fixture(name="live_stack", scope="session")
+def live_stack_fixture() -> LiveStack:
+    """Return the running preview stack, or skip naming exactly what is missing."""
+    try:
+        values = load_preview_env()
+    except PreviewError as exc:
+        pytest.skip(f"preview settings unavailable ({exc}); start the stack with `invoke preview.up`")
+    urls = preview_urls(values)
+    database_url = f"postgresql://postgres:postgres@127.0.0.1:{values['PREVIEW_STORAGE_POSTGRES_PORT']}/infrahub_sync"
+    for description, url in (
+        ("Sync API", f"{urls['sync_api']}/openapi.json"),
+        ("Infrahub", f"{urls['infrahub']}/api/config"),
+        ("Prefect", f"{urls['prefect']}/api/health"),
+    ):
+        try:
+            response = httpx.get(url, timeout=10)
+        except httpx.HTTPError as exc:
+            pytest.skip(f"preview {description} unreachable at {url} ({exc}); start it with `invoke preview.up`")
+        if response.status_code >= 500:
+            pytest.skip(f"preview {description} unhealthy at {url} (HTTP {response.status_code})")
+    try:
+        with psycopg.connect(database_url, connect_timeout=10) as probe:
+            probe.execute("SELECT 1")
+    except psycopg.Error as exc:
+        pytest.skip(f"preview service PostgreSQL unreachable ({exc}); start it with `invoke preview.up`")
+    principals = json.loads(values["PREVIEW_BEARER_TOKENS"])
+    actor = min(principals)
+    return LiveStack(
+        sync_api=urls["sync_api"],
+        infrahub=urls["infrahub"],
+        infrahub_token=values["INFRAHUB_INITIAL_ADMIN_TOKEN"],
+        bearer_token=principals[actor]["token"],
+        database_url=database_url,
+    )
+
+
+@pytest.fixture(name="api")
+def api_fixture(live_stack: LiveStack) -> Iterator[httpx.Client]:
+    """A bearer-authenticated client for the live Sync API."""
+    with httpx.Client(
+        base_url=live_stack.sync_api,
+        headers={"Authorization": f"Bearer {live_stack.bearer_token}"},
+        timeout=60,
+    ) as client:
+        yield client
+
+
+def _idempotency_headers() -> dict[str, str]:
+    """A fresh key per mutation, so a re-run never replays an earlier leg's response."""
+    return {"Idempotency-Key": f"guard-live-{uuid.uuid4()}"}
+
+
+def _register_configuration(api: httpx.Client, live_stack: LiveStack, name: str) -> tuple[str, int]:
+    """Register this leg's own package and return the identity the API assigned it.
+
+    Each leg registers its own, because the advisory key is derived from the `config_id`:
+    sharing one with another leg or with leftover probe state would let unrelated work
+    contend for the key this leg is measuring.
+    """
+    package = {
+        "format_version": 1,
+        "configuration": {
+            "name": name,
+            "source": {
+                "name": "infrahub",
+                "settings": {
+                    "url": live_stack.infrahub,
+                    "branch": "main",
+                    "token": {"$credential": "infrahub-token"},
+                },
+            },
+            "destination": {
+                "name": "infrahub",
+                "settings": {
+                    "url": live_stack.infrahub,
+                    "branch": SMOKE_BRANCH,
+                    "token": {"$credential": "infrahub-token"},
+                },
+            },
+            "schema_mapping": [
+                {
+                    "name": SMOKE_KIND,
+                    "mapping": SMOKE_KIND,
+                    "identifiers": ["name"],
+                    "fields": [{"name": field_name, "mapping": field_name} for field_name in _MAPPED_FIELDS],
+                }
+            ],
+        },
+        "credentials": {"infrahub-token": {"provider": "env", "identifier": "INFRAHUB_API_TOKEN"}},
+    }
+    registered = api.post(
+        "/configs",
+        headers=_idempotency_headers(),
+        json={"package": package, "reason": f"live write-guard leg: register {name}"},
+    )
+    assert registered.status_code == 201, registered.text
+    version = registered.json()["version"]
+    return version["config_id"], version["registry_version"]
+
+
+def _seed_one_source_update(live_stack: LiveStack) -> str:
+    """Leave the source differing from the destination in exactly one mapped value.
+
+    Mirroring the destination's devices into `main` verbatim removes everything else from
+    the plan; mutating the shared device afterwards leaves the single update these legs
+    contend over. The value is fresh on every run, because a fixed one converges after the
+    first apply and the update the assertions rest on quietly vanishes.
+    """
+    from infrahub_sdk import InfrahubClientSync  # pylint: disable=import-outside-toplevel
+
+    client = InfrahubClientSync(address=live_stack.infrahub, config={"api_token": live_stack.infrahub_token})
+    # Copied verbatim, every mapped field: a mirror carrying any manufactured value would
+    # be an update, and an update rewriting a device's own unique name is rejected.
+    payloads = [
+        {name: getattr(node, name).value for name in _MAPPED_FIELDS}
+        for node in client.all(kind=SMOKE_KIND, branch=SMOKE_BRANCH)
+    ]
+    assert SHARED_DEVICE_NAME in {payload["name"] for payload in payloads}, (
+        f"{SHARED_DEVICE_NAME!r} is not on {SMOKE_BRANCH}; run `uv run invoke preview.seed`"
+    )
+    for payload in payloads:
+        client.create(kind=SMOKE_KIND, branch="main", data=payload).save(allow_upsert=True)
+    mutated_type = f"guard-live-{uuid.uuid4().hex[:12]}"
+    shared = client.create(kind=SMOKE_KIND, branch="main", data={"name": SHARED_DEVICE_NAME, "type": mutated_type})
+    shared.save(allow_upsert=True)
+    return mutated_type
+
+
+def _await_phase(api: httpx.Client, run_id: str, phase: str) -> dict[str, Any]:
+    """Poll the durable record until it reaches `phase`, failing on any terminal detour."""
+    record = _await_terminal(api, run_id, phase, allow_failure=False)
+    assert record["phase"] == phase, f"run {run_id} reached {record['phase']!r} while waiting for {phase!r}"
+    return record
+
+
+def _await_terminal(api: httpx.Client, run_id: str, phase: str, *, allow_failure: bool) -> dict[str, Any]:
+    """Poll until the record reaches `phase`, or a terminal failure this caller admits."""
+    deadline = time.monotonic() + _PHASE_TIMEOUT_SECONDS
+    record: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        response = api.get(f"/runs/{run_id}")
+        assert response.status_code == 200, response.text
+        record = response.json()["run"]
+        if record["phase"] == phase:
+            return record
+        if record["phase"] in {"accepted", "planned"}:
+            time.sleep(_PHASE_POLL_SECONDS)
+            continue
+        if allow_failure and record["finished_at"] is not None:
+            return record
+        pytest.fail(f"run {run_id} reached {record['phase']!r} while waiting for {phase!r}: {record}")
+    pytest.fail(f"run {run_id} did not reach {phase!r} within {_PHASE_TIMEOUT_SECONDS}s: {record}")
+
+
+@dataclass(slots=True)
+class _Hold:
+    """One backend's observed hold of the configuration's advisory key."""
+
+    pid: int
+    first_seen: float
+    last_seen: float
+
+
+@dataclass(slots=True)
+class KeyObservations:
+    """What the sampler saw of one configuration's advisory key while workers ran."""
+
+    samples: int = 0
+    max_granted: int = 0
+    max_waiting: int = 0
+    first_waiting_at: float | None = None
+    holds: dict[int, _Hold] = field(default_factory=dict)
+    first_published: dict[str, float] = field(default_factory=dict)
+    published_during: list[tuple[float, frozenset[str]]] = field(default_factory=list)
+
+    @property
+    def ordered_holds(self) -> list[_Hold]:
+        """The observed holds, earliest first."""
+        return sorted(self.holds.values(), key=lambda hold: hold.first_seen)
+
+
+class _KeySampler:
+    """Sample one advisory key's holders, and optionally each run's plan publication.
+
+    Both readings come from one statement pair on one connection, so a sample is a single
+    consistent view: which backends held the key at that instant, and which of the runs
+    had already published a plan.
+    """
+
+    def __init__(self, database_url: str, configuration_id: str, run_ids: list[str] | None = None) -> None:
+        key = advisory_lock_key(configuration_id)
+        self._columns = ((key >> 32) & 0xFFFFFFFF, key & 0xFFFFFFFF)
+        self._database_url = database_url
+        # Shared with the caller, which fills it in once the API has answered: sampling
+        # starts before the submissions so no hold can begin unobserved.
+        self._run_ids = run_ids
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self.observations = KeyObservations()
+
+    def __enter__(self) -> Self:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exception: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=10)
+
+    def _run(self) -> None:
+        with psycopg.connect(self._database_url, autocommit=True) as connection:
+            while not self._stop.is_set():
+                rows = connection.execute(_HELD_KEY_SAMPLE, self._columns).fetchall()
+                run_ids = list(self._run_ids or ())
+                published: frozenset[str] = frozenset()
+                if run_ids:
+                    published = frozenset(
+                        str(row[0]) for row in connection.execute(_PUBLISHED_PLANS, (run_ids,)).fetchall()
+                    )
+                self._record(time.monotonic(), rows, published, tracking=bool(run_ids))
+                time.sleep(_SAMPLE_INTERVAL_SECONDS)
+
+    def _record(self, at: float, rows: list[tuple[Any, ...]], published: frozenset[str], *, tracking: bool) -> None:
+        observations = self.observations
+        observations.samples += 1
+        granted = [int(pid) for pid, is_granted in rows if is_granted]
+        observations.max_granted = max(observations.max_granted, len(granted))
+        waiting = len([pid for pid, is_granted in rows if not is_granted])
+        observations.max_waiting = max(observations.max_waiting, waiting)
+        if waiting and observations.first_waiting_at is None:
+            observations.first_waiting_at = at
+        for pid in granted:
+            hold = observations.holds.get(pid)
+            if hold is None:
+                observations.holds[pid] = _Hold(pid=pid, first_seen=at, last_seen=at)
+            else:
+                hold.last_seen = at
+        for run_id in published:
+            observations.first_published.setdefault(run_id, at)
+        if tracking:
+            observations.published_during.append((at, published))
+
+
+class _KeyHolder:
+    """Hold one configuration's advisory key from the test, to force real contention.
+
+    Submitting two writes together is not enough on this stack: worker start-up staggers
+    them often enough that an incidental overlap cannot be relied on. Taking the key first
+    makes both workers block on it, so releasing is the starting gun and what follows is
+    the guard ordering two contenders rather than two runs that never met.
+    """
+
+    def __init__(self, database_url: str, configuration_id: str) -> None:
+        self._key = advisory_lock_key(configuration_id)
+        self._connection = psycopg.connect(database_url, autocommit=True)
+        row = self._connection.execute(_TAKE_KEY, (self._key,)).fetchone()
+        assert row is not None
+        self.backend_pid = int(row[1])
+        self._held = True
+
+    def release(self) -> None:
+        """Release the key, letting the blocked workers contend with each other."""
+        if self._held:
+            self._connection.execute(_DROP_KEY, (self._key,))
+            self._held = False
+
+    def close(self) -> None:
+        """Release and close, whatever the leg did."""
+        self.release()
+        self._connection.close()
+
+
+@contextmanager
+def _held_key(database_url: str, configuration_id: str) -> Iterator[_KeyHolder]:
+    """Hold the configuration's key for the block, releasing it whatever happens."""
+    holder = _KeyHolder(database_url, configuration_id)
+    try:
+        yield holder
+    finally:
+        holder.close()
+
+
+def _await_blocked_workers(sampler: _KeySampler) -> None:
+    """Wait until both workers are blocked on the key this test is holding.
+
+    Both being blocked on that exact key at the same instant is the whole point: it is what
+    makes everything after the release the guard ordering two contenders, rather than two
+    runs that never met. Worker start-up decides how long that takes and has nothing to do
+    with the guard, so the budget is generous — deliberately longer than the guard's own
+    acquisition deadline, which is why these legs accept the first blocked worker taking the
+    specified contention result instead of the key.
+    """
+    observations = sampler.observations
+    deadline = time.monotonic() + _BOTH_BLOCKED_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if observations.max_waiting >= _BLOCKED_WORKERS:
+            return
+        time.sleep(_BLOCKED_POLL_SECONDS)
+    pytest.fail(
+        f"only {observations.max_waiting} worker(s) were ever blocked on the configuration's "
+        f"advisory key within {_BOTH_BLOCKED_TIMEOUT_SECONDS}s, so the two never contended for it"
+    )
+
+
+def _assert_serialized(observations: KeyObservations, *, holder_pid: int) -> list[_Hold]:
+    """Require the workers to have contended for the key and never to have shared it."""
+    assert observations.max_waiting >= _BLOCKED_WORKERS, (
+        f"at most {observations.max_waiting} worker(s) were ever blocked on the key at once, so "
+        f"the two never contended for it"
+    )
+    assert observations.max_granted == 1, (
+        f"the configuration's advisory key was held by {observations.max_granted} backends at once"
+    )
+    worker_holds = [hold for hold in observations.ordered_holds if hold.pid != holder_pid]
+    assert worker_holds, (
+        f"no worker ever held the key after the test released it, across {observations.samples} samples"
+    )
+    for earlier, later in pairwise(worker_holds):
+        assert earlier.last_seen < later.first_seen, (
+            f"two worker holds overlapped: pid {earlier.pid} [{earlier.first_seen}, {earlier.last_seen}] "
+            f"and pid {later.pid} [{later.first_seen}, {later.last_seen}]"
+        )
+    return worker_holds
+
+
+def _assert_write_verdict(label: str, record: dict[str, Any]) -> bool:
+    """Require one live write to have either run its stage or lost the key cleanly.
+
+    Whichever worker blocked first may have been waiting longer than the guard's own
+    acquisition deadline, because this leg holds the key until both are blocked. Losing it
+    that way is the envelope's specified contention result and writes nothing, so it is a
+    legal end for one of the two — but never for both. Either way the run is certain about
+    what it did, so neither end may require reconciliation.
+    """
+    assert record["reconciliation_required"] is False, f"write {label} reported uncertainty: {record}"
+    if record["outcome"] in _COMPLETED_OUTCOMES:
+        return True
+    failure = next(
+        (value for name, value in record["results"].items() if name.endswith("_failure")),
+        {},
+    )
+    assert failure.get("error_type") == _CONTENTION_ERROR, (
+        f"write {label} ended {record['outcome']!r} for a reason other than losing the key: {record}"
+    )
+    return False
+
+
+def test_two_live_apply_workers_serialize_on_one_configuration(api: httpx.Client, live_stack: LiveStack) -> None:
+    """Two reviewed applies, two runs, one configuration: one worker writes at a time.
+
+    Both applies are admitted, because a write admission is per run — so nothing but the
+    advisory key stands between the two workers, and the key is what the assertions read.
+    """
+    config_id, registry_version = _register_configuration(api, live_stack, "guard-live-apply")
+    _seed_one_source_update(live_stack)
+
+    approved: dict[str, tuple[str, str]] = {}
+    for label in ("A", "B"):
+        created = api.post(
+            "/runs",
+            headers=_idempotency_headers(),
+            json={
+                "operation": "plan",
+                "config_id": config_id,
+                "registry_version": registry_version,
+                "branch": SMOKE_BRANCH,
+                "reason": f"live write-guard apply leg: plan {label}",
+            },
+        )
+        assert created.status_code == 202, created.text
+        approved[label] = (created.json()["run"]["run_id"], "")
+    for label, (run_id, _) in list(approved.items()):
+        _await_phase(api, run_id, "planned")
+        plan = api.get(f"/runs/{run_id}/plan")
+        assert plan.status_code == 200, plan.text
+        summary = plan.json()["summary"]
+        assert summary["by_action"].get("update", 0) >= 1, f"plan {label} carries no update to contend over: {summary}"
+        approved[label] = (run_id, plan.json()["checksum"])
+
+    def apply(label: str) -> httpx.Response:
+        run_id, checksum = approved[label]
+        return api.post(
+            f"/runs/{run_id}/apply",
+            headers=_idempotency_headers(),
+            json={
+                "expected_checksum": checksum,
+                "confirm_writes": True,
+                "branch": SMOKE_BRANCH,
+                "reason": f"live write-guard apply leg: apply {label}",
+            },
+        )
+
+    with (
+        _KeySampler(live_stack.database_url, config_id) as sampler,
+        _held_key(live_stack.database_url, config_id) as holder,
+    ):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            responses = list(pool.map(apply, ("A", "B")))
+        assert [response.status_code for response in responses] == [202, 202], [r.text for r in responses]
+        _await_blocked_workers(sampler)
+        holder.release()
+        records = {
+            label: _await_terminal(api, run_id, "applied", allow_failure=True)
+            for label, (run_id, _) in approved.items()
+        }
+
+    _assert_serialized(sampler.observations, holder_pid=holder.backend_pid)
+    completed = [label for label, record in records.items() if _assert_write_verdict(label, record)]
+    assert completed, f"neither apply held the key long enough to run its write stage: {records}"
+
+
+def test_two_live_sync_workers_serialize_extraction_and_planning(api: httpx.Client, live_stack: LiveStack) -> None:
+    """Two composed syncs, two runs, one configuration: the second plans only after release.
+
+    A composed sync holds the key across its own destination extraction, planning,
+    verification, and apply, and publishes its reviewed plan from inside that hold. So the
+    second worker having published nothing while the first held the key is the observable
+    for "it extracted and planned nothing" — and its own publication landing inside its own
+    hold places that work after the first released.
+
+    The local pipeline lock cannot stand in for this: it covers the read-only plan stage
+    alone and is released before the apply, so under it alone the second worker would plan
+    while the first was still verifying and applying — well inside the first hold.
+    """
+    config_id, registry_version = _register_configuration(api, live_stack, "guard-live-sync")
+    _seed_one_source_update(live_stack)
+
+    def start(label: str) -> httpx.Response:
+        return api.post(
+            "/runs",
+            headers=_idempotency_headers(),
+            json={
+                "operation": "sync",
+                "config_id": config_id,
+                "registry_version": registry_version,
+                "branch": SMOKE_BRANCH,
+                "confirm_writes": True,
+                "reason": f"live write-guard sync leg: sync {label}",
+            },
+        )
+
+    sampled_run_ids: list[str] = []
+    run_ids: dict[str, str] = {}
+    with (
+        _KeySampler(live_stack.database_url, config_id, run_ids=sampled_run_ids) as sampler,
+        _held_key(live_stack.database_url, config_id) as holder,
+    ):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            responses = dict(zip(("A", "B"), pool.map(start, ("A", "B")), strict=True))
+        for label, response in responses.items():
+            assert response.status_code == 202, response.text
+            run_ids[label] = response.json()["run"]["run_id"]
+        sampled_run_ids.extend(run_ids.values())
+        _await_blocked_workers(sampler)
+        holder.release()
+        records = {
+            label: _await_terminal(api, run_id, "applied", allow_failure=True) for label, run_id in run_ids.items()
+        }
+
+    worker_holds = _assert_serialized(sampler.observations, holder_pid=holder.backend_pid)
+    observations = sampler.observations
+    completed = [label for label, record in records.items() if _assert_write_verdict(label, record)]
+    assert completed, f"neither sync held the key long enough to run its write stage: {records}"
+
+    assert observations.first_published, "no sync published a plan while sampled"
+    for run_id, published_at in observations.first_published.items():
+        inside = [hold for hold in worker_holds if hold.first_seen <= published_at <= hold.last_seen]
+        assert inside, (
+            f"run {run_id} published its reviewed plan at {published_at}, outside every observed hold "
+            f"{[(hold.pid, hold.first_seen, hold.last_seen) for hold in worker_holds]} — so it extracted "
+            f"and planned without holding the configuration's key"
+        )

--- a/tests/integration/test_saved_plan_apply_integration.py
+++ b/tests/integration/test_saved_plan_apply_integration.py
@@ -114,6 +114,7 @@ from infrahub_sync.adapters.infrahub import InfrahubAdapter
 from infrahub_sync.plan import read_saved_plan
 from infrahub_sync.plan.errors import OperationApplyFailedError, PeerAmbiguousError
 from infrahub_sync.utils import find_missing_schema_model, get_instance, get_potenda_from_instance, render_adapter
+from tests.plan.ownership_fixtures import granted_ownership
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping, Sequence
@@ -758,9 +759,9 @@ def _seed_the_peer_kinds(workspace: Path, environment: Mapping[str, str], suffix
         environment=environment,
     )
     run_id, _ = _plan_run(seed_config)
-    get_potenda_from_instance(
-        sync_instance=_sync_instance(seed_config), run_id=run_id, show_progress=False
-    ).apply_plan()
+    get_potenda_from_instance(sync_instance=_sync_instance(seed_config), run_id=run_id, show_progress=False).apply_plan(
+        ownership=granted_ownership()
+    )
 
 
 def _unreferenced_tag(client: Any, schemas: Mapping[str, Any]) -> Any:  # noqa: ANN401 — SDK client and nodes
@@ -1087,7 +1088,7 @@ def test_applying_a_stored_plan_runs_no_extraction(live_plan: LivePlan) -> None:
     only the fork-wide rewrite the criterion also rules out.
     """
     with _extraction_forbidden() as calls:
-        record = _potenda_for_apply(live_plan).apply_plan()
+        record = _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
 
     assert calls == [], f"The apply path called {calls}, so it re-ran extraction or comparison."
     assert record.applied_operations, "The apply completed without applying a single operation."
@@ -1110,11 +1111,11 @@ def test_re_applying_an_identical_plan_converges(live_plan: LivePlan) -> None:
     """
     writes = [operation for operation in live_plan.plan.operations() if operation.action != "delete"]
 
-    _potenda_for_apply(live_plan).apply_plan()
+    _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     first_counts = _counts_by_kind(live_plan)
     first_identities = _identities_by_operation(live_plan, writes)
 
-    _potenda_for_apply(live_plan).apply_plan()
+    _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     second_counts = _counts_by_kind(live_plan)
     second_identities = _identities_by_operation(live_plan, writes)
 
@@ -1190,10 +1191,10 @@ def test_the_write_class_conformance_matrix(live_plan: LivePlan, write_class: st
     """
     operation = _representative(live_plan, write_class)
 
-    _potenda_for_apply(live_plan).apply_plan()
+    _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     clean = _observation(live_plan, write_class)
 
-    _potenda_for_apply(live_plan).apply_plan()
+    _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     assert _observation(live_plan, write_class) == clean, f"apply-twice moved the {write_class} class off its counts."
 
     for before_the_write in (False, True):
@@ -1206,8 +1207,8 @@ def test_the_write_class_conformance_matrix(live_plan: LivePlan, write_class: st
             pytest.raises(InjectedCrashError),
             _crash_at(operation.operation_id, before_the_write=before_the_write),
         ):
-            _potenda_for_apply(live_plan).apply_plan()
-        _potenda_for_apply(live_plan).apply_plan()
+            _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
+        _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
         assert _observation(live_plan, write_class) == clean, (
             f"A crash injected {window} the destination write of {operation.operation_id!r} left the "
             f"{write_class} class off its clean-single-run state after re-applying."
@@ -1241,7 +1242,7 @@ def test_relationship_peer_sets_match_the_plan(live_plan: LivePlan) -> None:
     assert operations, f"The plan holds no relationship-bearing {RELATIONSHIP_KIND} operation."
 
     with _extraction_forbidden() as calls, _destination_queries_recorded(live_plan) as queries:
-        _potenda_for_apply(live_plan).apply_plan()
+        _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     assert calls == [], f"The apply path called {calls}, so the no-comparison-store precondition does not hold."
 
     expected_filters = live_plan.preexisting_peer_filters
@@ -1424,7 +1425,7 @@ def test_an_ambiguous_peer_refuses_the_operation(live_plan: LivePlan, ambiguous_
     referring = referrers[0]
 
     with pytest.raises(OperationApplyFailedError) as caught:
-        _potenda_for_apply(live_plan).apply_plan()
+        _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
 
     cause = caught.value.__cause__
     assert isinstance(cause, PeerAmbiguousError), f"The apply failed with {cause!r}, not a multi-match refusal."

--- a/tests/orchestration/test_flow.py
+++ b/tests/orchestration/test_flow.py
@@ -957,7 +957,7 @@ def test_no_canary_reaches_prefect_visible_state_on_a_failing_run(
 
 
 @pytest.mark.usefixtures("prefect_harness", "canary_environment")
-def test_flow_refuses_an_unconfirmed_sync_before_any_engine_is_built(
+def test_flow_refuses_the_composed_sync_writer_before_any_engine_is_built(
     monkeypatch: pytest.MonkeyPatch,
     source_logger: logging.Logger,  # noqa: ARG001 - restores the bridged logger's handlers and level
     tmp_path: Path,
@@ -971,8 +971,8 @@ def test_flow_refuses_an_unconfirmed_sync_before_any_engine_is_built(
 
     assert state.is_failed()
     assert isinstance(error, RunValidationError)
-    assert str(error) == "confirm_writes=true is required to run operation=sync"
-    assert "confirm_writes=true is required to run operation=sync" in str(state.message)
+    assert "operation=sync is not supported here" in str(error)
+    assert "operation=sync is not supported here" in str(state.message)
     assert factory.calls == []
 
 

--- a/tests/plan/ownership_fixtures.py
+++ b/tests/plan/ownership_fixtures.py
@@ -1,0 +1,31 @@
+"""One explicit write-ownership boundary for tests that drive a real apply.
+
+The engine requires a boundary and product code offers no default, so every apply a test
+drives has to pass one. This recorder is the plain "the hold is good" answer: it proves
+nothing about a real writer, it only records that it was asked, so a case that cares about
+the asking can read `proofs` and every other case can ignore it.
+
+Not a test module: no assertions live here.
+"""
+
+from __future__ import annotations
+
+
+class GrantedOwnership:
+    """A boundary that always grants, recording each proof it was asked for."""
+
+    def __init__(self) -> None:
+        self.proofs: list[str] = []
+
+    def before_operation(self) -> None:
+        """Record one pre-dispatch proof."""
+        self.proofs.append("before-operation")
+
+    def after_final_operation(self) -> None:
+        """Record the closing proof."""
+        self.proofs.append("after-final-operation")
+
+
+def granted_ownership() -> GrantedOwnership:
+    """Return a fresh always-granting write-ownership boundary."""
+    return GrantedOwnership()

--- a/tests/plan/ownership_fixtures.py
+++ b/tests/plan/ownership_fixtures.py
@@ -1,9 +1,9 @@
 """One explicit write-ownership boundary for tests that drive a real apply.
 
 The engine requires a boundary and product code offers no default, so every apply a test
-drives has to pass one. This recorder is the plain "the hold is good" answer: it proves
-nothing about a real writer, it only records that it was asked, so a case that cares about
-the asking can read `proofs` and every other case can ignore it.
+drives has to pass one. This is the plain "the hold is good" answer, for cases whose
+subject is something other than the proving itself; a case that cares about the proving
+passes its own recorder.
 
 Not a test module: no assertions live here.
 """
@@ -12,20 +12,15 @@ from __future__ import annotations
 
 
 class GrantedOwnership:
-    """A boundary that always grants, recording each proof it was asked for."""
-
-    def __init__(self) -> None:
-        self.proofs: list[str] = []
+    """A write-ownership boundary that always grants."""
 
     def before_operation(self) -> None:
-        """Record one pre-dispatch proof."""
-        self.proofs.append("before-operation")
+        """Grant the pre-dispatch proof."""
 
     def after_final_operation(self) -> None:
-        """Record the closing proof."""
-        self.proofs.append("after-final-operation")
+        """Grant the closing proof."""
 
 
 def granted_ownership() -> GrantedOwnership:
-    """Return a fresh always-granting write-ownership boundary."""
+    """Return an always-granting write-ownership boundary."""
     return GrantedOwnership()

--- a/tests/plan/ownership_fixtures.py
+++ b/tests/plan/ownership_fixtures.py
@@ -10,11 +10,6 @@ Not a test module: no assertions live here.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from infrahub_sync.plan.models import ApplyRecord
-
 
 class GrantedOwnership:
     """A write-ownership boundary that always grants."""
@@ -24,9 +19,6 @@ class GrantedOwnership:
 
     def after_final_operation(self) -> None:
         """Grant the closing proof."""
-
-    def record_applied(self, record: ApplyRecord) -> None:
-        """Accept the engine's completed record; no case here reads it back."""
 
 
 def granted_ownership() -> GrantedOwnership:

--- a/tests/plan/ownership_fixtures.py
+++ b/tests/plan/ownership_fixtures.py
@@ -10,6 +10,11 @@ Not a test module: no assertions live here.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from infrahub_sync.plan.models import ApplyRecord
+
 
 class GrantedOwnership:
     """A write-ownership boundary that always grants."""
@@ -19,6 +24,9 @@ class GrantedOwnership:
 
     def after_final_operation(self) -> None:
         """Grant the closing proof."""
+
+    def record_applied(self, record: ApplyRecord) -> None:
+        """Accept the engine's completed record; no case here reads it back."""
 
 
 def granted_ownership() -> GrantedOwnership:

--- a/tests/plan/test_config_version.py
+++ b/tests/plan/test_config_version.py
@@ -41,6 +41,7 @@ from infrahub_sync.plan.writer import MANIFEST_FILE_NAME, PLAN_DIR_NAME, write_p
 from infrahub_sync.potenda import Potenda
 from infrahub_sync.utils import get_instance
 from tests.plan.artifact_fixtures import RUN_ID, operation_record
+from tests.plan.ownership_fixtures import granted_ownership
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -350,7 +351,7 @@ def _apply_with(run_directory: Path, *, config_version: str) -> tuple[str, NoOpP
         run_id=RUN_ID,
     )
     try:
-        engine.apply_plan(config_version=config_version)
+        engine.apply_plan(ownership=granted_ownership(), config_version=config_version)
     except PlanVerificationError:
         return "failed", destination
     return "applied", destination

--- a/tests/plan/test_destination_binding.py
+++ b/tests/plan/test_destination_binding.py
@@ -33,6 +33,7 @@ from infrahub_sync.plan.verify import destination_binding_failure
 from infrahub_sync.plan.writer import write_plan_artifact
 from infrahub_sync.utils import PlanApplier
 from tests.plan.artifact_fixtures import RUN_ID, manifest_path, write_artifact
+from tests.plan.ownership_fixtures import granted_ownership
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -243,11 +244,12 @@ class _RecordingEngine:
     def apply_plan(
         self,
         *,
+        ownership: object,
         config_version: str | None = None,
         artifact: object = None,
         expected_checksum: str | None = None,
     ) -> ApplyRecord:
-        _ = config_version, expected_checksum
+        _ = config_version, expected_checksum, ownership
         self.apply_calls += 1
         # Recorded, not ignored: the seam's read is what the engine must apply, so a delegation
         # that arrived without it would mean the engine reads the artifact a second time.
@@ -272,7 +274,7 @@ def test_a_destination_mismatch_refuses_before_the_engine_is_reached(tmp_path: P
     applier, engine = _applier(tmp_path, _BoundDestination(LIVE_URL))
 
     with pytest.raises(PlanVerificationError) as raised:
-        applier.apply_plan()
+        applier.apply_plan(ownership=granted_ownership())
 
     message = str(raised.value)
     assert RECORDED_URL in message
@@ -287,7 +289,7 @@ def test_the_override_applies_and_discloses_the_change(tmp_path: Path, caplog: p
     applier, engine = _applier(tmp_path, _BoundDestination(LIVE_URL))
 
     with caplog.at_level(logging.WARNING, logger="infrahub_sync.utils"):
-        applier.apply_plan(allow_destination_change=True)
+        applier.apply_plan(ownership=granted_ownership(), allow_destination_change=True)
 
     assert engine.apply_calls == 1
     warnings = " ".join(record.getMessage() for record in caplog.records if record.levelno >= logging.WARNING)
@@ -299,7 +301,7 @@ def test_a_matching_destination_applies_without_ceremony(tmp_path: Path) -> None
     _artifact(tmp_path, destination_binding=BINDING_OVERRIDE)
     applier, engine = _applier(tmp_path, _BoundDestination(RECORDED_URL))
 
-    applier.apply_plan()
+    applier.apply_plan(ownership=granted_ownership())
 
     assert engine.apply_calls == 1
     assert engine.artifacts == [engine.artifacts[0]], "the engine was delegated to exactly once"
@@ -319,7 +321,7 @@ def test_a_plan_without_the_field_applies_against_any_destination(tmp_path: Path
     _artifact(tmp_path)
     applier, engine = _applier(tmp_path, _BoundDestination(LIVE_URL))
 
-    applier.apply_plan()
+    applier.apply_plan(ownership=granted_ownership())
 
     assert engine.apply_calls == 1
 
@@ -328,7 +330,7 @@ def test_a_destination_exposing_no_binding_applies_unchecked(tmp_path: Path) -> 
     _artifact(tmp_path, destination_binding=BINDING_OVERRIDE)
     applier, engine = _applier(tmp_path, object())
 
-    applier.apply_plan()
+    applier.apply_plan(ownership=granted_ownership())
 
     assert engine.apply_calls == 1
 

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -41,6 +41,7 @@ class RecordingOwnership:
 
     def __init__(self, events: list[str], *, lose_after: int | None = None) -> None:
         self.events = events
+        self.applied: ApplyRecord | None = None
         self._lose_after = lose_after
         self._proofs = 0
 
@@ -53,6 +54,9 @@ class RecordingOwnership:
 
     def after_final_operation(self) -> None:
         self.events.append("final-prove")
+
+    def record_applied(self, record: ApplyRecord) -> None:
+        self.applied = record
 
 
 class RecordingDestination:
@@ -345,6 +349,25 @@ def test_the_final_proof_precedes_the_applied_sidecar(tmp_path: Path) -> None:
     assert observed == ["running"]
     assert RunFile.load_or_default(directory / "run.json").status == "applied"
     assert events[-1] == "final-prove"
+
+
+def test_the_apply_lifecycle_reports_its_completed_record_to_the_write_scope(tmp_path: Path) -> None:
+    """The scope learns what was written before anything downstream of the engine can fail.
+
+    Everything after this point — the applied sidecar, the guard's release, the product
+    success commit — can fail without carrying a record of its own, and the scope's copy is
+    the only account of the write those failures have.
+    """
+    directory = _run_dir(tmp_path)
+    alpha, bravo, charlie = _three_operations(directory)
+    events: list[str] = []
+    ownership = RecordingOwnership(events)
+
+    _lifecycle(directory, ownership, RecordingDestination(events))
+
+    assert isinstance(ownership.applied, ApplyRecord)
+    assert ownership.applied.applied_operations == (alpha, charlie)
+    assert ownership.applied.skipped_delete_operations == (bravo,)
 
 
 def test_a_failed_applied_sidecar_still_carries_the_completed_record(

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -1,0 +1,281 @@
+"""The apply engine may not dispatch a planned operation without a proven write hold.
+
+The boundary is required, not optional: a caller that supplies none is refused where it
+calls, before any destination is contacted. What the boundary proves is left to the caller
+— these cases pass an explicit fake that records the exact interleaving of proofs and
+dispatches, because the ordering *is* the product rule: one proof immediately before every
+operation the engine dispatches, and one after the last one, before anything can record the
+apply as complete.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from infrahub_sync.plan.errors import OperationApplyFailedError
+from infrahub_sync.plan.models import ApplyRecord
+from infrahub_sync.potenda import Potenda
+from tests.plan.artifact_fixtures import CONFIG_VERSION, operation_record, write_artifact
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sync.plan.models import PlannedOperation
+
+RUN_ID = "20260903T0915-4c1ab390"
+
+
+class OwnershipLostError(RuntimeError):
+    """The failure a fake ownership boundary raises when its hold is gone."""
+
+
+class RecordingOwnership:
+    """An explicit write-ownership boundary that records its own call interleaving."""
+
+    def __init__(self, events: list[str], *, lose_after: int | None = None) -> None:
+        self.events = events
+        self._lose_after = lose_after
+        self._proofs = 0
+
+    def before_operation(self) -> None:
+        self._proofs += 1
+        if self._lose_after is not None and self._proofs > self._lose_after:
+            self.events.append("lost")
+            raise OwnershipLostError
+        self.events.append("prove")
+
+    def after_final_operation(self) -> None:
+        self.events.append("final-prove")
+
+
+class RecordingDestination:
+    """A destination implementing the planned-write surface that records every dispatch."""
+
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def new_peer_resolver(self) -> object:  # noqa: PLR6301
+        """The per-apply resolver factory; nothing below this double's surface reads it."""
+        return object()
+
+    def apply_planned_operation(self, *, operation: PlannedOperation, peers: Any) -> str:  # noqa: ANN401
+        _ = peers
+        self.events.append(f"dispatch:{operation.operation_id}")
+        return "node"
+
+
+class RejectingDestination(RecordingDestination):
+    """A destination whose one dispatch fails inside the operational boundary."""
+
+    def apply_planned_operation(self, *, operation: PlannedOperation, peers: Any) -> str:  # noqa: ANN401
+        super().apply_planned_operation(operation=operation, peers=peers)
+        msg = "the destination rejected the operation"
+        raise ValueError(msg)
+
+
+def _potenda(run_directory: Path, destination: object) -> Potenda:
+    return Potenda(
+        source=SimpleNamespace(top_level=[]),  # ty: ignore[invalid-argument-type]
+        destination=destination,  # ty: ignore[invalid-argument-type]
+        config=None,  # ty: ignore[invalid-argument-type]
+        top_level=["BuiltinTag"],
+        run_dir=run_directory,
+        run_id=RUN_ID,
+    )
+
+
+def _run_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / RUN_ID
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _three_operations(run_directory: Path) -> list[str]:
+    records = [
+        operation_record(identity={"name": "alpha"}),
+        operation_record(action="delete", identity={"name": "bravo"}),
+        operation_record(action="update", identity={"name": "charlie"}),
+    ]
+    write_artifact(run_directory, records, run_id=RUN_ID, source_snapshot=[])
+    return [str(record["operation_id"]) for record in records]
+
+
+def test_an_apply_without_an_ownership_boundary_is_refused_where_it_is_called(tmp_path: Path) -> None:
+    """No default, no None, no no-op: the engine cannot be asked to write unguarded."""
+    directory = _run_dir(tmp_path)
+    _three_operations(directory)
+    events: list[str] = []
+    destination = RecordingDestination(events)
+
+    with pytest.raises(TypeError):
+        _potenda(directory, destination).apply_plan(config_version=CONFIG_VERSION)  # ty: ignore[missing-argument]
+
+    assert events == []
+
+
+def test_one_proof_precedes_every_dispatch_and_one_follows_the_last(tmp_path: Path) -> None:
+    """The recorded delete is skipped, so it consumes no proof and no dispatch."""
+    directory = _run_dir(tmp_path)
+    alpha, _bravo, charlie = _three_operations(directory)
+    events: list[str] = []
+    ownership = RecordingOwnership(events)
+
+    record = _potenda(directory, RecordingDestination(events)).apply_plan(
+        config_version=CONFIG_VERSION, ownership=ownership
+    )
+
+    assert events == [
+        "prove",
+        f"dispatch:{alpha}",
+        "prove",
+        f"dispatch:{charlie}",
+        "final-prove",
+    ]
+    assert record.applied_operations == (alpha, charlie)
+
+
+def test_ownership_lost_after_the_first_operation_prevents_the_second(tmp_path: Path) -> None:
+    """A hold lost mid-apply stops the next write and keeps what the first one did."""
+    directory = _run_dir(tmp_path)
+    alpha, _bravo, _charlie = _three_operations(directory)
+    events: list[str] = []
+    ownership = RecordingOwnership(events, lose_after=1)
+
+    with pytest.raises(OwnershipLostError) as raised:
+        _potenda(directory, RecordingDestination(events)).apply_plan(config_version=CONFIG_VERSION, ownership=ownership)
+
+    assert events == ["prove", f"dispatch:{alpha}", "lost"]
+    carried = getattr(raised.value, "apply_record", None)
+    assert isinstance(carried, ApplyRecord)
+    assert carried.applied_operations == (alpha,)
+    # The proof did not dispatch, so no operation may be named as possibly half-written.
+    assert carried.failed_operation is None
+
+
+def test_a_lost_final_proof_carries_the_completed_record(tmp_path: Path) -> None:
+    """Everything the loop dispatched stays readable when the closing proof fails."""
+    directory = _run_dir(tmp_path)
+    alpha, bravo, charlie = _three_operations(directory)
+    events: list[str] = []
+
+    class LosingFinalOwnership(RecordingOwnership):
+        def after_final_operation(self) -> None:
+            self.events.append("final-lost")
+            raise OwnershipLostError
+
+    with pytest.raises(OwnershipLostError) as raised:
+        _potenda(directory, RecordingDestination(events)).apply_plan(
+            config_version=CONFIG_VERSION, ownership=LosingFinalOwnership(events)
+        )
+
+    assert events[-1] == "final-lost"
+    carried = getattr(raised.value, "apply_record", None)
+    assert isinstance(carried, ApplyRecord)
+    assert carried.applied_operations == (alpha, charlie)
+    assert carried.skipped_delete_operations == (bravo,)
+
+
+def test_a_failed_dispatch_still_names_the_operation_that_may_have_written(tmp_path: Path) -> None:
+    """The proof boundary must not blur the difference between refused and half-written."""
+    directory = _run_dir(tmp_path)
+    alpha, _bravo, _charlie = _three_operations(directory)
+    events: list[str] = []
+
+    with pytest.raises(OperationApplyFailedError) as raised:
+        _potenda(directory, RejectingDestination(events)).apply_plan(
+            config_version=CONFIG_VERSION, ownership=RecordingOwnership(events)
+        )
+
+    assert raised.value.apply_record.failed_operation == alpha
+    assert events == ["prove", f"dispatch:{alpha}"]
+
+
+def test_a_refused_plan_never_reaches_the_ownership_boundary(tmp_path: Path) -> None:
+    """Deterministic refusals decide before the boundary is asked to prove anything."""
+    directory = _run_dir(tmp_path)
+    _three_operations(directory)
+    manifest_path = directory / "plan" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["operations_count"] = 99
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    events: list[str] = []
+
+    with pytest.raises(Exception):  # noqa: B017 - any refusal; the point is that none proved.
+        _potenda(directory, RecordingDestination(events)).apply_plan(
+            config_version=CONFIG_VERSION, ownership=RecordingOwnership(events)
+        )
+
+    assert events == []
+
+
+def test_the_apply_seam_cannot_delegate_without_an_ownership_boundary(tmp_path: Path) -> None:
+    """`PlanApplier` assembles an apply; it may not assemble one that proves nothing."""
+    from infrahub_sync.utils import PlanApplier  # pylint: disable=import-outside-toplevel
+
+    directory = _run_dir(tmp_path)
+    _three_operations(directory)
+    delegations: list[object] = []
+
+    class _RecordingEngine:
+        def __init__(self) -> None:
+            self.destination = SimpleNamespace()
+            self.last_applied_plan_action_counts = {"create": 0, "update": 0, "delete": 0}
+
+        def apply_plan(self, **kwargs: object) -> ApplyRecord:  # noqa: PLR6301
+            delegations.append(kwargs)
+            return ApplyRecord()
+
+    applier = PlanApplier(_RecordingEngine(), run_dir=directory, run_id=RUN_ID)  # ty: ignore[invalid-argument-type]
+
+    with pytest.raises(TypeError):
+        applier.apply_plan()  # ty: ignore[missing-argument]
+
+    assert delegations == []
+
+
+def test_the_dispatch_tracker_records_only_a_proven_dispatch() -> None:
+    """The one in-memory Boolean separates "certainly wrote nothing" from "may have"."""
+    from infrahub_sync.plan.ownership import (  # pylint: disable=import-outside-toplevel
+        ProvenWriteOwnership,
+        WriteDispatchTracker,
+    )
+
+    tracker = WriteDispatchTracker()
+    proofs: list[str] = []
+
+    def prove() -> None:
+        proofs.append("prove")
+
+    ownership = ProvenWriteOwnership(prove=prove, tracker=tracker)
+    assert tracker.dispatch_started is False
+
+    ownership.after_final_operation()
+    assert proofs == ["prove"]
+    assert tracker.dispatch_started is False, "a closing proof alone is not a dispatch"
+
+    ownership.before_operation()
+    assert tracker.dispatch_started is True
+
+
+def test_a_failed_proof_before_the_first_dispatch_leaves_the_tracker_clean() -> None:
+    """A hold lost before any dispatch is a known pre-dispatch failure, not ambiguity."""
+    from infrahub_sync.plan.ownership import (  # pylint: disable=import-outside-toplevel
+        ProvenWriteOwnership,
+        WriteDispatchTracker,
+    )
+
+    tracker = WriteDispatchTracker()
+
+    def prove() -> None:
+        raise OwnershipLostError
+
+    ownership = ProvenWriteOwnership(prove=prove, tracker=tracker)
+
+    with pytest.raises(OwnershipLostError):
+        ownership.before_operation()
+
+    assert tracker.dispatch_started is False

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from infrahub_sdk.exceptions import ServerNotResponsiveError
 
 from infrahub_sync.plan.errors import OperationApplyFailedError
 from infrahub_sync.plan.models import ApplyRecord
@@ -74,7 +75,7 @@ class RejectingDestination(RecordingDestination):
     def apply_planned_operation(self, *, operation: PlannedOperation, peers: Any) -> str:  # noqa: ANN401
         super().apply_planned_operation(operation=operation, peers=peers)
         msg = "the destination rejected the operation"
-        raise ValueError(msg)
+        raise ServerNotResponsiveError(msg)
 
 
 def _potenda(run_directory: Path, destination: object) -> Potenda:

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -367,17 +367,47 @@ def test_the_apply_lifecycle_reports_its_completed_record_to_its_sink(tmp_path: 
     alpha, bravo, charlie = _three_operations(directory)
     events: list[str] = []
     reported: list[ApplyRecord] = []
+    observed: list[str | None] = []
 
-    _lifecycle(
-        directory,
-        RecordingOwnership(events),
-        RecordingDestination(events),
-        record_applied=reported.append,
-    )
+    def report(record: ApplyRecord) -> None:
+        observed.append(RunFile.load_or_default(directory / "run.json").status)
+        reported.append(record)
+
+    _lifecycle(directory, RecordingOwnership(events), RecordingDestination(events), record_applied=report)
 
     assert len(reported) == 1
     assert reported[0].applied_operations == (alpha, charlie)
     assert reported[0].skipped_delete_operations == (bravo,)
+    # Still `running` when the sink is asked: the scope is told what was written before the
+    # sidecar records the apply as complete, which is what makes the scope's copy the
+    # account every later failure can fall back on.
+    assert observed == ["running"]
+
+
+def test_a_sink_that_cannot_record_the_write_still_reaches_the_failure_boundary(tmp_path: Path) -> None:
+    """A sink that raises is a failure after a dispatch, and is handled as one.
+
+    The sink runs after the loop has written and before the applied sidecar, so a sink that
+    cannot record what happened leaves a run that wrote but was never marked complete. It
+    must reach the same boundary a failing sidecar reaches, carrying the same record —
+    otherwise the sidecar stays at `running` and the completed record is lost entirely.
+    """
+    directory = _run_dir(tmp_path)
+    alpha, bravo, charlie = _three_operations(directory)
+    events: list[str] = []
+
+    def refuse(_record: ApplyRecord) -> None:
+        msg = "the write scope could not record the completed apply"
+        raise OSError(msg)
+
+    with pytest.raises(OSError, match="could not record the completed apply") as raised:
+        _lifecycle(directory, RecordingOwnership(events), RecordingDestination(events), record_applied=refuse)
+
+    assert RunFile.load_or_default(directory / "run.json").status == "failed"
+    carried = getattr(raised.value, "apply_record", None)
+    assert isinstance(carried, ApplyRecord)
+    assert carried.applied_operations == (alpha, charlie)
+    assert carried.skipped_delete_operations == (bravo,)
 
 
 def test_a_failed_applied_sidecar_still_carries_the_completed_record(

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -25,6 +25,7 @@ from infrahub_sync.potenda import Potenda
 from tests.plan.artifact_fixtures import CONFIG_VERSION, operation_record, write_artifact
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from infrahub_sync.plan.models import PlannedOperation
@@ -41,7 +42,6 @@ class RecordingOwnership:
 
     def __init__(self, events: list[str], *, lose_after: int | None = None) -> None:
         self.events = events
-        self.applied: ApplyRecord | None = None
         self._lose_after = lose_after
         self._proofs = 0
 
@@ -54,9 +54,6 @@ class RecordingOwnership:
 
     def after_final_operation(self) -> None:
         self.events.append("final-prove")
-
-    def record_applied(self, record: ApplyRecord) -> None:
-        self.applied = record
 
 
 class RecordingDestination:
@@ -309,7 +306,13 @@ class _EngineApplier:
         )
 
 
-def _lifecycle(directory: Path, ownership: object, destination: object) -> object:
+def _lifecycle(
+    directory: Path,
+    ownership: object,
+    destination: object,
+    *,
+    record_applied: Callable[[ApplyRecord], None] = lambda _record: None,
+) -> object:
     """Run the core-owned apply lifecycle over one real engine and one real sidecar."""
     from infrahub_sync import execution  # pylint: disable=import-outside-toplevel
 
@@ -322,6 +325,7 @@ def _lifecycle(directory: Path, ownership: object, destination: object) -> objec
         allow_destination_change=False,
         expected_checksum=None,
         ownership=ownership,  # ty: ignore[invalid-argument-type]
+        record_applied=record_applied,
         _plan_applier_factory=lambda *_args, **_kwargs: applier,  # ty: ignore[invalid-argument-type]
         run_directory=directory,
         sidecar_mode="apply",
@@ -351,23 +355,29 @@ def test_the_final_proof_precedes_the_applied_sidecar(tmp_path: Path) -> None:
     assert events[-1] == "final-prove"
 
 
-def test_the_apply_lifecycle_reports_its_completed_record_to_the_write_scope(tmp_path: Path) -> None:
+def test_the_apply_lifecycle_reports_its_completed_record_to_its_sink(tmp_path: Path) -> None:
     """The scope learns what was written before anything downstream of the engine can fail.
 
     Everything after this point — the applied sidecar, the guard's release, the product
     success commit — can fail without carrying a record of its own, and the scope's copy is
-    the only account of the write those failures have.
+    the only account of the write those failures have. It arrives through a sink of its
+    own: the ownership boundary authorizes the write and is not asked what it did.
     """
     directory = _run_dir(tmp_path)
     alpha, bravo, charlie = _three_operations(directory)
     events: list[str] = []
-    ownership = RecordingOwnership(events)
+    reported: list[ApplyRecord] = []
 
-    _lifecycle(directory, ownership, RecordingDestination(events))
+    _lifecycle(
+        directory,
+        RecordingOwnership(events),
+        RecordingDestination(events),
+        record_applied=reported.append,
+    )
 
-    assert isinstance(ownership.applied, ApplyRecord)
-    assert ownership.applied.applied_operations == (alpha, charlie)
-    assert ownership.applied.skipped_delete_operations == (bravo,)
+    assert len(reported) == 1
+    assert reported[0].applied_operations == (alpha, charlie)
+    assert reported[0].skipped_delete_operations == (bravo,)
 
 
 def test_a_failed_applied_sidecar_still_carries_the_completed_record(

--- a/tests/plan/test_write_ownership.py
+++ b/tests/plan/test_write_ownership.py
@@ -11,12 +11,14 @@ apply as complete.
 from __future__ import annotations
 
 import json
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
 from infrahub_sdk.exceptions import ServerNotResponsiveError
 
+from infrahub_sync.cache.sidecars import RunFile
 from infrahub_sync.plan.errors import OperationApplyFailedError
 from infrahub_sync.plan.models import ApplyRecord
 from infrahub_sync.potenda import Potenda
@@ -280,3 +282,100 @@ def test_a_failed_proof_before_the_first_dispatch_leaves_the_tracker_clean() -> 
         ownership.before_operation()
 
     assert tracker.dispatch_started is False
+
+
+class _EngineApplier:
+    """The apply seam over a real engine, so the engine's own proof order is what runs."""
+
+    def __init__(self, engine: Potenda) -> None:
+        self.engine = engine
+
+    @property
+    def applied_plan_action_counts(self) -> dict[str, int]:
+        """Return counts parsed from the artifact the engine just applied."""
+        counts = self.engine.last_applied_plan_action_counts
+        assert counts is not None
+        return counts
+
+    def apply_plan(self, *, ownership: object, **_kwargs: object) -> ApplyRecord:
+        """Delegate to the engine exactly as the production seam does."""
+        return self.engine.apply_plan(
+            ownership=ownership,  # ty: ignore[invalid-argument-type] - the test's explicit boundary.
+            config_version=CONFIG_VERSION,
+        )
+
+
+def _lifecycle(directory: Path, ownership: object, destination: object) -> object:
+    """Run the core-owned apply lifecycle over one real engine and one real sidecar."""
+    from infrahub_sync import execution  # pylint: disable=import-outside-toplevel
+
+    applier = _EngineApplier(_potenda(directory, destination))
+    return execution._run_apply_lifecycle(
+        sync_instance=SimpleNamespace(name="write-ownership"),  # ty: ignore[invalid-argument-type]
+        run_id=RUN_ID,
+        branch=None,
+        verbosity=logging.INFO,
+        allow_destination_change=False,
+        expected_checksum=None,
+        ownership=ownership,  # ty: ignore[invalid-argument-type]
+        _plan_applier_factory=lambda *_args, **_kwargs: applier,  # ty: ignore[invalid-argument-type]
+        run_directory=directory,
+        sidecar_mode="apply",
+    )
+
+
+def test_the_final_proof_precedes_the_applied_sidecar(tmp_path: Path) -> None:
+    """Nothing may record an apply as complete before the closing proof succeeds.
+
+    The proof reads the sidecar the lifecycle owns: seeing `running` there is what shows
+    the proof ran while the apply was still open, rather than after it was recorded.
+    """
+    directory = _run_dir(tmp_path)
+    _three_operations(directory)
+    events: list[str] = []
+    observed: list[str | None] = []
+
+    class WatchingOwnership(RecordingOwnership):
+        def after_final_operation(self) -> None:
+            observed.append(RunFile.load_or_default(directory / "run.json").status)
+            super().after_final_operation()
+
+    _lifecycle(directory, WatchingOwnership(events), RecordingDestination(events))
+
+    assert observed == ["running"]
+    assert RunFile.load_or_default(directory / "run.json").status == "applied"
+    assert events[-1] == "final-prove"
+
+
+def test_a_failed_applied_sidecar_still_carries_the_completed_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What the loop wrote stays readable when the run file cannot record it.
+
+    Only the success transition fails, so the failed transition the lifecycle falls back
+    to still runs — and the record travelling on the exception is the completed one, not
+    an empty stand-in.
+    """
+    from infrahub_sync import execution  # pylint: disable=import-outside-toplevel
+
+    directory = _run_dir(tmp_path)
+    alpha, bravo, charlie = _three_operations(directory)
+    events: list[str] = []
+    original = execution._save_run_transition
+
+    def refuse_success(run_directory: Path, **kwargs: Any) -> None:  # noqa: ANN401 - mirrors the wrapped signature.
+        if kwargs.get("status") == "applied":
+            msg = "the run file could not record the applied transition"
+            raise OSError(msg)
+        original(run_directory, **kwargs)
+
+    monkeypatch.setattr(execution, "_save_run_transition", refuse_success)
+
+    with pytest.raises(OSError, match="applied transition") as raised:
+        _lifecycle(directory, RecordingOwnership(events), RecordingDestination(events))
+
+    carried = getattr(raised.value, "apply_record", None)
+    assert isinstance(carried, ApplyRecord)
+    assert carried.applied_operations == (alpha, charlie)
+    assert carried.skipped_delete_operations == (bravo,)
+    assert carried.failed_operation is None

--- a/tests/product_store/test_contract.py
+++ b/tests/product_store/test_contract.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
+from itertools import count
 from pathlib import Path
 from threading import Barrier, Event, local
 from types import SimpleNamespace
@@ -45,7 +46,13 @@ from infrahub_sync.product_store import (
     local_product_projection,
 )
 from infrahub_sync.product_store import store as product_store_store
-from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunStore, S3ArtifactStore, SQLiteRunStore
+from infrahub_sync.product_store.store import (
+    FileArtifactStore,
+    PostgreSQLRunStore,
+    S3ArtifactStore,
+    SQLiteRunStore,
+    _RelationalRunStore,
+)
 
 # This intentionally mirrors infrahub_sync/product_store/__init__.py's __all__, hand-maintained
 # so a change to the module's exports has to touch this list too.
@@ -266,17 +273,20 @@ class _PositionConflictOnceSQLiteStore(SQLiteRunStore):
         self.insert_calls = 0
         super().__init__(database)
 
-    def _insert_prefect_execution(self, cursor, run_id, link, position):
+    def _insert_prefect_execution(self, cursor, run_id, link, position, *, mutation_receipt_id=None):
         self.insert_calls += 1
         if self.insert_calls == 1:
             error = _FakeSQLiteIntegrityError("synthetic position race")
             error.sqlite_errorcode = 2067
             raise error
-        return super()._insert_prefect_execution(cursor, run_id, link, position)
+        return super()._insert_prefect_execution(
+            cursor, run_id, link, position, mutation_receipt_id=mutation_receipt_id
+        )
 
 
 class _ChildConflictSQLiteStore(SQLiteRunStore):
-    def _insert_prefect_execution(self, cursor, run_id, link, position):  # noqa: ARG002, PLR6301
+    def _insert_prefect_execution(self, cursor, run_id, link, position, *, mutation_receipt_id=None):  # noqa: PLR6301
+        _ = cursor, run_id, link, position, mutation_receipt_id
         error = _FakeSQLiteIntegrityError("synthetic child uniqueness failure")
         error.sqlite_errorcode = 2067
         raise error
@@ -472,6 +482,41 @@ def _receipt(  # noqa: PLR0913 - receipt factory exposes contract dimensions.
         created_at=now,
         updated_at=now,
     )
+
+
+_APPEND_ORDINAL = count(1)
+_STAGE_OPERATIONS = ("plan", "verify", "apply", "sync")
+
+
+def _append_execution(
+    target: ProductProjection | _RelationalRunStore,
+    run_id: str,
+    link: PrefectExecutionLink,
+    *,
+    allocate_attempt: bool = False,
+    secrets: Sequence[str] = (),
+) -> PrefectExecutionLink:
+    """Reserve the mutation receipt that owns one execution append, then append it.
+
+    Every execution belongs to exactly one still-unresolved submission, so a case that
+    wants a link has to name the receipt that asked for it. A purpose outside the four
+    stages is owned by a cancellation receipt, the one kind the stage arbitration leaves
+    alone.
+    """
+    ordinal = next(_APPEND_ORDINAL)
+    receipt = _receipt(
+        f"m-append-{ordinal}",
+        run_id=run_id,
+        client_key=f"append-key-{ordinal}",
+        operation=link.purpose if link.purpose in _STAGE_OPERATIONS else "cancel",
+    )
+    if isinstance(target, ProductProjection):
+        target.reserve_mutation(receipt)
+        return target.add_prefect_execution(
+            run_id, link, receipt_id=receipt.receipt_id, allocate_attempt=allocate_attempt, secrets=secrets
+        )
+    target.reserve_mutation(receipt, None)
+    return target.add_prefect_execution(run_id, link, receipt_id=receipt.receipt_id, allocate_attempt=allocate_attempt)
 
 
 def _configuration_declaration(**settings_overrides: object) -> dict[str, Any]:
@@ -795,6 +840,7 @@ def test_sqlite_concurrent_mutation_reservation_creates_exactly_one_product_run(
 
 
 def test_write_capable_mutation_admission_is_atomic_on_both_profiles(provider: ProductProjection) -> None:
+    """One admission wins; the loser keeps a receipt carrying its own stored refusal."""
     provider.create_run(_run())
 
     def reserve(position: int) -> str:
@@ -804,11 +850,8 @@ def test_write_capable_mutation_admission_is_atomic_on_both_profiles(provider: P
             operation="apply",
             target_run_id="run-001",
         )
-        try:
-            provider.reserve_mutation(receipt, admit_write=True)
-        except WriteAdmissionConflictError:
-            return "refused"
-        return "admitted"
+        reserved, _created = provider.reserve_mutation(receipt, admit_write=True)
+        return "refused" if reserved.state == "accepted" else "admitted"
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         outcomes = list(pool.map(reserve, range(2)))
@@ -818,7 +861,8 @@ def test_write_capable_mutation_admission_is_atomic_on_both_profiles(provider: P
         provider.lookup_mutation("operator@example.com", sha256(f"apply-key-{position}".encode()).hexdigest())
         for position in range(2)
     ]
-    assert sum(receipt.available for receipt in receipts) == 1
+    assert all(receipt.available for receipt in receipts), "both requests keep a durable answer"
+    assert sum(receipt.value.state == "reserved" for receipt in receipts if receipt.value is not None) == 1
 
 
 def test_write_admission_exact_receipt_replay_precedes_the_run_conflict(provider: ProductProjection) -> None:
@@ -914,7 +958,8 @@ def test_sqlite_foreign_key_failure_passes_through_as_integrity_error(tmp_path: 
     store = SQLiteRunStore(tmp_path / "records.sqlite3")
 
     with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY constraint failed"):
-        store.add_prefect_execution(
+        _append_execution(
+            store,
             "missing-run",
             PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1),
         )
@@ -973,7 +1018,7 @@ def test_every_prefect_link_field_and_multiple_attempts_round_trip(provider: Pro
 
     provider.create_run(expected)
     for link in links:
-        provider.add_prefect_execution(expected.run_id, link)
+        _append_execution(provider, expected.run_id, link)
 
     loaded = provider.lookup_run(expected.run_id).value
     assert loaded is not None
@@ -1164,7 +1209,7 @@ def test_new_execution_requires_submitted_at_without_persistence(provider: Produ
     link = PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=None)
 
     with pytest.raises(ValueError, match=r"^new Prefect execution requires submitted_at$"):
-        provider.add_prefect_execution("run-001", link)
+        _append_execution(provider, "run-001", link)
 
     stored = provider.lookup_run("run-001").value
     assert stored is not None
@@ -1215,7 +1260,8 @@ def test_migrated_execution_claim_uses_observation_fallback_at_admission_deadlin
         timezone(timedelta(hours=-4))
     )
     projection.create_run(_run())
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-001",
@@ -1259,7 +1305,8 @@ def test_legacy_execution_without_any_admission_anchor_remains_claimable(profile
     projection = ProductProjection(records, FileArtifactStore(tmp_path / f"objects-{profile}"))
     observed_at = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     projection.create_run(_run())
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-001",
@@ -1291,8 +1338,8 @@ def test_execution_claim_stall_and_terminal_cas_contract(provider: ProductProjec
     now = datetime(2026, 8, 29, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
 
     assert provider.mark_execution_stalled("run-001", "flow-001", stalled_at=now)
@@ -1325,7 +1372,8 @@ def test_execution_claim_respects_inclusive_admission_ttl(
     claimed_at = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
+    _append_execution(
+        provider,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-001",
@@ -1362,8 +1410,8 @@ def test_execution_liveness_mutations_refuse_naive_timestamps_without_writing(
     naive = now.replace(tzinfo=None)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     if mutation == "interrupt":
         provider.claim_execution("run-001", "flow-001", worker_id=worker_id, claimed_at=now)
@@ -1403,8 +1451,8 @@ def test_every_execution_terminal_transition_refuses_naive_timestamp_without_wri
     now = datetime(2026, 8, 29, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     if transition in {"interrupt", "commit"}:
         assert provider.claim_execution("run-001", "flow-001", worker_id=worker_id, claimed_at=now)
@@ -1444,7 +1492,8 @@ def test_claim_and_abandon_race_has_one_winner(provider: ProductProjection, age_
     now = datetime(2026, 8, 29, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
+    _append_execution(
+        provider,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-001",
@@ -1485,7 +1534,8 @@ def test_migrated_claim_and_abandon_race_at_deadline_has_one_winner(profile: str
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     projection.create_run(_run())
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-001",
@@ -1524,8 +1574,8 @@ def test_migrated_claim_and_abandon_race_at_deadline_has_one_winner(profile: str
 def test_execution_claim_refuses_invalid_worker_identity_without_mutation(provider: ProductProjection) -> None:
     now = datetime(2026, 8, 29, tzinfo=timezone.utc)
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
 
     with pytest.raises(ValueError, match="service worker identity is invalid"):
@@ -1541,8 +1591,8 @@ def test_claimed_finish_writeback_is_atomic_and_worker_bound(provider: ProductPr
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     assert provider.claim_execution("run-001", "flow-001", worker_id=worker_id, claimed_at=now)
     writeback = product_store.ExecutionFinishWriteback(
@@ -1594,10 +1644,11 @@ def test_older_execution_terminalization_settles_only_its_link_and_receipt(
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-older", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-older", purpose="plan", attempt=1, submitted_at=now)
     )
-    provider.add_prefect_execution(
+    _append_execution(
+        provider,
         "run-001",
         PrefectExecutionLink(
             flow_run_id="flow-latest", purpose="verify", attempt=1, submitted_at=now + timedelta(seconds=1)
@@ -1720,7 +1771,8 @@ def test_cross_link_late_writer_cannot_overwrite_newer_execution_result(provider
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
     for attempt, flow_run_id in enumerate(("flow-older", "flow-latest"), start=1):
-        provider.add_prefect_execution(
+        _append_execution(
+            provider,
             "run-001",
             PrefectExecutionLink(flow_run_id=flow_run_id, purpose="plan", attempt=attempt, submitted_at=now),
         )
@@ -1786,8 +1838,8 @@ def test_cancellation_saga_persists_intent_acknowledgement_and_clean_terminal(pr
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -1836,15 +1888,16 @@ def test_execution_append_and_cancellation_intent_serialize_in_both_orders(
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
 
     def append() -> bool:
         try:
-            provider.add_prefect_execution(
+            _append_execution(
+                provider,
                 "run-001",
                 PrefectExecutionLink(
                     flow_run_id="flow-new",
@@ -1886,8 +1939,8 @@ def test_execution_append_and_cancellation_intent_race_has_one_winner(provider: 
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -1896,7 +1949,8 @@ def test_execution_append_and_cancellation_intent_race_has_one_winner(provider: 
     def append() -> bool:
         barrier.wait()
         try:
-            provider.add_prefect_execution(
+            _append_execution(
+                provider,
                 "run-001",
                 PrefectExecutionLink(
                     flow_run_id="flow-new",
@@ -1940,8 +1994,8 @@ def test_cancellation_intent_admission_revalidates_only_its_exact_receipt_owner(
         client_key="competitor-key",
     )
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-old", purpose="plan", attempt=1, submitted_at=now)
     )
     for receipt in (owner, competitor):
         provider.reserve_mutation(receipt)
@@ -1970,8 +2024,8 @@ def test_cancellation_intent_rejects_naive_time_without_partial_state(provider: 
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2000,8 +2054,8 @@ def test_cancellation_intent_requires_the_policy_owned_recovery_deadline(
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2042,8 +2096,8 @@ def test_cancellation_expiry_is_inclusive_bounded_and_receipt_stable(
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     claimed = claim_state == "claimed"
     acknowledged = ack_state == "acknowledged"
@@ -2103,8 +2157,8 @@ def test_cancellation_acknowledgement_at_or_after_deadline_atomically_expires(
     deadline = now + timedelta(seconds=30)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2146,8 +2200,8 @@ def test_cancellation_acknowledgement_and_expiry_race_converges_at_deadline(
     deadline = now + timedelta(seconds=30)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2195,8 +2249,8 @@ def test_business_commit_wins_unacknowledged_cancellation_and_settles_receipt(pr
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="verify", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="verify", attempt=1, submitted_at=now)
     )
     assert provider.claim_execution("run-001", "flow-001", worker_id=worker_id, claimed_at=now)
     provider.reserve_mutation(receipt)
@@ -2237,8 +2291,8 @@ def test_external_cancelled_observation_without_acknowledgement_is_not_clean(pro
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2266,8 +2320,8 @@ def test_terminal_cancelled_observation_serializes_before_expiry(provider: Produ
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     receipt = _receipt(operation="cancel", target_run_id="run-001")
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     provider.reserve_mutation(receipt)
     assert provider.claim_mutation(receipt.receipt_id)
@@ -2313,8 +2367,8 @@ def test_claimed_success_and_failure_writebacks_have_one_consistent_winner(provi
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     worker_id = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
     provider.create_run(_run())
-    provider.add_prefect_execution(
-        "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
+    _append_execution(
+        provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1, submitted_at=now)
     )
     assert provider.claim_execution("run-001", "flow-001", worker_id=worker_id, claimed_at=now)
     barrier = Barrier(2)
@@ -2369,10 +2423,10 @@ def test_claimed_success_and_failure_writebacks_have_one_consistent_winner(provi
 def test_duplicate_prefect_execution_is_rejected_when_appended(provider: ProductProjection) -> None:
     link = PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1)
     provider.create_run(_run())
-    provider.add_prefect_execution("run-001", link)
+    _append_execution(provider, "run-001", link)
 
     with pytest.raises(DuplicatePrefectExecutionError, match="already linked"):
-        provider.add_prefect_execution("run-001", link)
+        _append_execution(provider, "run-001", link)
 
 
 def test_prefect_position_conflict_retries_without_misreporting_a_duplicate(tmp_path: Path) -> None:
@@ -2380,7 +2434,8 @@ def test_prefect_position_conflict_retries_without_misreporting_a_duplicate(tmp_
     projection = ProductProjection(records, FileArtifactStore(tmp_path / "objects"))
     projection.create_run(_run())
 
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1),
     )
@@ -2395,7 +2450,8 @@ def test_service_prefect_attempt_ordinals_are_allocated_atomically(provider: Pro
     provider.create_run(_run())
 
     def append(position: int) -> PrefectExecutionLink:
-        return provider.add_prefect_execution(
+        return _append_execution(
+            provider,
             "run-001",
             PrefectExecutionLink(flow_run_id=f"flow-{position}", purpose="verify", attempt=1),
             allocate_attempt=True,
@@ -2415,7 +2471,8 @@ def test_mutator_existence_checks_do_not_hydrate_the_run(tmp_path: Path) -> None
     projection = ProductProjection(records, FileArtifactStore(tmp_path / "objects"))
     records.create(_run())
 
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1),
     )
@@ -2424,7 +2481,8 @@ def test_mutator_existence_checks_do_not_hydrate_the_run(tmp_path: Path) -> None
 
 def test_missing_run_prefect_mutator_raises_specific_public_error(provider: ProductProjection) -> None:
     with pytest.raises(RunNotFoundError, match="unavailable Sync run ID"):
-        provider.add_prefect_execution(
+        _append_execution(
+            provider,
             "missing-run",
             PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1),
         )
@@ -3161,7 +3219,8 @@ def test_secret_canary_is_absent_from_raw_provider_contents(profile: str, tmp_pa
         _run().model_copy(update={"actor": secret, "results": {"credential": secret}}),
         secrets=(secret,),
     )
-    projection.add_prefect_execution(
+    _append_execution(
+        projection,
         "run-001",
         PrefectExecutionLink(flow_run_id="flow-001", purpose=f"plan:{secret}", attempt=1),
         secrets=(secret,),
@@ -3774,11 +3833,15 @@ def test_concurrent_identical_checksums_deduplicate_to_exactly_one_row_on_both_p
 
 # --- Run-to-configuration binding columns (deliberately inert so far) -------------------------
 
+# The pre-binding shape the additive migration still brings forward. It carries
+# ``reconciliation_required`` because that column is part of the clean V3 table and is
+# never migrated onto an older one: V3 development databases are recreated across it.
 _LEGACY_PRODUCT_RUNS_TABLE = """
 CREATE TABLE product_runs (
     run_id TEXT PRIMARY KEY, operation TEXT NOT NULL, configuration_reference TEXT NOT NULL,
     actor TEXT, audit_links TEXT NOT NULL, started_at TEXT NOT NULL, finished_at TEXT,
-    phase TEXT NOT NULL, outcome TEXT, summary TEXT NOT NULL, results TEXT NOT NULL
+    phase TEXT NOT NULL, outcome TEXT, summary TEXT NOT NULL, results TEXT NOT NULL,
+    reconciliation_required BOOLEAN NOT NULL DEFAULT FALSE
 );
 """
 _CONFIGURATION_BINDING_COLUMN_NAMES = ("config_id", "registry_version", "package_checksum")
@@ -3854,7 +3917,7 @@ def test_migration_is_idempotent_across_repeated_store_construction(tmp_path: Pa
 
 def test_existing_run_lifecycle_is_unaffected_by_the_new_binding_columns(provider: ProductProjection) -> None:
     provider.create_run(_run())
-    provider.add_prefect_execution("run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1))
+    _append_execution(provider, "run-001", PrefectExecutionLink(flow_run_id="flow-001", purpose="plan", attempt=1))
     provider.publish_artifact("run-001", artifact_id="plan", kind="plan", media_type="application/json", data=b"{}")
 
     provider.finish_run("run-001", phase="planned", outcome="succeeded", summary={"create": 1}, results={})

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -61,6 +61,24 @@ def _postgresql_dsn_or_skip() -> str:
     return dsn
 
 
+@pytest.fixture(name="_postgresql_schema", scope="session")
+def postgresql_schema_fixture() -> str:
+    """Recreate the disposable database's schema once, then return its DSN.
+
+    V3 is unreleased and its development databases are recreated rather than migrated, so
+    the clean schema this module asserts is the one a fresh server bootstraps.
+    """
+    dsn = _postgresql_dsn_or_skip()
+    # pylint: disable-next=import-outside-toplevel
+    import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
+    with psycopg.connect(dsn) as admin:
+        admin.execute("DROP SCHEMA public CASCADE")
+        admin.execute("CREATE SCHEMA public")
+        admin.commit()
+    return dsn
+
+
 @pytest.fixture(params=("sqlite", pytest.param("postgresql", marks=pytest.mark.integration)))
 def projection(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[ProductProjection]:
     """One product projection per provider profile, isolated per test."""
@@ -68,7 +86,7 @@ def projection(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Produ
     if request.param == "sqlite":
         yield ProductProjection(SQLiteRunStore(tmp_path / "records.sqlite3"), artifacts)
         return
-    dsn = _postgresql_dsn_or_skip()
+    dsn = request.getfixturevalue("_postgresql_schema")
     # pylint: disable-next=import-outside-toplevel
     import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
 
@@ -118,11 +136,13 @@ def _receipt(receipt_id: str, *, run_id: str, operation: str, client_key: str | 
 
 
 def _link(flow_run_id: str, *, purpose: str) -> PrefectExecutionLink:
+    # Submitted now, not at the module's fixed instant: an execution older than the
+    # admission TTL is no longer claimable, and these cases are about claimed work.
     return PrefectExecutionLink(
         flow_run_id=flow_run_id,
         purpose=purpose,
         attempt=1,
-        submitted_at=_STARTED_AT,
+        submitted_at=datetime.now(timezone.utc),
     )
 
 
@@ -256,12 +276,13 @@ def test_every_later_reservation_refuses_once_a_write_is_admitted(
     projection: ProductProjection, operation: str
 ) -> None:
     """A run that has admitted its one write never admits another stage of any kind."""
-    projection.create_run(_run(_rid("admitted-run")))
-    admitted = _admit_write(projection, _rid("admitted-run"), "m-apply", operation="apply")
+    run_id = _rid(f"admitted-run-{operation}")
+    projection.create_run(_run(run_id))
+    admitted = _admit_write(projection, run_id, "m-apply", operation="apply")
     assert admitted.state == "reserved"
 
     refused, _created = projection.reserve_mutation(
-        _receipt(f"m-later-{operation}", run_id=_rid("admitted-run"), operation=operation),
+        _receipt(f"m-later-{operation}", run_id=run_id, operation=operation),
         admit_write=operation in {"apply", "sync"},
     )
 
@@ -312,10 +333,18 @@ def test_a_terminal_write_still_refuses_a_later_reservation(projection: ProductP
 
 
 def test_only_the_admitted_receipt_may_append_the_write_execution(projection: ProductProjection) -> None:
-    """A second receipt cannot borrow the admission another receipt won."""
+    """A second receipt cannot borrow the admission another receipt won.
+
+    The stranger is a real, still-unresolved receipt of the same run — a cancellation,
+    the one kind the stage arbitration deliberately leaves alone — so what refuses its
+    append is the admission's ownership and not the absence of a reservation.
+    """
     projection.create_run(_run(_rid("owned-append")))
     admitted = _admit_write(projection, _rid("owned-append"), "m-apply", operation="apply")
-    stranger = _receipt("m-stranger", run_id=_rid("owned-append"), operation="apply")
+    stranger, _created = projection.reserve_mutation(
+        _receipt("m-stranger", run_id=_rid("owned-append"), operation="cancel")
+    )
+    assert stranger.state == "reserved"
 
     with pytest.raises(ValueError, match="write admission"):
         projection.add_prefect_execution(
@@ -355,7 +384,7 @@ def test_a_receipt_appends_at_most_one_execution(projection: ProductProjection) 
         receipt_id=admitted.receipt_id,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="already appended"):
         projection.add_prefect_execution(
             _rid("single-append"),
             _link("flow-apply-again", purpose="apply"),
@@ -368,18 +397,17 @@ def test_a_receipt_appends_at_most_one_execution(projection: ProductProjection) 
 
 
 def test_a_read_reservation_cannot_append_after_a_write_admission(projection: ProductProjection) -> None:
-    """A receipt reserved before the write cannot append its execution afterwards."""
+    """A run holding a write admission accepts no read execution either.
+
+    The appending receipt is an unresolved cancellation, so the run genuinely has one
+    receipt that could ask; the admission is what refuses it.
+    """
     projection.create_run(_run(_rid("late-read-append")))
-    verify = _reserve_read(projection, _rid("late-read-append"), "m-verify", operation="verify")
-    projection.complete_mutation(
-        verify.receipt_id,
-        response_status=202,
-        response_body={"accepted": True},
-        flow_run_id="flow-verify",
-    )
     admitted = _admit_write(projection, _rid("late-read-append"), "m-apply", operation="apply")
     assert admitted.state == "reserved"
-    late = _receipt("m-late-verify", run_id=_rid("late-read-append"), operation="verify")
+    late, _created = projection.reserve_mutation(
+        _receipt("m-late-verify", run_id=_rid("late-read-append"), operation="cancel")
+    )
 
     with pytest.raises(ValueError, match="write admission"):
         projection.add_prefect_execution(

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -14,14 +14,13 @@ single-writer lock cannot stand in for it.
 
 from __future__ import annotations
 
-import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
-from threading import Barrier, Lock
+from threading import Barrier
 from typing import TYPE_CHECKING, Any
-from uuid import NAMESPACE_URL, uuid4, uuid5
+from uuid import uuid4
 
 import pytest
 
@@ -34,10 +33,9 @@ from infrahub_sync.product_store import (
     ProductRun,
 )
 from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunStore, SQLiteRunStore
-from infrahub_sync.service.auth import Principal
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Iterator
     from pathlib import Path
 
 _DSN_ENVIRONMENT_NAME = "PRODUCT_STORE_TEST_POSTGRESQL_DSN"
@@ -693,151 +691,3 @@ def test_an_expired_cancellation_of_a_claimed_write_records_reconciliation(proje
     assert stored is not None
     assert stored.reconciliation_required is True
     assert (stored.phase, stored.outcome) == ("interrupted", "ambiguous")
-
-
-class _SubmissionRecorder:
-    """A Prefect stand-in that records every submission it is asked to make.
-
-    The point of the barrier below is that the loser never reaches this at all, so what
-    matters is the count, not what a submission returns.
-    """
-
-    def __init__(self) -> None:
-        self.submissions: list[str] = []
-        self._lock = Lock()
-
-    async def submit(self, parameters: Mapping[str, Any], *, idempotency_key: str) -> Any:  # noqa: ANN401
-        """Record one submission and answer with a stable flow-run identity."""
-        _ = parameters
-        with self._lock:
-            self.submissions.append(idempotency_key)
-        from infrahub_sync.service.orchestration import Submission  # pylint: disable=import-outside-toplevel
-
-        return Submission(flow_run_id=str(uuid5(NAMESPACE_URL, idempotency_key)), state="pending")
-
-    async def observe(self, flow_run_id: str) -> Any:  # noqa: ANN401, PLR6301
-        """Report the submitted execution as running; nothing here reads it back."""
-        from infrahub_sync.service.orchestration import Observation  # pylint: disable=import-outside-toplevel
-
-        _ = flow_run_id
-        return Observation(available=True, state="running")
-
-
-def _publish_reviewed_plan(projection: ProductProjection, run_id: str) -> str:
-    """Publish the retained review document both stages read before reserving."""
-    from infrahub_sync.service.models import (  # pylint: disable=import-outside-toplevel
-        PlanResource,
-        PlanSummaryResource,
-    )
-    from infrahub_sync.service.service import PLAN_ARTIFACT_ID  # pylint: disable=import-outside-toplevel
-
-    checksum = "b" * 64
-    document = PlanResource(
-        run_id=run_id,
-        checksum=checksum,
-        checksum_ok=True,
-        verification_notes=(),
-        summary=PlanSummaryResource(
-            by_action={"update": 1},
-            by_kind={},
-            total=1,
-            delete_operations_computed=True,
-            deletes_not_executed=0,
-        ),
-        operations=(),
-    )
-    projection.publish_artifact(
-        run_id,
-        artifact_id=PLAN_ARTIFACT_ID,
-        kind="saved-plan-review",
-        media_type="application/json",
-        data=document.model_dump_json().encode(),
-    )
-    return checksum
-
-
-_RACE_ROUNDS = 4
-
-
-def _race_one_round(
-    projection: ProductProjection, principal: Principal, run_id: str, round_number: int
-) -> tuple[dict[str, int], list[str]]:
-    """Start one apply and one verify at a barrier; return their statuses and submissions."""
-    from infrahub_sync.service.models import (  # pylint: disable=import-outside-toplevel
-        ApplyRunRequest,
-        VerifyRunRequest,
-    )
-    from infrahub_sync.service.service import RunService  # pylint: disable=import-outside-toplevel
-
-    checksum = _publish_reviewed_plan(projection, run_id)
-    orchestration = _SubmissionRecorder()
-    service = RunService(projection, orchestration)  # ty: ignore[invalid-argument-type]
-    barrier = Barrier(2)
-
-    def submit(stage: str) -> tuple[str, int]:
-        barrier.wait(timeout=30)
-        key = f"race-{round_number}-{stage}"
-        if stage == "apply":
-            request: Any = ApplyRunRequest(
-                expected_checksum=checksum, confirm_writes=True, reason="race: apply the reviewed plan"
-            )
-            status, _body = asyncio.run(service.apply_run(run_id, request, principal, key))
-        else:
-            request = VerifyRunRequest(reason="race: verify the reviewed plan")
-            status, _body = asyncio.run(service.verify_run(run_id, request, principal, key))
-        return stage, status
-
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        outcomes = dict(pool.map(submit, ("apply", "verify")))
-    return outcomes, orchestration.submissions
-
-
-def test_a_concurrent_apply_and_verify_admit_exactly_one_of_them(projection: ProductProjection) -> None:
-    """An apply and a verify that start together decide before either submits anything.
-
-    This is the cross-purpose race, and it is not the apply-versus-apply one: the two
-    requests want different stages, so nothing but the run's own arbitration keeps them
-    apart. Either may win, and which one wins decides which rule the round exercises — an
-    apply that wins is refusing the verify by its admission, a verify that wins is refusing
-    the apply by being an unresolved submission. The case asserts the shape of the outcome
-    rather than the identity of the winner, and runs several independent rounds so a broken
-    rule cannot hide behind one round's scheduling. Each rule is also pinned on its own,
-    deterministically, by the sequential cases above.
-
-    What makes it worth running concurrently: the loser is answered from the store, so it
-    never reaches Prefect. The recorder counts exactly one submission per round, whichever
-    way that round went.
-    """
-    principal = Principal(actor="operator@example.com", administrator=True)
-
-    for round_number in range(_RACE_ROUNDS):
-        run_id = _rid(f"apply-versus-verify-race-{round_number}")
-        projection.create_run(_run(run_id))
-        outcomes, submissions = _race_one_round(projection, principal, run_id, round_number)
-
-        assert sorted(outcomes.values()) == [202, 409], f"round {round_number}: {outcomes}"
-        winner = next(stage for stage, status in outcomes.items() if status == 202)
-        loser = next(stage for stage, status in outcomes.items() if status == 409)
-
-        admitted = projection.lookup_mutation(
-            principal.actor, sha256(f"race-{round_number}-{winner}".encode()).hexdigest()
-        ).value
-        assert admitted is not None
-        assert submissions == [admitted.prefect_key], (
-            f"round {round_number}: {loser} reached Prefect despite losing the reservation: {submissions}"
-        )
-
-        refused = projection.lookup_mutation(
-            principal.actor, sha256(f"race-{round_number}-{loser}".encode()).hexdigest()
-        ).value
-        assert refused is not None
-        assert refused.response_status == 409
-        assert _refusal_code(refused) == _CONFLICT_CODE
-        assert refused.flow_run_id is None, "the loser was answered from the store, before any submission"
-
-        stored = projection.lookup_run(run_id).value
-        assert stored is not None
-        assert len(stored.prefect_executions) == 1, (
-            f"round {round_number}: {loser} appended an execution: {stored.prefect_executions}"
-        )
-        assert stored.prefect_executions[0].purpose == winner

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -1,0 +1,570 @@
+"""Pre-submission admission: one run admits one write, and one receipt owns its append.
+
+The rules under test are store rules, not service rules: whichever request wins the
+run's write reservation is decided inside one store transaction, before either
+competitor can submit anything to Prefect. The loser is told so durably, by a stored
+refusal on its own receipt, so replaying its idempotency key replays the refusal
+instead of racing again.
+
+SQLite covers the transaction shape. The same cases run against a real PostgreSQL
+server when ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` names one, because row-level
+serialization between two competing reservations is a provider fact and SQLite's
+single-writer lock cannot stand in for it.
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from hashlib import sha256
+from threading import Barrier
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import pytest
+
+from infrahub_sync.product_store import (
+    ExecutionFinishWriteback,
+    ExecutionMergeWriteback,
+    MutationReceipt,
+    PrefectExecutionLink,
+    ProductProjection,
+    ProductRun,
+)
+from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunStore, SQLiteRunStore
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_DSN_ENVIRONMENT_NAME = "PRODUCT_STORE_TEST_POSTGRESQL_DSN"
+# The PostgreSQL parameter runs against a persistent disposable database, so every run
+# ID and receipt identity in this module is namespaced to one test session.
+_SESSION = uuid4().hex[:10]
+_CONFLICT_CODE = "run-execution-conflict"
+_WORKER_ID = "5f2d3a0e-2f2c-4a55-9d3f-9a2a1c6f4b71"
+_STARTED_AT = datetime(2026, 9, 3, 9, tzinfo=timezone.utc)
+
+
+def _postgresql_dsn_or_skip() -> str:
+    """Return a reachable disposable DSN, or skip before any server is contacted."""
+    dsn = os.environ.get(_DSN_ENVIRONMENT_NAME)
+    if not dsn:
+        pytest.skip(f"the admission contract's PostgreSQL parameter requires {_DSN_ENVIRONMENT_NAME}")
+    psycopg = pytest.importorskip("psycopg")
+    try:
+        with psycopg.connect(dsn, connect_timeout=5) as probe:
+            probe.execute("SELECT 1")
+    except psycopg.Error:
+        pytest.skip(f"{_DSN_ENVIRONMENT_NAME} is not reachable")
+    return dsn
+
+
+@pytest.fixture(params=("sqlite", pytest.param("postgresql", marks=pytest.mark.integration)))
+def projection(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[ProductProjection]:
+    """One product projection per provider profile, isolated per test."""
+    artifacts = FileArtifactStore(tmp_path / "objects")
+    if request.param == "sqlite":
+        yield ProductProjection(SQLiteRunStore(tmp_path / "records.sqlite3"), artifacts)
+        return
+    dsn = _postgresql_dsn_or_skip()
+    # pylint: disable-next=import-outside-toplevel
+    import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
+    from infrahub_sync.service.storage import PsycopgConnectionFactory
+
+    def connect() -> Any:  # noqa: ANN401 - the store's own DB-API connection protocol.
+        return PsycopgConnectionFactory(psycopg.connect)(dsn)
+
+    yield ProductProjection(PostgreSQLRunStore(connect), artifacts)
+
+
+def _rid(name: str) -> str:
+    """Namespace one run ID to this test session."""
+    return f"{name}-{_SESSION}"
+
+
+def _run(run_id: str, *, operation: str = "plan") -> ProductRun:
+    return ProductRun(
+        run_id=run_id,
+        operation=operation,  # ty: ignore[invalid-argument-type] - the literal is one of Operation.
+        configuration_reference="config-001@1",
+        config_id="config-001",
+        registry_version=1,
+        package_checksum="a" * 64,
+        actor="operator@example.com",
+        started_at=_STARTED_AT,
+        phase="accepted",
+    )
+
+
+def _receipt(receipt_id: str, *, run_id: str, operation: str, client_key: str | None = None) -> MutationReceipt:
+    key = client_key if client_key is not None else receipt_id
+    return MutationReceipt(
+        receipt_id=f"{receipt_id}.{run_id}",
+        actor="operator@example.com",
+        key_digest=sha256(f"{key}:{run_id}".encode()).hexdigest(),
+        operation=operation,
+        target_run_id=run_id,
+        request_fingerprint=sha256(f"{operation}:{run_id}".encode()).hexdigest(),
+        reason="admission contract",
+        resource_id=run_id,
+        run_id=run_id,
+        prefect_key=sha256(f"prefect:{receipt_id}:{run_id}".encode()).hexdigest(),
+        created_at=_STARTED_AT,
+        updated_at=_STARTED_AT,
+    )
+
+
+def _link(flow_run_id: str, *, purpose: str) -> PrefectExecutionLink:
+    return PrefectExecutionLink(
+        flow_run_id=flow_run_id,
+        purpose=purpose,
+        attempt=1,
+        submitted_at=_STARTED_AT,
+    )
+
+
+def _refusal_code(receipt: MutationReceipt) -> str | None:
+    """Return the stored refusal's error code, or None when the receipt is not a refusal."""
+    body = receipt.response_body
+    if body is None:
+        return None
+    error = body.get("error")
+    return error.get("code") if isinstance(error, dict) else None
+
+
+def _admit_write(projection: ProductProjection, run_id: str, receipt_id: str, *, operation: str) -> MutationReceipt:
+    """Reserve one write admission on an existing run and return the stored receipt."""
+    reserved, _created = projection.reserve_mutation(
+        _receipt(receipt_id, run_id=run_id, operation=operation),
+        admit_write=True,
+    )
+    return reserved
+
+
+def _reserve_read(projection: ProductProjection, run_id: str, receipt_id: str, *, operation: str) -> MutationReceipt:
+    reserved, _created = projection.reserve_mutation(_receipt(receipt_id, run_id=run_id, operation=operation))
+    return reserved
+
+
+def test_exactly_one_of_two_concurrent_applies_wins_the_run_write_reservation(
+    projection: ProductProjection,
+) -> None:
+    """Two applies that start together decide at the store, before either submits.
+
+    The barrier is what discriminates: both callers are inside ``reserve_mutation``
+    before either can commit, so a reservation that read the run's records without
+    serializing on its authoritative row would let both win and both submit.
+    """
+    projection.create_run(_run(_rid("race-apply-apply")))
+    barrier = Barrier(2)
+
+    def reserve(receipt_id: str) -> MutationReceipt:
+        barrier.wait(timeout=30)
+        reserved, _created = projection.reserve_mutation(
+            _receipt(receipt_id, run_id=_rid("race-apply-apply"), operation="apply"),
+            admit_write=True,
+        )
+        return reserved
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = [future.result() for future in [pool.submit(reserve, "m-race-a"), pool.submit(reserve, "m-race-b")]]
+
+    winners = [receipt for receipt in results if receipt.state == "reserved"]
+    losers = [receipt for receipt in results if receipt.state == "accepted"]
+    assert len(winners) == 1
+    assert len(losers) == 1
+    assert losers[0].response_status == 409
+    assert _refusal_code(losers[0]) == _CONFLICT_CODE
+    assert losers[0].flow_run_id is None
+
+
+def test_an_apply_loses_to_an_unresolved_verify_receipt(projection: ProductProjection) -> None:
+    """A verify already reserved and not yet answered blocks the write reservation.
+
+    The verify receipt carries no execution yet, so a rule that only looked for a
+    non-terminal execution would admit the write and race the verify's submission.
+    """
+    projection.create_run(_run(_rid("apply-versus-verify")))
+    _reserve_read(projection, _rid("apply-versus-verify"), "m-verify", operation="verify")
+
+    refused = _admit_write(projection, _rid("apply-versus-verify"), "m-apply", operation="apply")
+
+    assert refused.state == "accepted"
+    assert refused.response_status == 409
+    assert _refusal_code(refused) == _CONFLICT_CODE
+
+
+def test_an_apply_loses_to_a_nonterminal_execution(projection: ProductProjection) -> None:
+    """A still-running read execution blocks the write reservation."""
+    projection.create_run(_run(_rid("apply-versus-execution")))
+    verify = _reserve_read(projection, _rid("apply-versus-execution"), "m-verify", operation="verify")
+    projection.add_prefect_execution(
+        _rid("apply-versus-execution"),
+        _link("flow-verify", purpose="verify"),
+        receipt_id=verify.receipt_id,
+    )
+    projection.complete_mutation(
+        verify.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-verify",
+    )
+
+    refused = _admit_write(projection, _rid("apply-versus-execution"), "m-apply", operation="apply")
+
+    assert refused.state == "accepted"
+    assert _refusal_code(refused) == _CONFLICT_CODE
+
+
+def test_an_apply_wins_once_the_verify_is_resolved_and_terminal(projection: ProductProjection) -> None:
+    """The negative cases above must not be satisfied by refusing every apply."""
+    projection.create_run(_run(_rid("apply-after-verify")))
+    verify = _reserve_read(projection, _rid("apply-after-verify"), "m-verify", operation="verify")
+    projection.add_prefect_execution(
+        _rid("apply-after-verify"),
+        _link("flow-verify", purpose="verify"),
+        receipt_id=verify.receipt_id,
+    )
+    projection.complete_mutation(
+        verify.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-verify",
+    )
+    projection.claim_execution(_rid("apply-after-verify"), "flow-verify", worker_id=_WORKER_ID)
+    projection.commit_claimed_execution(
+        _rid("apply-after-verify"),
+        "flow-verify",
+        worker_id=_WORKER_ID,
+        terminal_at=datetime.now(timezone.utc),
+        terminal_state="completed",
+        terminal_outcome="succeeded",
+        writeback=ExecutionMergeWriteback(results={"verification": {"outcome": "verified"}}),
+    )
+
+    admitted = _admit_write(projection, _rid("apply-after-verify"), "m-apply", operation="apply")
+
+    assert admitted.state == "reserved"
+    assert admitted.response_status is None
+
+
+@pytest.mark.parametrize("operation", ["plan", "verify", "apply", "sync"])
+def test_every_later_reservation_refuses_once_a_write_is_admitted(
+    projection: ProductProjection, operation: str
+) -> None:
+    """A run that has admitted its one write never admits another stage of any kind."""
+    projection.create_run(_run(_rid("admitted-run")))
+    admitted = _admit_write(projection, _rid("admitted-run"), "m-apply", operation="apply")
+    assert admitted.state == "reserved"
+
+    refused, _created = projection.reserve_mutation(
+        _receipt(f"m-later-{operation}", run_id=_rid("admitted-run"), operation=operation),
+        admit_write=operation in {"apply", "sync"},
+    )
+
+    assert refused.state == "accepted"
+    assert refused.response_status == 409
+    assert _refusal_code(refused) == _CONFLICT_CODE
+
+
+def test_a_terminal_write_still_refuses_a_later_reservation(projection: ProductProjection) -> None:
+    """Terminal write evidence is immutable; the run is never reopened for more work."""
+    projection.create_run(_run(_rid("terminal-write")))
+    apply_receipt = _admit_write(projection, _rid("terminal-write"), "m-apply", operation="apply")
+    projection.add_prefect_execution(
+        _rid("terminal-write"),
+        _link("flow-apply", purpose="apply"),
+        receipt_id=apply_receipt.receipt_id,
+    )
+    projection.complete_mutation(
+        apply_receipt.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-apply",
+    )
+    projection.claim_execution(_rid("terminal-write"), "flow-apply", worker_id=_WORKER_ID)
+    projection.commit_claimed_execution(
+        _rid("terminal-write"),
+        "flow-apply",
+        worker_id=_WORKER_ID,
+        terminal_at=datetime.now(timezone.utc),
+        terminal_state="completed",
+        terminal_outcome="succeeded",
+        writeback=ExecutionFinishWriteback(
+            phase="applied",
+            outcome="succeeded",
+            finished_at=datetime.now(timezone.utc),
+            summary={},
+            results={},
+        ),
+    )
+
+    refused, _created = projection.reserve_mutation(
+        _receipt("m-second-apply", run_id=_rid("terminal-write"), operation="apply"),
+        admit_write=True,
+    )
+
+    assert refused.state == "accepted"
+    assert _refusal_code(refused) == _CONFLICT_CODE
+
+
+def test_only_the_admitted_receipt_may_append_the_write_execution(projection: ProductProjection) -> None:
+    """A second receipt cannot borrow the admission another receipt won."""
+    projection.create_run(_run(_rid("owned-append")))
+    admitted = _admit_write(projection, _rid("owned-append"), "m-apply", operation="apply")
+    stranger = _receipt("m-stranger", run_id=_rid("owned-append"), operation="apply")
+
+    with pytest.raises(ValueError, match="write admission"):
+        projection.add_prefect_execution(
+            _rid("owned-append"),
+            _link("flow-stranger", purpose="apply"),
+            receipt_id=stranger.receipt_id,
+        )
+
+    appended = projection.add_prefect_execution(
+        _rid("owned-append"),
+        _link("flow-apply", purpose="apply"),
+        receipt_id=admitted.receipt_id,
+    )
+    assert appended.flow_run_id == "flow-apply"
+
+
+def test_an_appended_execution_purpose_must_match_the_admitted_operation(projection: ProductProjection) -> None:
+    """The admission names one operation; the append cannot be a different stage."""
+    projection.create_run(_run(_rid("purpose-match")))
+    admitted = _admit_write(projection, _rid("purpose-match"), "m-apply", operation="apply")
+
+    with pytest.raises(ValueError, match="write admission"):
+        projection.add_prefect_execution(
+            _rid("purpose-match"),
+            _link("flow-sync", purpose="sync"),
+            receipt_id=admitted.receipt_id,
+        )
+
+
+def test_a_receipt_appends_at_most_one_execution(projection: ProductProjection) -> None:
+    """The receipt-to-execution relation is the one-append rule, enforced durably."""
+    projection.create_run(_run(_rid("single-append")))
+    admitted = _admit_write(projection, _rid("single-append"), "m-apply", operation="apply")
+    projection.add_prefect_execution(
+        _rid("single-append"),
+        _link("flow-apply", purpose="apply"),
+        receipt_id=admitted.receipt_id,
+    )
+
+    with pytest.raises(ValueError):
+        projection.add_prefect_execution(
+            _rid("single-append"),
+            _link("flow-apply-again", purpose="apply"),
+            receipt_id=admitted.receipt_id,
+        )
+
+    stored = projection.lookup_run(_rid("single-append")).value
+    assert stored is not None
+    assert [link.flow_run_id for link in stored.prefect_executions] == ["flow-apply"]
+
+
+def test_a_read_reservation_cannot_append_after_a_write_admission(projection: ProductProjection) -> None:
+    """A receipt reserved before the write cannot append its execution afterwards."""
+    projection.create_run(_run(_rid("late-read-append")))
+    verify = _reserve_read(projection, _rid("late-read-append"), "m-verify", operation="verify")
+    projection.complete_mutation(
+        verify.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-verify",
+    )
+    admitted = _admit_write(projection, _rid("late-read-append"), "m-apply", operation="apply")
+    assert admitted.state == "reserved"
+    late = _receipt("m-late-verify", run_id=_rid("late-read-append"), operation="verify")
+
+    with pytest.raises(ValueError, match="write admission"):
+        projection.add_prefect_execution(
+            _rid("late-read-append"),
+            _link("flow-late-verify", purpose="verify"),
+            receipt_id=late.receipt_id,
+        )
+
+
+def test_a_resolved_receipt_cannot_append_an_execution(projection: ProductProjection) -> None:
+    """An append belongs to a submission still in flight, never to an answered one."""
+    projection.create_run(_run(_rid("resolved-append")))
+    admitted = _admit_write(projection, _rid("resolved-append"), "m-apply", operation="apply")
+    projection.complete_mutation(
+        admitted.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-apply",
+    )
+
+    with pytest.raises(ValueError, match="unresolved"):
+        projection.add_prefect_execution(
+            _rid("resolved-append"),
+            _link("flow-apply", purpose="apply"),
+            receipt_id=admitted.receipt_id,
+        )
+
+
+def test_the_same_client_key_resumes_one_reservation_and_one_prefect_key(projection: ProductProjection) -> None:
+    """A repeated submission before its answer reuses the reservation it already made."""
+    projection.create_run(_run(_rid("same-key-resume")))
+    first = _admit_write(projection, _rid("same-key-resume"), "m-apply", operation="apply")
+
+    resumed, created = projection.reserve_mutation(
+        _receipt("m-apply-second", run_id=_rid("same-key-resume"), operation="apply", client_key="m-apply"),
+        admit_write=True,
+    )
+
+    assert created is False
+    assert resumed.receipt_id == first.receipt_id
+    assert resumed.prefect_key == first.prefect_key
+    assert resumed.state == "reserved"
+
+
+def test_a_different_client_key_cannot_resume_another_actors_reservation(projection: ProductProjection) -> None:
+    """Resume is keyed by the client's own key; a new key is a new, losing request."""
+    projection.create_run(_run(_rid("different-key")))
+    _admit_write(projection, _rid("different-key"), "m-apply", operation="apply")
+
+    refused, created = projection.reserve_mutation(
+        _receipt("m-apply-other", run_id=_rid("different-key"), operation="apply", client_key="other-key"),
+        admit_write=True,
+    )
+
+    assert created is True
+    assert refused.state == "accepted"
+    assert _refusal_code(refused) == _CONFLICT_CODE
+
+
+def test_a_new_run_reservation_is_never_arbitrated_against_another_run(projection: ProductProjection) -> None:
+    """Creating a sync run admits its write; a previous run's admission is irrelevant."""
+    projection.create_run(_run(_rid("existing-run")))
+    _admit_write(projection, _rid("existing-run"), "m-existing-apply", operation="apply")
+
+    created_receipt, created = projection.reserve_mutation(
+        _receipt("m-new-sync", run_id=_rid("new-sync-run"), operation="sync"),
+        run=_run(_rid("new-sync-run"), operation="sync"),
+        admit_write=True,
+    )
+
+    assert created is True
+    assert created_receipt.state == "reserved"
+
+
+def test_cancellation_is_outside_the_stage_arbitration(projection: ProductProjection) -> None:
+    """An admitted write must still be cancellable; cancel never reserves a stage."""
+    projection.create_run(_run(_rid("cancellable")))
+    _admit_write(projection, _rid("cancellable"), "m-apply", operation="apply")
+
+    cancel, created = projection.reserve_mutation(_receipt("m-cancel", run_id=_rid("cancellable"), operation="cancel"))
+
+    assert created is True
+    assert cancel.state == "reserved"
+
+
+def _claimed_write_run(projection: ProductProjection, run_id: str, *, purpose: str) -> str:
+    """Admit, append, and claim one write execution, returning its flow-run ID."""
+    projection.create_run(_run(run_id, operation="sync" if purpose == "sync" else "plan"))
+    admitted = _admit_write(projection, run_id, f"m-{run_id}", operation=purpose)
+    flow_run_id = f"flow-{run_id}"
+    projection.add_prefect_execution(run_id, _link(flow_run_id, purpose=purpose), receipt_id=admitted.receipt_id)
+    projection.complete_mutation(
+        admitted.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id=flow_run_id,
+    )
+    projection.claim_execution(run_id, flow_run_id, worker_id=_WORKER_ID)
+    return flow_run_id
+
+
+@pytest.mark.parametrize("purpose", ["apply", "sync"])
+def test_a_claimed_write_interruption_records_durable_reconciliation_evidence(
+    projection: ProductProjection, purpose: str
+) -> None:
+    """An ambiguous write verdict and its safety bit are one durable decision."""
+    run_id = _rid(f"ambiguous-{purpose}")
+    flow_run_id = _claimed_write_run(projection, run_id, purpose=purpose)
+
+    assert projection.interrupt_execution(run_id, flow_run_id) is True
+
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.reconciliation_required is True
+    assert (stored.phase, stored.outcome) == ("interrupted", "ambiguous")
+
+
+def test_an_interrupted_read_execution_records_no_reconciliation_evidence(projection: ProductProjection) -> None:
+    """A plan or verify worker cannot have written; ambiguity is a write-only verdict."""
+    projection.create_run(_run(_rid("ambiguous-plan")))
+    reserved = _reserve_read(projection, _rid("ambiguous-plan"), "m-plan", operation="plan")
+    projection.add_prefect_execution(
+        _rid("ambiguous-plan"), _link("flow-plan", purpose="plan"), receipt_id=reserved.receipt_id
+    )
+    projection.complete_mutation(
+        reserved.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-plan",
+    )
+    projection.claim_execution(_rid("ambiguous-plan"), "flow-plan", worker_id=_WORKER_ID)
+
+    assert projection.interrupt_execution(_rid("ambiguous-plan"), "flow-plan") is True
+
+    stored = projection.lookup_run(_rid("ambiguous-plan")).value
+    assert stored is not None
+    assert stored.reconciliation_required is False
+
+
+def test_the_worker_commits_ambiguity_and_its_evidence_together(projection: ProductProjection) -> None:
+    """A live worker that may have written records the verdict, the record, and the bit."""
+    flow_run_id = _claimed_write_run(projection, _rid("worker-ambiguous"), purpose="apply")
+
+    committed = projection.commit_claimed_execution(
+        _rid("worker-ambiguous"),
+        flow_run_id,
+        worker_id=_WORKER_ID,
+        terminal_at=datetime.now(timezone.utc),
+        terminal_state="interrupted",
+        terminal_outcome="ambiguous",
+        writeback=ExecutionFinishWriteback(
+            phase="apply-interrupted",
+            outcome="ambiguous",
+            finished_at=datetime.now(timezone.utc),
+            summary={"failed_stage": "apply", "applied_operations": ["op-1"]},
+            results={"apply_failure": {"stage": "apply", "outcome": "ambiguous"}},
+        ),
+    )
+
+    assert committed is True
+    stored = projection.lookup_run(_rid("worker-ambiguous")).value
+    assert stored is not None
+    assert stored.reconciliation_required is True
+    assert stored.results["apply_failure"]["outcome"] == "ambiguous"
+
+
+def test_result_replacement_cannot_clear_recorded_reconciliation_evidence(projection: ProductProjection) -> None:
+    """Nothing normal-looking written afterwards may retract the safety bit."""
+    flow_run_id = _claimed_write_run(projection, _rid("never-cleared"), purpose="apply")
+    projection.interrupt_execution(_rid("never-cleared"), flow_run_id)
+
+    projection.record_results(_rid("never-cleared"), {"reconciliation_required": False, "outcome": "succeeded"})
+    projection.merge_results(_rid("never-cleared"), {"reconciliation_required": False})
+    projection.finish_run(_rid("never-cleared"), phase="applied", outcome="succeeded", summary={}, results={})
+
+    stored = projection.lookup_run(_rid("never-cleared")).value
+    assert stored is not None
+    assert stored.reconciliation_required is True
+
+
+def test_a_new_run_starts_without_reconciliation_evidence(projection: ProductProjection) -> None:
+    """The field is authoritative and false by default, not absent."""
+    projection.create_run(_run(_rid("clean-run")))
+
+    stored = projection.lookup_run(_rid("clean-run")).value
+
+    assert stored is not None
+    assert stored.reconciliation_required is False

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from threading import Barrier
 from typing import TYPE_CHECKING, Any
@@ -596,3 +596,98 @@ def test_a_new_run_starts_without_reconciliation_evidence(projection: ProductPro
 
     assert stored is not None
     assert stored.reconciliation_required is False
+
+
+def _cancellation_intent(projection: ProductProjection, run_id: str, flow_run_id: str, *, receipt_id: str) -> datetime:
+    """Record first cancellation intent on one claimed execution and return its deadline."""
+    requested_at = datetime.now(timezone.utc)
+    recovery_deadline_at = requested_at + timedelta(seconds=30)
+    assert projection.request_execution_cancellation(
+        run_id,
+        flow_run_id,
+        requested_at=requested_at,
+        recovery_deadline_at=recovery_deadline_at,
+        recovery_seconds=30.0,
+        expected_latest_position=0,
+        receipt_id=receipt_id,
+    )
+    return recovery_deadline_at
+
+
+@pytest.mark.parametrize("purpose", ["apply", "sync"])
+def test_cancelling_a_claimed_write_is_conservative_ambiguity(projection: ProductProjection, purpose: str) -> None:
+    """A claimed write may already have reached the destination, so no clean stop exists.
+
+    Acknowledgement arrives well inside the recovery deadline, which for a read stage is
+    exactly when a clean cancellation is still possible — so what decides here is that the
+    claimed execution is a write, not that time ran out.
+    """
+    run_id = _rid(f"cancel-claimed-{purpose}")
+    flow_run_id = _claimed_write_run(projection, run_id, purpose=purpose)
+    cancel, _created = projection.reserve_mutation(_receipt("m-cancel", run_id=run_id, operation="cancel"))
+    projection.claim_mutation(cancel.receipt_id)
+    _cancellation_intent(projection, run_id, flow_run_id, receipt_id=cancel.receipt_id)
+
+    acknowledged = projection.acknowledge_execution_cancellation(
+        run_id,
+        flow_run_id,
+        acknowledged_at=datetime.now(timezone.utc),
+        response_status=202,
+        response_body={"accepted": True},
+    )
+
+    assert acknowledged is False, "a claimed write is never acknowledged as a clean stop"
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.reconciliation_required is True
+    assert (stored.phase, stored.outcome) == ("interrupted", "ambiguous")
+    answered = projection.lookup_mutation(cancel.actor, cancel.key_digest).value
+    assert answered is not None
+    assert _refusal_code(answered) == "cancellation-ambiguous"
+
+
+def test_cancelling_a_claimed_read_stage_is_still_a_clean_acknowledgement(projection: ProductProjection) -> None:
+    """A verify worker cannot have written, so cancelling it keeps its ordinary path."""
+    run_id = _rid("cancel-claimed-verify")
+    projection.create_run(_run(run_id))
+    reserved = _reserve_read(projection, run_id, "m-verify", operation="verify")
+    projection.add_prefect_execution(run_id, _link("flow-verify", purpose="verify"), receipt_id=reserved.receipt_id)
+    projection.complete_mutation(
+        reserved.receipt_id,
+        response_status=202,
+        response_body={"accepted": True},
+        flow_run_id="flow-verify",
+    )
+    projection.claim_execution(run_id, "flow-verify", worker_id=_WORKER_ID)
+    cancel, _created = projection.reserve_mutation(_receipt("m-cancel", run_id=run_id, operation="cancel"))
+    projection.claim_mutation(cancel.receipt_id)
+    _cancellation_intent(projection, run_id, "flow-verify", receipt_id=cancel.receipt_id)
+
+    acknowledged = projection.acknowledge_execution_cancellation(
+        run_id,
+        "flow-verify",
+        acknowledged_at=datetime.now(timezone.utc),
+        response_status=202,
+        response_body={"accepted": True},
+    )
+
+    assert acknowledged is True
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.reconciliation_required is False
+
+
+def test_an_expired_cancellation_of_a_claimed_write_records_reconciliation(projection: ProductProjection) -> None:
+    """Recovery that ran out of time on a claimed write is ambiguity, not abandonment."""
+    run_id = _rid("cancel-expired-apply")
+    flow_run_id = _claimed_write_run(projection, run_id, purpose="apply")
+    cancel, _created = projection.reserve_mutation(_receipt("m-cancel", run_id=run_id, operation="cancel"))
+    projection.claim_mutation(cancel.receipt_id)
+    deadline = _cancellation_intent(projection, run_id, flow_run_id, receipt_id=cancel.receipt_id)
+
+    assert projection.expire_execution_cancellation(run_id, flow_run_id, terminal_at=deadline + timedelta(seconds=1))
+
+    stored = projection.lookup_run(run_id).value
+    assert stored is not None
+    assert stored.reconciliation_required is True
+    assert (stored.phase, stored.outcome) == ("interrupted", "ambiguous")

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -14,13 +14,14 @@ single-writer lock cannot stand in for it.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
-from threading import Barrier
+from threading import Barrier, Lock
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import pytest
 
@@ -33,9 +34,10 @@ from infrahub_sync.product_store import (
     ProductRun,
 )
 from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunStore, SQLiteRunStore
+from infrahub_sync.service.auth import Principal
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
     from pathlib import Path
 
 _DSN_ENVIRONMENT_NAME = "PRODUCT_STORE_TEST_POSTGRESQL_DSN"
@@ -691,3 +693,151 @@ def test_an_expired_cancellation_of_a_claimed_write_records_reconciliation(proje
     assert stored is not None
     assert stored.reconciliation_required is True
     assert (stored.phase, stored.outcome) == ("interrupted", "ambiguous")
+
+
+class _SubmissionRecorder:
+    """A Prefect stand-in that records every submission it is asked to make.
+
+    The point of the barrier below is that the loser never reaches this at all, so what
+    matters is the count, not what a submission returns.
+    """
+
+    def __init__(self) -> None:
+        self.submissions: list[str] = []
+        self._lock = Lock()
+
+    async def submit(self, parameters: Mapping[str, Any], *, idempotency_key: str) -> Any:  # noqa: ANN401
+        """Record one submission and answer with a stable flow-run identity."""
+        _ = parameters
+        with self._lock:
+            self.submissions.append(idempotency_key)
+        from infrahub_sync.service.orchestration import Submission  # pylint: disable=import-outside-toplevel
+
+        return Submission(flow_run_id=str(uuid5(NAMESPACE_URL, idempotency_key)), state="pending")
+
+    async def observe(self, flow_run_id: str) -> Any:  # noqa: ANN401, PLR6301
+        """Report the submitted execution as running; nothing here reads it back."""
+        from infrahub_sync.service.orchestration import Observation  # pylint: disable=import-outside-toplevel
+
+        _ = flow_run_id
+        return Observation(available=True, state="running")
+
+
+def _publish_reviewed_plan(projection: ProductProjection, run_id: str) -> str:
+    """Publish the retained review document both stages read before reserving."""
+    from infrahub_sync.service.models import (  # pylint: disable=import-outside-toplevel
+        PlanResource,
+        PlanSummaryResource,
+    )
+    from infrahub_sync.service.service import PLAN_ARTIFACT_ID  # pylint: disable=import-outside-toplevel
+
+    checksum = "b" * 64
+    document = PlanResource(
+        run_id=run_id,
+        checksum=checksum,
+        checksum_ok=True,
+        verification_notes=(),
+        summary=PlanSummaryResource(
+            by_action={"update": 1},
+            by_kind={},
+            total=1,
+            delete_operations_computed=True,
+            deletes_not_executed=0,
+        ),
+        operations=(),
+    )
+    projection.publish_artifact(
+        run_id,
+        artifact_id=PLAN_ARTIFACT_ID,
+        kind="saved-plan-review",
+        media_type="application/json",
+        data=document.model_dump_json().encode(),
+    )
+    return checksum
+
+
+_RACE_ROUNDS = 4
+
+
+def _race_one_round(
+    projection: ProductProjection, principal: Principal, run_id: str, round_number: int
+) -> tuple[dict[str, int], list[str]]:
+    """Start one apply and one verify at a barrier; return their statuses and submissions."""
+    from infrahub_sync.service.models import (  # pylint: disable=import-outside-toplevel
+        ApplyRunRequest,
+        VerifyRunRequest,
+    )
+    from infrahub_sync.service.service import RunService  # pylint: disable=import-outside-toplevel
+
+    checksum = _publish_reviewed_plan(projection, run_id)
+    orchestration = _SubmissionRecorder()
+    service = RunService(projection, orchestration)  # ty: ignore[invalid-argument-type]
+    barrier = Barrier(2)
+
+    def submit(stage: str) -> tuple[str, int]:
+        barrier.wait(timeout=30)
+        key = f"race-{round_number}-{stage}"
+        if stage == "apply":
+            request: Any = ApplyRunRequest(
+                expected_checksum=checksum, confirm_writes=True, reason="race: apply the reviewed plan"
+            )
+            status, _body = asyncio.run(service.apply_run(run_id, request, principal, key))
+        else:
+            request = VerifyRunRequest(reason="race: verify the reviewed plan")
+            status, _body = asyncio.run(service.verify_run(run_id, request, principal, key))
+        return stage, status
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = dict(pool.map(submit, ("apply", "verify")))
+    return outcomes, orchestration.submissions
+
+
+def test_a_concurrent_apply_and_verify_admit_exactly_one_of_them(projection: ProductProjection) -> None:
+    """An apply and a verify that start together decide before either submits anything.
+
+    This is the cross-purpose race, and it is not the apply-versus-apply one: the two
+    requests want different stages, so nothing but the run's own arbitration keeps them
+    apart. Either may win, and which one wins decides which rule the round exercises — an
+    apply that wins is refusing the verify by its admission, a verify that wins is refusing
+    the apply by being an unresolved submission. The case asserts the shape of the outcome
+    rather than the identity of the winner, and runs several independent rounds so a broken
+    rule cannot hide behind one round's scheduling. Each rule is also pinned on its own,
+    deterministically, by the sequential cases above.
+
+    What makes it worth running concurrently: the loser is answered from the store, so it
+    never reaches Prefect. The recorder counts exactly one submission per round, whichever
+    way that round went.
+    """
+    principal = Principal(actor="operator@example.com", administrator=True)
+
+    for round_number in range(_RACE_ROUNDS):
+        run_id = _rid(f"apply-versus-verify-race-{round_number}")
+        projection.create_run(_run(run_id))
+        outcomes, submissions = _race_one_round(projection, principal, run_id, round_number)
+
+        assert sorted(outcomes.values()) == [202, 409], f"round {round_number}: {outcomes}"
+        winner = next(stage for stage, status in outcomes.items() if status == 202)
+        loser = next(stage for stage, status in outcomes.items() if status == 409)
+
+        admitted = projection.lookup_mutation(
+            principal.actor, sha256(f"race-{round_number}-{winner}".encode()).hexdigest()
+        ).value
+        assert admitted is not None
+        assert submissions == [admitted.prefect_key], (
+            f"round {round_number}: {loser} reached Prefect despite losing the reservation: {submissions}"
+        )
+
+        refused = projection.lookup_mutation(
+            principal.actor, sha256(f"race-{round_number}-{loser}".encode()).hexdigest()
+        ).value
+        assert refused is not None
+        assert refused.response_status == 409
+        assert _refusal_code(refused) == _CONFLICT_CODE
+        assert refused.flow_run_id is None, "the loser was answered from the store, before any submission"
+
+        stored = projection.lookup_run(run_id).value
+        assert stored is not None
+        assert len(stored.prefect_executions) == 1, (
+            f"round {round_number}: {loser} appended an execution: {stored.prefect_executions}"
+        )
+        assert stored.prefect_executions[0].purpose == winner

--- a/tests/product_store/test_write_admission.py
+++ b/tests/product_store/test_write_admission.py
@@ -10,6 +10,11 @@ SQLite covers the transaction shape. The same cases run against a real PostgreSQ
 server when ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` names one, because row-level
 serialization between two competing reservations is a provider fact and SQLite's
 single-writer lock cannot stand in for it.
+
+WARNING: the PostgreSQL parameter's session fixture runs ``DROP SCHEMA public CASCADE``
+against whatever database ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` points at, which destroys
+every table in that database's ``public`` schema. Point that variable only at a disposable,
+single-purpose database — never at a shared or persistent development database.
 """
 
 from __future__ import annotations

--- a/tests/runtime_schema/test_worker_path.py
+++ b/tests/runtime_schema/test_worker_path.py
@@ -43,7 +43,9 @@ if TYPE_CHECKING:
 pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
 
+from infrahub_sync.plan.ownership import WriteDispatchTracker
 from infrahub_sync.service import flow as service_flow
+from tests.service.execution_fixtures import bind_granting_guard
 
 _SNAPSHOT: dict[str, Any] = {
     "BuiltinTag": {
@@ -221,6 +223,7 @@ def test_a_registered_stage_reaches_execution_with_its_models_bound(
     monkeypatch.setattr(service_flow, "_publish_plan", _skip)
     monkeypatch.setattr(service_flow, "_verify_registered_apply", _skip)
     monkeypatch.setattr(service_flow, "_require_planned_schema", _skip)
+    bind_granting_guard(monkeypatch, service_flow)
 
     result, _ = service_flow._execute_stage(
         "run-composed-sync",
@@ -233,6 +236,7 @@ def test_a_registered_stage_reaches_execution_with_its_models_bound(
         secrets=[],
         config_directory=str(tmp_path),
         projection=cast("ProductProjection", projection),
+        tracker=WriteDispatchTracker(),
     )
 
     assert result["operation"] == "sync"

--- a/tests/service/execution_fixtures.py
+++ b/tests/service/execution_fixtures.py
@@ -61,3 +61,42 @@ def append_execution(
     return projection.add_prefect_execution(
         run_id, link, receipt_id=receipt.receipt_id, allocate_attempt=allocate_attempt
     )
+
+
+class GrantingGuardSession:
+    """A direct-session double that always grants the configuration write guard.
+
+    Stage-driving tests whose subject is something else — binding, schema, ordering —
+    still cross the guard, so they need a session that answers its three statements. What
+    the guard does with a session that does not grant is
+    `tests/service/test_managed_write_guard.py`'s subject, not theirs.
+    """
+
+    def execute(self, query: str, params: object = None) -> _GrantingCursor:  # noqa: PLR6301
+        """Answer the acquire, ownership, and release statements the guard issues."""
+        _ = params
+        if "pg_locks" in query:
+            return _GrantingCursor((_BACKEND_PID, True))
+        if "pg_advisory_unlock" in query:
+            return _GrantingCursor((True, _BACKEND_PID))
+        return _GrantingCursor((None,))
+
+    def close(self) -> None:
+        """Close the dedicated session."""
+
+
+class _GrantingCursor:
+    def __init__(self, row: tuple[object, ...]) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[object, ...]:
+        return self._row
+
+
+_BACKEND_PID = 4242
+
+
+def bind_granting_guard(monkeypatch: object, flow_module: object) -> None:
+    """Bind a granting configuration write guard onto one service flow module."""
+    monkeypatch.setattr(flow_module, "service_guard_session", GrantingGuardSession)  # ty: ignore[unresolved-attribute]
+    monkeypatch.setattr(flow_module, "service_guard_secrets", lambda: ())  # ty: ignore[unresolved-attribute]

--- a/tests/service/execution_fixtures.py
+++ b/tests/service/execution_fixtures.py
@@ -24,8 +24,14 @@ _ORDINAL = count(1)
 _WRITE_PURPOSES = ("apply", "sync")
 
 
-def owning_receipt(projection: ProductProjection, run_id: str, *, purpose: str) -> MutationReceipt:
-    """Reserve the receipt that may append one execution of `purpose` to `run_id`."""
+def append_execution(
+    projection: ProductProjection,
+    run_id: str,
+    link: PrefectExecutionLink,
+    *,
+    allocate_attempt: bool = False,
+) -> PrefectExecutionLink:
+    """Reserve the receipt that owns this append, then append `link` through it."""
     ordinal = next(_ORDINAL)
     receipt_id = f"m-fixture-{ordinal}"
     now = datetime.now(timezone.utc)
@@ -34,9 +40,9 @@ def owning_receipt(projection: ProductProjection, run_id: str, *, purpose: str) 
             receipt_id=receipt_id,
             actor="owner",
             key_digest=sha256(f"fixture-key-{ordinal}".encode()).hexdigest(),
-            operation=purpose,
+            operation=link.purpose,
             target_run_id=run_id,
-            request_fingerprint=sha256(f"{purpose}:{run_id}:{ordinal}".encode()).hexdigest(),
+            request_fingerprint=sha256(f"{link.purpose}:{run_id}:{ordinal}".encode()).hexdigest(),
             reason="service execution fixture",
             resource_id=run_id,
             run_id=run_id,
@@ -44,22 +50,10 @@ def owning_receipt(projection: ProductProjection, run_id: str, *, purpose: str) 
             created_at=now,
             updated_at=now,
         ),
-        admit_write=purpose in _WRITE_PURPOSES,
+        admit_write=link.purpose in _WRITE_PURPOSES,
     )
-    return reserved
-
-
-def append_execution(
-    projection: ProductProjection,
-    run_id: str,
-    link: PrefectExecutionLink,
-    *,
-    allocate_attempt: bool = False,
-) -> PrefectExecutionLink:
-    """Reserve the owning receipt and append `link` as the one execution it may add."""
-    receipt = owning_receipt(projection, run_id, purpose=link.purpose)
     return projection.add_prefect_execution(
-        run_id, link, receipt_id=receipt.receipt_id, allocate_attempt=allocate_attempt
+        run_id, link, receipt_id=reserved.receipt_id, allocate_attempt=allocate_attempt
     )
 
 

--- a/tests/service/execution_fixtures.py
+++ b/tests/service/execution_fixtures.py
@@ -1,0 +1,63 @@
+"""Append a durable service execution the way the API does: through its owning receipt.
+
+Every `prefect_executions` row belongs to exactly one still-unresolved mutation receipt,
+and a write execution additionally needs the run's write admission to name that receipt.
+Service tests that only need a durable link would otherwise have to restate that whole
+reservation; this builds it once.
+
+Not a test module: no assertions live here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+from itertools import count
+from typing import TYPE_CHECKING
+
+from infrahub_sync.product_store import MutationReceipt
+
+if TYPE_CHECKING:
+    from infrahub_sync.product_store import PrefectExecutionLink, ProductProjection
+
+_ORDINAL = count(1)
+_WRITE_PURPOSES = ("apply", "sync")
+
+
+def owning_receipt(projection: ProductProjection, run_id: str, *, purpose: str) -> MutationReceipt:
+    """Reserve the receipt that may append one execution of `purpose` to `run_id`."""
+    ordinal = next(_ORDINAL)
+    receipt_id = f"m-fixture-{ordinal}"
+    now = datetime.now(timezone.utc)
+    reserved, _created = projection.reserve_mutation(
+        MutationReceipt(
+            receipt_id=receipt_id,
+            actor="owner",
+            key_digest=sha256(f"fixture-key-{ordinal}".encode()).hexdigest(),
+            operation=purpose,
+            target_run_id=run_id,
+            request_fingerprint=sha256(f"{purpose}:{run_id}:{ordinal}".encode()).hexdigest(),
+            reason="service execution fixture",
+            resource_id=run_id,
+            run_id=run_id,
+            prefect_key=sha256(f"prefect:{receipt_id}".encode()).hexdigest(),
+            created_at=now,
+            updated_at=now,
+        ),
+        admit_write=purpose in _WRITE_PURPOSES,
+    )
+    return reserved
+
+
+def append_execution(
+    projection: ProductProjection,
+    run_id: str,
+    link: PrefectExecutionLink,
+    *,
+    allocate_attempt: bool = False,
+) -> PrefectExecutionLink:
+    """Reserve the owning receipt and append `link` as the one execution it may add."""
+    receipt = owning_receipt(projection, run_id, purpose=link.purpose)
+    return projection.add_prefect_execution(
+        run_id, link, receipt_id=receipt.receipt_id, allocate_attempt=allocate_attempt
+    )

--- a/tests/service/test_apply_versus_verify_race.py
+++ b/tests/service/test_apply_versus_verify_race.py
@@ -1,0 +1,257 @@
+"""One apply and one verify that start together: exactly one of them is admitted.
+
+The rule is the product store's — whichever request wins the run's write reservation is
+decided inside one store transaction — but proving it concurrently needs the service path
+that reaches that transaction, because the property under test is that the loser is
+answered from the store and never reaches Prefect at all. That makes this a service test
+by its dependencies, and it lives here rather than beside the sequential admission cases
+in `tests/product_store/test_write_admission.py` for that reason: `tests/service` is the
+tree the Python 3.10 legs exclude, and the Sync service is Python 3.11+.
+
+Both store profiles still run. SQLite covers the transaction shape; the same case runs
+against a real PostgreSQL server when ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` names one,
+because row-level serialization between two competing reservations is a provider fact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from hashlib import sha256
+from threading import Barrier, Lock
+from typing import TYPE_CHECKING, Any
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+import pytest
+
+from infrahub_sync.product_store import MutationReceipt, ProductProjection, ProductRun
+from infrahub_sync.product_store.store import FileArtifactStore, PostgreSQLRunStore, SQLiteRunStore
+from infrahub_sync.service.auth import Principal
+from infrahub_sync.service.models import (
+    ApplyRunRequest,
+    PlanResource,
+    PlanSummaryResource,
+    VerifyRunRequest,
+)
+from infrahub_sync.service.orchestration import Observation, Submission
+from infrahub_sync.service.service import PLAN_ARTIFACT_ID, RunService
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+    from pathlib import Path
+
+_DSN_ENVIRONMENT_NAME = "PRODUCT_STORE_TEST_POSTGRESQL_DSN"
+# The PostgreSQL parameter runs against a persistent disposable database, so every run
+# ID and receipt identity in this module is namespaced to one test session.
+_SESSION = uuid4().hex[:10]
+_CONFLICT_CODE = "run-execution-conflict"
+_STARTED_AT = datetime(2026, 9, 3, 9, tzinfo=timezone.utc)
+
+
+def _postgresql_dsn_or_skip() -> str:
+    """Return a reachable disposable DSN, or skip before any server is contacted."""
+    dsn = os.environ.get(_DSN_ENVIRONMENT_NAME)
+    if not dsn:
+        pytest.skip(f"the admission race's PostgreSQL parameter requires {_DSN_ENVIRONMENT_NAME}")
+    psycopg = pytest.importorskip("psycopg")
+    try:
+        with psycopg.connect(dsn, connect_timeout=5) as probe:
+            probe.execute("SELECT 1")
+    except psycopg.Error:
+        pytest.skip(f"{_DSN_ENVIRONMENT_NAME} is not reachable")
+    return dsn
+
+
+@pytest.fixture(name="_postgresql_schema", scope="session")
+def postgresql_schema_fixture() -> str:
+    """Recreate the disposable database's schema once, then return its DSN."""
+    dsn = _postgresql_dsn_or_skip()
+    # pylint: disable-next=import-outside-toplevel
+    import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
+    with psycopg.connect(dsn) as admin:
+        admin.execute("DROP SCHEMA public CASCADE")
+        admin.execute("CREATE SCHEMA public")
+        admin.commit()
+    return dsn
+
+
+@pytest.fixture(params=("sqlite", pytest.param("postgresql", marks=pytest.mark.integration)))
+def projection(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[ProductProjection]:
+    """One product projection per provider profile, isolated per test."""
+    artifacts = FileArtifactStore(tmp_path / "objects")
+    if request.param == "sqlite":
+        yield ProductProjection(SQLiteRunStore(tmp_path / "records.sqlite3"), artifacts)
+        return
+    dsn = request.getfixturevalue("_postgresql_schema")
+    # pylint: disable-next=import-outside-toplevel
+    import psycopg  # ty: ignore[unresolved-import] - TODO: optional service dependency
+
+    from infrahub_sync.service.storage import PsycopgConnectionFactory
+
+    def connect() -> Any:  # noqa: ANN401 - the store's own DB-API connection protocol.
+        return PsycopgConnectionFactory(psycopg.connect)(dsn)
+
+    yield ProductProjection(PostgreSQLRunStore(connect), artifacts)
+
+
+def _rid(name: str) -> str:
+    """Namespace one run ID to this test session."""
+    return f"{name}-{_SESSION}"
+
+
+def _run(run_id: str) -> ProductRun:
+    return ProductRun(
+        run_id=run_id,
+        operation="plan",
+        configuration_reference="config-001@1",
+        config_id="config-001",
+        registry_version=1,
+        package_checksum="a" * 64,
+        actor="operator@example.com",
+        started_at=_STARTED_AT,
+        phase="accepted",
+    )
+
+
+def _refusal_code(receipt: MutationReceipt) -> str | None:
+    """Return the stored refusal's error code, or None when the receipt is not a refusal."""
+    body = receipt.response_body
+    if body is None:
+        return None
+    error = body.get("error")
+    return error.get("code") if isinstance(error, dict) else None
+
+
+class _SubmissionRecorder:
+    """A Prefect stand-in that records every submission it is asked to make.
+
+    The point of the barrier below is that the loser never reaches this at all, so what
+    matters is the count, not what a submission returns.
+    """
+
+    def __init__(self) -> None:
+        self.submissions: list[str] = []
+        self._lock = Lock()
+
+    async def submit(self, parameters: Mapping[str, Any], *, idempotency_key: str) -> Any:  # noqa: ANN401
+        """Record one submission and answer with a stable flow-run identity."""
+        _ = parameters
+        with self._lock:
+            self.submissions.append(idempotency_key)
+        return Submission(flow_run_id=str(uuid5(NAMESPACE_URL, idempotency_key)), state="pending")
+
+    async def observe(self, flow_run_id: str) -> Any:  # noqa: ANN401, PLR6301
+        """Report the submitted execution as running; nothing here reads it back."""
+        _ = flow_run_id
+        return Observation(available=True, state="running")
+
+
+def _publish_reviewed_plan(projection: ProductProjection, run_id: str) -> str:
+    """Publish the retained review document both stages read before reserving."""
+    checksum = "b" * 64
+    document = PlanResource(
+        run_id=run_id,
+        checksum=checksum,
+        checksum_ok=True,
+        verification_notes=(),
+        summary=PlanSummaryResource(
+            by_action={"update": 1},
+            by_kind={},
+            total=1,
+            delete_operations_computed=True,
+            deletes_not_executed=0,
+        ),
+        operations=(),
+    )
+    projection.publish_artifact(
+        run_id,
+        artifact_id=PLAN_ARTIFACT_ID,
+        kind="saved-plan-review",
+        media_type="application/json",
+        data=document.model_dump_json().encode(),
+    )
+    return checksum
+
+
+_RACE_ROUNDS = 4
+
+
+def _race_one_round(
+    projection: ProductProjection, principal: Principal, run_id: str, round_number: int
+) -> tuple[dict[str, int], list[str]]:
+    """Start one apply and one verify at a barrier; return their statuses and submissions."""
+    checksum = _publish_reviewed_plan(projection, run_id)
+    orchestration = _SubmissionRecorder()
+    service = RunService(projection, orchestration)  # ty: ignore[invalid-argument-type]
+    barrier = Barrier(2)
+
+    def submit(stage: str) -> tuple[str, int]:
+        barrier.wait(timeout=30)
+        key = f"race-{round_number}-{stage}"
+        if stage == "apply":
+            request: Any = ApplyRunRequest(
+                expected_checksum=checksum, confirm_writes=True, reason="race: apply the reviewed plan"
+            )
+            status, _body = asyncio.run(service.apply_run(run_id, request, principal, key))
+        else:
+            request = VerifyRunRequest(reason="race: verify the reviewed plan")
+            status, _body = asyncio.run(service.verify_run(run_id, request, principal, key))
+        return stage, status
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = dict(pool.map(submit, ("apply", "verify")))
+    return outcomes, orchestration.submissions
+
+
+def test_a_concurrent_apply_and_verify_admit_exactly_one_of_them(projection: ProductProjection) -> None:
+    """An apply and a verify that start together decide before either submits anything.
+
+    This is the cross-purpose race, and it is not the apply-versus-apply one: the two
+    requests want different stages, so nothing but the run's own arbitration keeps them
+    apart. Either may win, and which one wins decides which rule the round exercises — an
+    apply that wins is refusing the verify by its admission, a verify that wins is refusing
+    the apply by being an unresolved submission. The case asserts the shape of the outcome
+    rather than the identity of the winner, and runs several independent rounds so a broken
+    rule cannot hide behind one round's scheduling. Each rule is also pinned on its own,
+    deterministically, by the sequential cases above.
+
+    What makes it worth running concurrently: the loser is answered from the store, so it
+    never reaches Prefect. The recorder counts exactly one submission per round, whichever
+    way that round went.
+    """
+    principal = Principal(actor="operator@example.com", administrator=True)
+
+    for round_number in range(_RACE_ROUNDS):
+        run_id = _rid(f"apply-versus-verify-race-{round_number}")
+        projection.create_run(_run(run_id))
+        outcomes, submissions = _race_one_round(projection, principal, run_id, round_number)
+
+        assert sorted(outcomes.values()) == [202, 409], f"round {round_number}: {outcomes}"
+        winner = next(stage for stage, status in outcomes.items() if status == 202)
+        loser = next(stage for stage, status in outcomes.items() if status == 409)
+
+        admitted = projection.lookup_mutation(
+            principal.actor, sha256(f"race-{round_number}-{winner}".encode()).hexdigest()
+        ).value
+        assert admitted is not None
+        assert submissions == [admitted.prefect_key], (
+            f"round {round_number}: {loser} reached Prefect despite losing the reservation: {submissions}"
+        )
+
+        refused = projection.lookup_mutation(
+            principal.actor, sha256(f"race-{round_number}-{loser}".encode()).hexdigest()
+        ).value
+        assert refused is not None
+        assert refused.response_status == 409
+        assert _refusal_code(refused) == _CONFLICT_CODE
+        assert refused.flow_run_id is None, "the loser was answered from the store, before any submission"
+
+        stored = projection.lookup_run(run_id).value
+        assert stored is not None
+        assert len(stored.prefect_executions) == 1, (
+            f"round {round_number}: {loser} appended an execution: {stored.prefect_executions}"
+        )
+        assert stored.prefect_executions[0].purpose == winner

--- a/tests/service/test_apply_versus_verify_race.py
+++ b/tests/service/test_apply_versus_verify_race.py
@@ -11,6 +11,11 @@ tree the Python 3.10 legs exclude, and the Sync service is Python 3.11+.
 Both store profiles still run. SQLite covers the transaction shape; the same case runs
 against a real PostgreSQL server when ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` names one,
 because row-level serialization between two competing reservations is a provider fact.
+
+WARNING: the PostgreSQL parameter's session fixture runs ``DROP SCHEMA public CASCADE``
+against whatever database ``PRODUCT_STORE_TEST_POSTGRESQL_DSN`` points at, which destroys
+every table in that database's ``public`` schema. Point that variable only at a disposable,
+single-purpose database — never at a shared or persistent development database.
 """
 
 from __future__ import annotations

--- a/tests/service/test_flow_and_prefect.py
+++ b/tests/service/test_flow_and_prefect.py
@@ -49,6 +49,7 @@ from infrahub_sync.service.orchestration import (
     PrefectOrchestration,
 )
 from tests.configuration.validation_packages import package
+from tests.service.execution_fixtures import append_execution
 
 if TYPE_CHECKING:
     from prefect.client.schemas.actions import DeploymentUpdate
@@ -65,7 +66,8 @@ def _claimed_worker_execution(monkeypatch: pytest.MonkeyPatch) -> None:
         flow_run_id = str(uuid5(NAMESPACE_URL, run_id))
         run = projection.lookup_run(run_id).value
         if run is not None and not any(link.flow_run_id == flow_run_id for link in run.prefect_executions):
-            projection.add_prefect_execution(
+            append_execution(
+                projection,
                 run_id,
                 PrefectExecutionLink(flow_run_id=flow_run_id, purpose="test", attempt=1),
             )

--- a/tests/service/test_flow_and_prefect.py
+++ b/tests/service/test_flow_and_prefect.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import logging
-from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Event, Thread, current_thread
@@ -49,7 +48,7 @@ from infrahub_sync.service.orchestration import (
     PrefectOrchestration,
 )
 from tests.configuration.validation_packages import package
-from tests.service.execution_fixtures import append_execution
+from tests.service.execution_fixtures import append_execution, bind_granting_guard
 
 if TYPE_CHECKING:
     from prefect.client.schemas.actions import DeploymentUpdate
@@ -214,6 +213,7 @@ def test_worker_rejects_missing_registered_package_before_runtime_construction(
     )
     constructed = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", lambda *_args, **_kwargs: constructed.append(True))
 
@@ -457,6 +457,7 @@ def test_service_flow_redacts_worker_logs_exception_chain_and_failed_state(
     )
     monkeypatch.setenv("NETBOX_TOKEN", environment_canary)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (run_logger, True))
 
     def resolve(
@@ -523,6 +524,7 @@ def test_service_apply_failure_retains_partial_write_evidence(
     projection = _create_product_run(tmp_path.resolve(), run_id)
     partial = ApplyRecord(applied_operations=("op-applied",), failed_operation="op-failed")
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -567,6 +569,7 @@ def test_service_verify_failure_merges_evidence_and_terminalizes_exact_link(
     run_id = "run-service-verify-failure"
     projection = _create_product_run(tmp_path.resolve(), run_id, operation="verify")
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -597,6 +600,7 @@ def test_success_writeback_persistence_failure_is_not_recorded_as_business_failu
     projection = _create_product_run(tmp_path.resolve(), run_id)
     saved = _saved(run_id)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -634,6 +638,7 @@ def test_success_writeback_commit_error_preserves_reread_committed_result(
     projection = _create_product_run(tmp_path.resolve(), run_id)
     saved = _saved(run_id)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -667,10 +672,10 @@ def test_service_confirmed_sync_retains_the_semantic_sync_operation(
     projection = _create_product_run(tmp_path.resolve(), run_id, operation="sync")
     saved = _saved(run_id)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
-    monkeypatch.setattr(service_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(service_flow, "_verify_registered_apply", lambda **_kwargs: None)
     monkeypatch.setattr(service_flow, "_require_planned_schema", lambda **_kwargs: None)
 
@@ -712,6 +717,7 @@ def test_service_plan_worker_updates_the_api_created_run_and_publishes_review(
     saved = _saved(run_id)
     seen: list[str] = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -748,6 +754,7 @@ def test_service_verify_is_read_only_for_product_lifecycle(monkeypatch: pytest.M
     before = projection.lookup_run(run_id).value
     saved = _saved(run_id)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
@@ -786,8 +793,8 @@ def test_confirmed_service_sync_calls_plan_verify_apply_in_order_on_one_run(
     saved = _saved(run_id)
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
-    monkeypatch.setattr(service_flow, "bounded_run_lock", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(service_flow, "resolve_runtime_instance", _instance)
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(service_flow, "_verify_registered_apply", lambda **_kwargs: None)

--- a/tests/service/test_http_api.py
+++ b/tests/service/test_http_api.py
@@ -1547,3 +1547,53 @@ def test_version_is_unauthenticated_and_declares_the_unstable_api(
     }
     operation = client.get("/openapi.json").json()["paths"]["/version"]["get"]
     assert "security" not in operation
+
+
+def test_cancelling_a_claimed_write_answers_with_durable_ambiguity(
+    service_api: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    """A worker already holding the write may have reached the destination.
+
+    Cancellation is accepted by Prefect and still cannot promise a clean stop, so the
+    operator is told the run is terminal and uncertain rather than cancelled, and the
+    public record says reconciliation is required.
+    """
+    client, projection, orchestration = service_api
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
+    applied = client.post(
+        f"/runs/{run_id}/apply",
+        headers={**AUTH, "Idempotency-Key": "cancel-claimed-apply"},
+        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    )
+    apply_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
+    assert projection.claim_execution(run_id, apply_flow_run_id, worker_id=_PLAN_WORKER_ID)
+    orchestration.observations[apply_flow_run_id] = Observation(available=True, state="running")
+
+    cancelled = client.post(
+        f"/runs/{run_id}/cancel",
+        headers={**AUTH, "Idempotency-Key": "cancel-the-claimed-write"},
+        json={"reason": "stop the write"},
+    )
+
+    assert cancelled.status_code == 409
+    assert cancelled.json()["error"]["code"] == "cancellation-ambiguous"
+    assert orchestration.cancelled == [apply_flow_run_id]
+    resource = client.get(f"/runs/{run_id}", headers={"Authorization": f"Bearer {OWNER_TOKEN}"}).json()
+    assert resource["run"]["reconciliation_required"] is True
+    assert resource["run"]["outcome"] == "ambiguous"
+
+
+def test_a_run_that_never_wrote_reports_no_reconciliation_requirement(
+    service_api: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    """The field is authoritative and public, so its false answer has to be visible too."""
+    client, _projection, _orchestration = service_api
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+
+    resource = client.get(f"/runs/{run_id}", headers={"Authorization": f"Bearer {OWNER_TOKEN}"}).json()
+
+    assert resource["run"]["reconciliation_required"] is False

--- a/tests/service/test_http_api.py
+++ b/tests/service/test_http_api.py
@@ -35,6 +35,7 @@ from infrahub_sync.configuration import ConfigurationPackage
 from infrahub_sync.plan.models import PlanManifest
 from infrahub_sync.plan.review import SavedPlan
 from infrahub_sync.product_store import (
+    ExecutionMergeWriteback,
     PrefectExecutionLink,
     ProductProjection,
     ProductRun,
@@ -60,6 +61,7 @@ from infrahub_sync.service.orchestration import (
     Submission,
 )
 from infrahub_sync.service.service import PLAN_ARTIFACT_ID, RunService, ServiceAPIError
+from tests.service.execution_fixtures import append_execution
 
 if TYPE_CHECKING:
     from opsmill_prefect_extras.executors import RemoteExecutionClient
@@ -277,6 +279,32 @@ def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str =
     return plan
 
 
+_PLAN_WORKER_ID = "6b1f0a2c-9d3e-4f57-8a10-2c5b7e4d9f31"
+
+
+def _settle_open_executions(projection: ProductProjection, run_id: str) -> None:
+    """Finish the plan stage the way its worker does, so a write may then be admitted.
+
+    A run only admits its one write while nothing else is still running on it, so a
+    published reviewed plan has to leave its own execution terminal.
+    """
+    run = projection.lookup_run(run_id).value
+    assert run is not None
+    for link in run.prefect_executions:
+        if link.terminal_at is not None:
+            continue
+        projection.claim_execution(run_id, link.flow_run_id, worker_id=_PLAN_WORKER_ID)
+        projection.commit_claimed_execution(
+            run_id,
+            link.flow_run_id,
+            worker_id=_PLAN_WORKER_ID,
+            terminal_at=datetime.now(timezone.utc),
+            terminal_state="completed",
+            terminal_outcome="succeeded",
+            writeback=ExecutionMergeWriteback(results={"plan": {"outcome": "planned"}}),
+        )
+
+
 def test_worker_published_plan_is_retrievable_through_an_independent_api_projection(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -426,6 +454,7 @@ def test_reserved_apply_retry_replays_after_the_plan_artifact_expires(
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
     headers = {**AUTH, "Idempotency-Key": "apply-expired-plan-retry"}
     body = {
         "expected_checksum": plan.checksum,
@@ -852,7 +881,8 @@ def test_cancel_append_during_observation_never_targets_the_stale_execution(
         await asyncio.sleep(0)
         assert flow_run_id == old_flow_run_id
         if not appended:
-            projection.add_prefect_execution(
+            append_execution(
+                projection,
                 run_id,
                 PrefectExecutionLink(
                     flow_run_id=new_flow_run_id,
@@ -1020,7 +1050,8 @@ def test_cancellation_remote_success_then_crash_resumes_same_intent(
 
     uncertain = client.post(f"/runs/{run_id}/cancel", headers=headers, json=body)
     with pytest.raises(WriteAdmissionConflictError):
-        projection.add_prefect_execution(
+        append_execution(
+            projection,
             run_id,
             PrefectExecutionLink(
                 flow_run_id="flow-racing-cancellation-retry",
@@ -1056,30 +1087,31 @@ def test_cancel_scans_past_newer_non_active_links(
     client, projection, orchestration = service_api
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
-    plan = _publish_plan(projection, run_id)
-    applied = client.post(
-        f"/runs/{run_id}/apply",
-        headers={**AUTH, "Idempotency-Key": "cancel-active-apply"},
-        json={"expected_checksum": plan.checksum, "reason": "approved", "confirm_writes": True},
+    _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
+    active = client.post(
+        f"/runs/{run_id}/verify",
+        headers={**AUTH, "Idempotency-Key": "cancel-active-verify"},
+        json={"reason": "the running check"},
     )
-    verified = client.post(
+    newer = client.post(
         f"/runs/{run_id}/verify",
         headers={**AUTH, "Idempotency-Key": "newer-finished-verify"},
         json={"reason": "later read-only check"},
     )
-    apply_flow_run_id = applied.json()["orchestration"][-1]["flow_run_id"]
-    verify_flow_run_id = verified.json()["orchestration"][-1]["flow_run_id"]
-    orchestration.observations[apply_flow_run_id] = Observation(available=True, state="running")
-    orchestration.observations[verify_flow_run_id] = newest_observation
+    active_flow_run_id = active.json()["orchestration"][-1]["flow_run_id"]
+    newer_flow_run_id = newer.json()["orchestration"][-1]["flow_run_id"]
+    orchestration.observations[active_flow_run_id] = Observation(available=True, state="running")
+    orchestration.observations[newer_flow_run_id] = newest_observation
 
     cancelled = client.post(
         f"/runs/{run_id}/cancel",
         headers={**AUTH, "Idempotency-Key": f"scan-cancel-{newest_observation.reason or newest_observation.state}"},
-        json={"reason": "stop the active write"},
+        json={"reason": "stop the active stage"},
     )
 
     assert cancelled.status_code == 202
-    assert orchestration.cancelled == [apply_flow_run_id]
+    assert orchestration.cancelled == [active_flow_run_id]
 
 
 def test_cancel_treats_expired_and_terminal_links_as_non_cancellable(
@@ -1089,6 +1121,7 @@ def test_cancel_treats_expired_and_terminal_links_as_non_cancellable(
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
     applied = client.post(
         f"/runs/{run_id}/apply",
         headers={**AUTH, "Idempotency-Key": "apply-before-expiry"},
@@ -1117,12 +1150,14 @@ def test_owner_admin_authorization_apply_verify_and_cancel(  # noqa: PLR0914 - o
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
     other_headers = {"Authorization": f"Bearer {OTHER_TOKEN}", "Idempotency-Key": "other-key"}
     admin_headers = {"Authorization": f"Bearer {ADMIN_TOKEN}", "Idempotency-Key": "admin-key"}
 
     refused = client.post(f"/runs/{run_id}/verify", headers=other_headers, json={"reason": "not my run"})
     verified = client.post(f"/runs/{run_id}/verify", headers=admin_headers, json={"reason": "admin review"})
     verified_replay = client.post(f"/runs/{run_id}/verify", headers=admin_headers, json={"reason": "admin review"})
+    _settle_open_executions(projection, run_id)
     unconfirmed = client.post(
         f"/runs/{run_id}/apply",
         headers={**AUTH, "Idempotency-Key": "apply-unconfirmed"},
@@ -1198,6 +1233,7 @@ def test_concurrent_and_post_completion_distinct_apply_keys_are_refused(
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
     ready = Barrier(2)
 
     def apply(position: int):
@@ -1218,7 +1254,7 @@ def test_concurrent_and_post_completion_distinct_apply_keys_are_refused(
     accepted = next(response for response in responses if response.status_code == 202)
     refused = next(response for response in responses if response.status_code == 409)
     accepted_position = next(position for position, response in enumerate(responses) if response.status_code == 202)
-    assert refused.json()["error"]["code"] == "apply-already-admitted"
+    assert refused.json()["error"]["code"] == "run-execution-conflict"
     assert len(orchestration.submissions) == 2
 
     projection.finish_run(
@@ -1246,9 +1282,9 @@ def test_concurrent_and_post_completion_distinct_apply_keys_are_refused(
     assert replay.status_code == 202
     assert replay.json() == accepted.json()
     assert post_completion.status_code == 409
-    assert post_completion.json()["error"]["code"] == "apply-already-admitted"
+    assert post_completion.json()["error"]["code"] == "run-execution-conflict"
     assert len(orchestration.submissions) == 2
-    refusals = [event for event in projection.audit_events(run_id) if event.outcome == "refused-apply-admission"]
+    refusals = [event for event in projection.audit_events(run_id) if event.outcome == "refused-run-execution-conflict"]
     assert len(refusals) == 2
 
 
@@ -1270,6 +1306,7 @@ def test_confirmed_sync_reserves_its_write_admission_and_replays(
     replay = client.post("/runs", headers=headers, json=body)
     run_id = accepted.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    _settle_open_executions(projection, run_id)
     later_apply = client.post(
         f"/runs/{run_id}/apply",
         headers={**AUTH, "Idempotency-Key": "apply-after-sync"},
@@ -1279,7 +1316,7 @@ def test_confirmed_sync_reserves_its_write_admission_and_replays(
     assert accepted.status_code == 202
     assert replay.json() == accepted.json()
     assert later_apply.status_code == 409
-    assert later_apply.json()["error"]["code"] == "apply-already-admitted"
+    assert later_apply.json()["error"]["code"] == "run-execution-conflict"
     assert [parameters["stage"] for parameters, _ in orchestration.submissions] == ["sync"]
 
 
@@ -1303,6 +1340,10 @@ def test_owner_and_administrator_mutation_matrix(
     created = _create(client)
     run_id = created.json()["run"]["run_id"]
     plan = _publish_plan(projection, run_id)
+    if operation == "apply":
+        # A write is admitted only while nothing else is running; cancellation needs the
+        # opposite, so only this parameter settles the plan stage first.
+        _settle_open_executions(projection, run_id)
     headers = {"Authorization": f"Bearer {token}", "Idempotency-Key": f"{actor}-{operation}"}
     bodies = {
         "verify": {"reason": f"{actor} verification"},

--- a/tests/service/test_http_api.py
+++ b/tests/service/test_http_api.py
@@ -10,7 +10,7 @@ from hashlib import sha256
 from pathlib import Path
 from threading import Barrier
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, get_args
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 import pytest
@@ -30,6 +30,7 @@ from prefect.client.schemas.responses import (
     StateWaitDetails,
 )
 from prefect.states import Cancelled, Cancelling, Running
+from pydantic import BaseModel
 
 from infrahub_sync.configuration import ConfigurationPackage
 from infrahub_sync.plan.models import PlanManifest
@@ -244,8 +245,9 @@ def test_admission_reads_registered_binding_before_allocating_run(
     assert len(orchestration.submissions) == 1
 
 
-def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str = "a" * 64) -> PlanResource:
-    plan = PlanResource(
+def _plan_document(run_id: str, *, checksum: str = "a" * 64) -> PlanResource:
+    """The review document a worker publishes, before it reaches the artifact store."""
+    return PlanResource(
         run_id=run_id,
         checksum=checksum,
         checksum_ok=True,
@@ -269,6 +271,11 @@ def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str =
             ),
         ),
     )
+
+
+def _publish_plan(projection: ProductProjection, run_id: str, *, checksum: str = "a" * 64) -> PlanResource:
+    """Publish the review document, as the plan stage's worker does."""
+    plan = _plan_document(run_id, checksum=checksum)
     projection.publish_artifact(
         run_id,
         artifact_id=PLAN_ARTIFACT_ID,
@@ -1604,11 +1611,9 @@ def test_the_server_cannot_emit_a_field_its_public_resource_does_not_declare() -
 
     The projection copies a store record's fields wholesale, so a field added to the
     durable record for internal reasons would otherwise appear on the wire with nobody
-    deciding to publish it. The strict emitted variant is what turns that into a refusal at
-    the boundary, where the change is being made.
+    deciding to publish it. The emitted variant drops it instead — the run stays readable,
+    and what an operator sees is exactly what the resource declares.
     """
-    from pydantic import ValidationError
-
     from infrahub_sync.service.models import public_run_resource
 
     class _FutureProductRun(ProductRun):
@@ -1617,22 +1622,92 @@ def test_the_server_cannot_emit_a_field_its_public_resource_does_not_declare() -
         internal_canary: str = "internal-only"
 
     record = _FutureProductRun(
-        run_id="run-strict-boundary",
+        run_id="run-bounded-boundary",
         operation="plan",
         configuration_reference="config-001@1",
         started_at=datetime.now(timezone.utc),
         phase="accepted",
     )
 
-    with pytest.raises(ValidationError, match="internal_canary"):
-        public_run_resource(record)
+    emitted = public_run_resource(record)
+
+    assert emitted.run_id == "run-bounded-boundary"
+    assert "internal_canary" not in emitted.model_dump_json()
+
+
+def test_the_server_cannot_emit_a_field_nested_inside_a_retained_plan(
+    service_api: tuple[TestClient, ProductProjection, _FakeOrchestration],
+) -> None:
+    """Bounding a resource one level deep is not bounding it.
+
+    A retained plan is bytes some other version of this worker wrote, so its nested summary
+    and operations are exactly where an unknown key arrives. The read still answers — an
+    unknown key is not a reason to fail a plan an operator is trying to review — and the
+    key is not in what the API returns.
+    """
+    client, projection, _orchestration = service_api
+    created = _create(client)
+    run_id = created.json()["run"]["run_id"]
+    # A retained artifact is immutable, so the unknown keys go into the one publication —
+    # which is the realistic case anyway: the bytes were written by another version.
+    document = json.loads(_plan_document(run_id).model_dump_json())
+    document["summary"]["internal_canary"] = "nested-summary-leak"
+    document["operations"][0]["internal_canary"] = "nested-operation-leak"
+    projection.publish_artifact(
+        run_id,
+        artifact_id=PLAN_ARTIFACT_ID,
+        kind="saved-plan-review",
+        media_type="application/json",
+        data=json.dumps(document).encode(),
+    )
+
+    response = client.get(f"/runs/{run_id}/plan", headers={"Authorization": f"Bearer {OWNER_TOKEN}"})
+
+    assert response.status_code == 200, response.text
+    assert "nested-summary-leak" not in response.text
+    assert "nested-operation-leak" not in response.text
+    assert response.json()["summary"]["total"] == document["summary"]["total"]
+
+
+def test_every_model_reachable_from_an_emitted_resource_is_bounded() -> None:
+    """The property, not the two nested models somebody happened to probe.
+
+    Adding a nested model that accepts undeclared fields reopens the same hole one level
+    further down, and nothing about the resources above it would look wrong. Walking the
+    whole field graph is what makes that a failure here rather than a finding later.
+    """
+    from infrahub_sync.service.models import EMITTED_RESOURCES
+
+    unbounded: list[str] = []
+    seen: set[type[BaseModel]] = set()
+    pending: list[tuple[str, type[BaseModel]]] = [(model.__name__, model) for model in EMITTED_RESOURCES]
+    while pending:
+        path, model = pending.pop()
+        if model in seen:
+            continue
+        seen.add(model)
+        if model.model_config.get("extra") not in {"ignore", "forbid"}:
+            unbounded.append(f"{path} ({model.__name__}: extra={model.model_config.get('extra')!r})")
+        for name, field in model.model_fields.items():
+            pending.extend((f"{path}.{name}", nested) for nested in _reachable_models(field.annotation))
+
+    assert unbounded == [], f"these models can emit fields they do not declare: {unbounded}"
+    assert len(seen) > len(EMITTED_RESOURCES), "the walk never reached a nested model, so it proves nothing"
+
+
+def _reachable_models(annotation: object) -> list[type[BaseModel]]:
+    """Return every pydantic model one field annotation can carry."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return [annotation]
+    return [nested for argument in get_args(annotation) for nested in _reachable_models(argument)]
 
 
 def test_the_client_still_reads_a_run_resource_from_a_newer_server() -> None:
-    """Strictness belongs to the emitter; a client has to survive a server that grew.
+    """Boundedness belongs to the emitter; a client has to survive a server that grew.
 
-    The same model parses a payload carrying a field this client does not know, because
-    refusing it would break every reader the day a field is added.
+    The client's own model keeps the unknown field rather than refusing the payload,
+    because a reader that broke the day a field was added would be useless. Only what the
+    server *builds* is bounded.
     """
     payload = {
         "run_id": "run-forward-compatible",

--- a/tests/service/test_http_api.py
+++ b/tests/service/test_http_api.py
@@ -1597,3 +1597,53 @@ def test_a_run_that_never_wrote_reports_no_reconciliation_requirement(
     resource = client.get(f"/runs/{run_id}", headers={"Authorization": f"Bearer {OWNER_TOKEN}"}).json()
 
     assert resource["run"]["reconciliation_required"] is False
+
+
+def test_the_server_cannot_emit_a_field_its_public_resource_does_not_declare() -> None:
+    """An internal record field may not become an operator-facing one by accident.
+
+    The projection copies a store record's fields wholesale, so a field added to the
+    durable record for internal reasons would otherwise appear on the wire with nobody
+    deciding to publish it. The strict emitted variant is what turns that into a refusal at
+    the boundary, where the change is being made.
+    """
+    from pydantic import ValidationError
+
+    from infrahub_sync.service.models import public_run_resource
+
+    class _FutureProductRun(ProductRun):
+        """A store record that gained an internal field a later change did not publish."""
+
+        internal_canary: str = "internal-only"
+
+    record = _FutureProductRun(
+        run_id="run-strict-boundary",
+        operation="plan",
+        configuration_reference="config-001@1",
+        started_at=datetime.now(timezone.utc),
+        phase="accepted",
+    )
+
+    with pytest.raises(ValidationError, match="internal_canary"):
+        public_run_resource(record)
+
+
+def test_the_client_still_reads_a_run_resource_from_a_newer_server() -> None:
+    """Strictness belongs to the emitter; a client has to survive a server that grew.
+
+    The same model parses a payload carrying a field this client does not know, because
+    refusing it would break every reader the day a field is added.
+    """
+    payload = {
+        "run_id": "run-forward-compatible",
+        "operation": "plan",
+        "configuration_reference": "config-001@1",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "phase": "accepted",
+        "field_from_a_newer_server": "readable",
+    }
+
+    parsed = PublicRunResource.model_validate(payload)
+
+    assert parsed.run_id == "run-forward-compatible"
+    assert parsed.model_extra == {"field_from_a_newer_server": "readable"}

--- a/tests/service/test_http_api.py
+++ b/tests/service/test_http_api.py
@@ -1106,6 +1106,10 @@ def test_cancel_scans_past_newer_non_active_links(
         headers={**AUTH, "Idempotency-Key": "newer-finished-verify"},
         json={"reason": "later read-only check"},
     )
+    # Read the admissions before indexing their bodies: an admission regression refuses one
+    # of these, and a refusal has no `orchestration` to index. Assert it as the wrong status
+    # rather than let it surface as a KeyError that names the wrong defect.
+    assert (active.status_code, newer.status_code) == (202, 202), (active.json(), newer.json())
     active_flow_run_id = active.json()["orchestration"][-1]["flow_run_id"]
     newer_flow_run_id = newer.json()["orchestration"][-1]["flow_run_id"]
     orchestration.observations[active_flow_run_id] = Observation(available=True, state="running")

--- a/tests/service/test_legacy_run_binding.py
+++ b/tests/service/test_legacy_run_binding.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,16 +14,12 @@ import pytest
 pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
 
-from infrahub_sync.execution import RunResult
-from infrahub_sync.plan.canonical import canonical_json_bytes
-from infrahub_sync.plan.checksum import compute_plan_checksum
 from infrahub_sync.plan.models import PlanManifest
 from infrahub_sync.plan.review import SavedPlan
-from infrahub_sync.plan.writer import MANIFEST_FILE_NAME, OPERATIONS_FILE_NAME, PLAN_DIR_NAME, write_plan_artifact
 from infrahub_sync.product_store import PrefectExecutionLink, ProductRun, local_product_projection
 from infrahub_sync.service import flow as service_flow
 from infrahub_sync.service.flow import service_sync_run
-from tests.service.execution_fixtures import append_execution
+from tests.service.execution_fixtures import append_execution, bind_granting_guard
 
 FLOW_RUN_ID = "ed4778cb-f2cf-4b1f-a87b-68be37659e93"
 WORKER_ID = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
@@ -81,17 +76,15 @@ def _legacy_saved(run_id: str) -> SavedPlan:
     )
 
 
-@pytest.mark.parametrize("stage", ["plan", "verify", "apply"])
+@pytest.mark.parametrize("stage", ["plan", "verify"])
 def test_all_absent_legacy_run_reaches_existing_local_worker_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stage: Literal["plan", "verify", "apply"]
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stage: Literal["plan", "verify"]
 ) -> None:
-    """No durable legacy run is rejected merely because it predates tuple binding."""
+    """No durable legacy read stage is rejected merely because it predates tuple binding."""
     run_id = f"legacy-{stage}"
     projection = _legacy_run(tmp_path / "product", run_id, stage)
     saved = _legacy_saved(run_id)
     resolved: list[tuple[str, str]] = []
-    verified: list[tuple[str, object]] = []
-    parsed: list[object] = []
     instance = SimpleNamespace(name="legacy-inventory")
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
@@ -105,105 +98,44 @@ def test_all_absent_legacy_run_reaches_existing_local_worker_path(
     monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
     monkeypatch.setattr(service_flow, "_plan", lambda *_args, **_kwargs: saved)
     monkeypatch.setattr(service_flow, "_publish_plan", lambda *_args, **_kwargs: None)
-    if stage == "apply":
-        artifact = object()
-        monkeypatch.setattr(service_flow, "resolve_run_directory", lambda *_args: tmp_path)
-        monkeypatch.setattr(service_flow, "read_plan_artifact_bytes", lambda _path: artifact)
+    monkeypatch.setattr(service_flow, "execute_run", lambda *_args, **_kwargs: saved)
 
-        def verify(**kwargs: object) -> list[object]:
-            verified.append((str(kwargs["run_id"]), kwargs["config_version"]))
-            return []
-
-        monkeypatch.setattr(service_flow, "verify_plan", verify)
-        monkeypatch.setattr(
-            service_flow,
-            "parse_plan_artifact",
-            lambda *_args, **_kwargs: (parsed.append(True), SimpleNamespace(manifest=saved.manifest))[1],
-        )
-
-    def execute(*_args: object, operation: str, **_kwargs: object) -> SavedPlan | RunResult:
-        if operation == "verify":
-            return saved
-        return RunResult(
-            sync_name="legacy-inventory",
-            operation="apply",
-            run_id=run_id,
-            status="no-change",
-            changed=False,
-            summary={"create": 0, "update": 0, "delete": 0},
-            artifact_path=str(tmp_path / run_id),
-        )
-
-    monkeypatch.setattr(service_flow, "execute_run", execute)
-    if stage == "apply":
-        service_sync_run.fn(run_id, stage, expected_checksum="a" * 64, confirm_writes=True)
-    else:
-        service_sync_run.fn(run_id, stage)
+    service_sync_run.fn(run_id, stage)
 
     assert resolved == [("legacy-inventory", str(tmp_path))]
-    assert verified == ([(run_id, "legacy-config-version")] if stage == "apply" else [])
-    assert parsed == ([True] if stage == "apply" else [])
 
 
-@pytest.mark.parametrize(
-    ("manifest_binding", "expected_error"),
-    [
-        pytest.param(("registered-config", 1, "a" * 64), "registered saved plan binding", id="registered"),
-        pytest.param({"config_id": "registered-config"}, "configuration binding must be all absent", id="partial"),
-    ],
-)
-def test_legacy_apply_refuses_checksum_valid_nonlegacy_manifest_before_destination(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    manifest_binding: tuple[str, int, str] | dict[str, str],
-    expected_error: str,
+@pytest.mark.parametrize("stage", ["apply", "sync"])
+def test_a_legacy_run_cannot_run_a_managed_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, stage: Literal["apply", "sync"]
 ) -> None:
-    """A legacy run accepts only a fully legacy manifest before destination construction."""
-    run_id = "legacy-nonlegacy-manifest"
+    """The write guard serializes writers per registered configuration.
+
+    A legacy run names no configuration, so there is no key to serialize it against and
+    nothing it could be made to wait behind. It is refused before its configuration is
+    resolved, before its retained artifact is read, and before any guard session is
+    opened — so a pre-binding run can still be read, but can never be written from.
+    """
+    run_id = f"legacy-{stage}"
     projection = _legacy_run(tmp_path / "product", run_id, "apply")
-    instance = SimpleNamespace(name="legacy-inventory")
-    run_dir = tmp_path / "runs" / instance.name / run_id
-    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path / "runs"))
+    resolved: list[str] = []
+    guard_sessions: list[object] = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
-    monkeypatch.setattr(service_flow, "resolve_sync_instance", lambda *_args, **_kwargs: instance, raising=False)
-    monkeypatch.setattr(service_flow, "resolve_config_version", lambda _instance: "legacy-config-version")
-    monkeypatch.setattr(service_flow, "collect_secret_values", lambda _instance=None: ())
-    if isinstance(manifest_binding, tuple):
-        write_plan_artifact(
-            run_dir=run_dir,
-            run_id=run_id,
-            config_version="legacy-config-version",
-            source_snapshot=[],
-            deletes_computed=True,
-            operations=[],
-            configuration_binding=manifest_binding,
-            schema_fingerprint="c" * 64,
-        )
-    else:
-        write_plan_artifact(
-            run_dir=run_dir,
-            run_id=run_id,
-            config_version="legacy-config-version",
-            source_snapshot=[],
-            deletes_computed=True,
-            operations=[],
-        )
-        plan_dir = run_dir / PLAN_DIR_NAME
-        manifest_path = plan_dir / MANIFEST_FILE_NAME
-        manifest = json.loads(manifest_path.read_bytes())
-        manifest.update(manifest_binding)
-        manifest["plan_checksum"] = compute_plan_checksum(manifest, (plan_dir / OPERATIONS_FILE_NAME).read_bytes())
-        manifest_path.write_bytes(canonical_json_bytes(manifest))
+    monkeypatch.setattr(
+        service_flow,
+        "resolve_sync_instance",
+        lambda name, **_kwargs: resolved.append(name),
+        raising=False,
+    )
+    monkeypatch.setattr(service_flow, "service_guard_session", lambda: guard_sessions.append(object()))
+    monkeypatch.setattr(service_flow, "read_plan_artifact_bytes", lambda _path: pytest.fail("artifact was read"))
 
-    def destination_construction_sentinel(*_args: object, **_kwargs: object) -> RunResult:
-        msg = "destination construction sentinel reached"
-        raise RuntimeError(msg)
+    with pytest.raises(RuntimeError, match="registered configuration binding"):
+        service_sync_run.fn(run_id, stage, expected_checksum="a" * 64, confirm_writes=True)
 
-    monkeypatch.setattr(service_flow, "execute_run", destination_construction_sentinel)
-
-    with pytest.raises(RuntimeError, match=expected_error):
-        service_sync_run.fn(run_id, "apply", expected_checksum="a" * 64, confirm_writes=True)
+    assert resolved == []
+    assert guard_sessions == []
 
 
 def test_prefect_binding_carrier_is_optional_only_as_one_closed_group() -> None:
@@ -279,6 +211,7 @@ def test_cross_product_and_partial_worker_carriers_refuse_before_runtime(
     )
     constructed: list[object] = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (logging.getLogger("test-service"), False))
     monkeypatch.setattr(
         service_flow, "resolve_sync_instance", lambda *_args, **_kwargs: constructed.append(True), raising=False

--- a/tests/service/test_legacy_run_binding.py
+++ b/tests/service/test_legacy_run_binding.py
@@ -24,6 +24,7 @@ from infrahub_sync.plan.writer import MANIFEST_FILE_NAME, OPERATIONS_FILE_NAME, 
 from infrahub_sync.product_store import PrefectExecutionLink, ProductRun, local_product_projection
 from infrahub_sync.service import flow as service_flow
 from infrahub_sync.service.flow import service_sync_run
+from tests.service.execution_fixtures import append_execution
 
 FLOW_RUN_ID = "ed4778cb-f2cf-4b1f-a87b-68be37659e93"
 WORKER_ID = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
@@ -43,7 +44,8 @@ def _legacy_run(cache: Path, run_id: str, operation: Literal["plan", "verify", "
             summary={"sync_name": "legacy-inventory"},
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         run_id,
         PrefectExecutionLink(
             flow_run_id=FLOW_RUN_ID, purpose=operation, attempt=1, submitted_at=datetime.now(timezone.utc)
@@ -268,7 +270,8 @@ def test_cross_product_and_partial_worker_carriers_refuse_before_runtime(
             summary={"sync_name": "legacy-inventory"},
         )
     projection.create_run(run)
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         run.run_id,
         PrefectExecutionLink(
             flow_run_id=FLOW_RUN_ID, purpose="plan", attempt=1, submitted_at=datetime.now(timezone.utc)

--- a/tests/service/test_liveness_policy.py
+++ b/tests/service/test_liveness_policy.py
@@ -973,3 +973,47 @@ def test_request_time_reconciliation_terminalizes_each_pending_link(tmp_path) ->
 
     assert response.status_code == 200
     assert response.json()["run"]["phase"] == "abandoned"
+
+
+@pytest.mark.parametrize(("purpose", "expected"), [("apply", True), ("sync", True), ("plan", False)])
+def test_a_lost_write_worker_leaves_durable_reconciliation_evidence(tmp_path, purpose: str, expected: bool) -> None:  # noqa: FBT001 - one parametrized dimension of the verdict.
+    """Losing a worker that held the write is the same uncertainty as losing the write.
+
+    Reconciliation cannot tell whether a disappeared apply or sync reached the
+    destination, so it records that the operator must look. A lost plan worker wrote
+    nothing by construction, so the same interrupted verdict carries no such evidence —
+    which is what makes the record worth reading.
+    """
+    now = datetime(2026, 9, 3, 12, tzinfo=timezone.utc)
+    owner = str(uuid4())
+    run_id = f"run-lost-{purpose}-worker"
+    projection = local_product_projection(tmp_path)
+    projection.create_run(
+        _run(
+            run_id,
+            PrefectExecutionLink(
+                flow_run_id=f"flow-lost-{purpose}",
+                purpose=purpose,
+                attempt=1,
+                submitted_at=now - timedelta(minutes=10),
+                claimed_at=now - timedelta(seconds=30),
+                claiming_worker_id=owner,
+            ),
+        )
+    )
+    pool = PoolStatus(
+        detail_available=True,
+        queue_depth=0,
+        observed_at=now,
+        workers=(PoolWorker(owner, "offline", now, 10.0),),
+    )
+    reconciler = RunLivenessReconciler(
+        projection, _Orchestration(pool), LivenessPolicy(300, 30, 5), "pool", clock=lambda: now
+    )
+
+    asyncio.run(reconciler.reconcile_once())
+
+    run = projection.lookup_run(run_id).value
+    assert run is not None
+    assert run.prefect_executions[0].terminal_state == "interrupted"
+    assert run.reconciliation_required is expected

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -40,7 +40,6 @@ from infrahub_sync.product_store import (  # noqa: E402
 )
 from infrahub_sync.runtime_schema import RuntimeModelPlan, RuntimeSideModels  # noqa: E402
 from infrahub_sync.service import flow as service_flow  # noqa: E402
-from infrahub_sync.service.apply_guard import ApplyGuardContentionError  # noqa: E402
 from infrahub_sync.service.flow import service_sync_run  # noqa: E402
 from tests.configuration.validation_packages import package  # noqa: E402
 
@@ -280,7 +279,7 @@ def test_guard_contention_touches_no_destination_and_creates_no_success_evidence
     """Another writer's hold is a clean refusal: nothing read, nothing written, no ambiguity."""
     prepared = _prepare(tmp_path, monkeypatch, acquire_failure=_lock_timeout())
 
-    with pytest.raises(ApplyGuardContentionError):
+    with pytest.raises(RuntimeError, match="ApplyGuardContentionError"):
         _apply(prepared)
 
     assert "live-schema-read" not in prepared.events
@@ -301,7 +300,7 @@ def test_a_failure_before_the_first_dispatch_stays_an_ordinary_failed_run(
 
     prepared = _prepare(tmp_path, monkeypatch, engine=refuse)
 
-    with pytest.raises(ValueError, match="before any operation"):
+    with pytest.raises(RuntimeError, match="before any operation"):
         _apply(prepared)
 
     run = _stored(prepared)
@@ -323,7 +322,7 @@ def test_a_failure_after_the_first_dispatch_becomes_durable_ambiguity(
 
     prepared = _prepare(tmp_path, monkeypatch, engine=dispatch_then_fail)
 
-    with pytest.raises(ValueError, match="after the first operation"):
+    with pytest.raises(RuntimeError, match="after the first operation"):
         _apply(prepared)
 
     run = _stored(prepared)
@@ -409,7 +408,7 @@ def test_a_managed_write_without_a_registered_binding_is_refused(
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
     monkeypatch.setattr(service_flow, "service_guard_session", lambda: guard_sessions.append(object()))
 
-    with pytest.raises(ValueError, match="registered configuration"):
+    with pytest.raises(RuntimeError, match="registered configuration binding"):
         service_sync_run.fn(run_id, "apply", expected_checksum="a" * 64, confirm_writes=True)
 
     assert guard_sessions == []

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -540,14 +540,14 @@ def test_a_stale_approved_checksum_is_refused_before_any_guard_session(
 def _dispatch_and_complete(kwargs: dict[str, Any]) -> None:
     """Stand in for the engine: dispatch once, then report what it completed.
 
-    `_run_apply_lifecycle` reports the completed record to the write scope before its own
+    `_run_apply_lifecycle` reports the completed record through its own sink before its own
     sidecar write, which is the only reason a failure raised *after* the engine returned can
     still say what was written. The double does the same thing at the same point.
     """
     ownership = kwargs["ownership"]
     ownership.before_operation()
     ownership.after_final_operation()
-    ownership.record_applied(ApplyRecord(applied_operations=("op-live-1",), skipped_delete_operations=("op-live-2",)))
+    kwargs["record_applied"](ApplyRecord(applied_operations=("op-live-1",), skipped_delete_operations=("op-live-2",)))
 
 
 @pytest.mark.parametrize("stage", ["apply", "sync"])

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -26,6 +26,7 @@ psycopg: Any = pytest.importorskip("psycopg")
 
 from pathlib import Path  # noqa: E402
 
+from infrahub_sync import execution  # noqa: E402
 from infrahub_sync.configuration import ConfigurationPackage  # noqa: E402
 from infrahub_sync.configuration.runtime import resolve_runtime_instance  # noqa: E402
 from infrahub_sync.execution import RunResult, RunValidationError, execute_run  # noqa: E402
@@ -415,11 +416,16 @@ def test_a_managed_write_without_a_registered_binding_is_refused(
 
 
 def test_the_managed_write_path_takes_no_local_pipeline_lock() -> None:
-    """One correctness guard, not two: the file lock is gone from the supported path."""
-    assert service_flow.__file__ is not None
-    source = Path(service_flow.__file__).read_text(encoding="utf-8")
+    """One correctness guard, not two: the file lock is gone from the supported path.
 
-    assert "bounded_run_lock" not in source
+    Asserted on the shared execution surface as well, because the composition the managed
+    path used to reach the pipeline lock through no longer exists at all.
+    """
+    assert service_flow.__file__ is not None
+    flow_source = Path(service_flow.__file__).read_text(encoding="utf-8")
+
+    assert "bounded_run_lock" not in flow_source
+    assert not hasattr(execution, "bounded_run_lock")
 
 
 def test_the_direct_sync_writer_is_refused_instead_of_running_unguarded() -> None:

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -24,6 +24,8 @@ pytest.importorskip("prefect")
 pytest.importorskip("opsmill_prefect_extras")
 psycopg: Any = pytest.importorskip("psycopg")
 
+from pathlib import Path  # noqa: E402
+
 from infrahub_sync.configuration import ConfigurationPackage  # noqa: E402
 from infrahub_sync.configuration.runtime import resolve_runtime_instance  # noqa: E402
 from infrahub_sync.execution import RunResult, RunValidationError, execute_run  # noqa: E402
@@ -44,7 +46,6 @@ from tests.configuration.validation_packages import package  # noqa: E402
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
 FLOW_RUN_ID = "b0c0a2d4-6f31-4a58-9b0e-2d4e6f318a55"
 WORKER_ID = "4d9a1c77-2f8e-4d3b-9c11-6a0e7b2f9d40"
@@ -416,21 +417,22 @@ def test_a_managed_write_without_a_registered_binding_is_refused(
 
 def test_the_managed_write_path_takes_no_local_pipeline_lock() -> None:
     """One correctness guard, not two: the file lock is gone from the supported path."""
-    source = service_flow.__loader__.get_source(service_flow.__name__)  # ty: ignore[possibly-unbound-attribute]
-    assert source is not None
+    assert service_flow.__file__ is not None
+    source = Path(service_flow.__file__).read_text(encoding="utf-8")
+
     assert "bounded_run_lock" not in source
 
 
 def test_the_direct_sync_writer_is_refused_instead_of_running_unguarded() -> None:
     """The unsupported direct write path cannot prove any per-operation ownership."""
     with pytest.raises(RunValidationError, match="sync"):
-        execute_run(object(), operation="sync", confirm_writes=True)  # ty: ignore[invalid-argument-type]
+        execute_run(object(), operation="sync", confirm_writes=True)  # ty: ignore[no-matching-overload]
 
 
 def test_a_managed_apply_without_an_ownership_boundary_is_refused() -> None:
     """`execute_run` refuses a write it cannot prove, before it builds anything."""
     with pytest.raises(RunValidationError, match="ownership"):
-        execute_run(  # ty: ignore[invalid-argument-type]
+        execute_run(  # ty: ignore[no-matching-overload]
             object(),
             operation="apply",
             run_id="managed-apply",

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -461,13 +461,13 @@ def test_the_direct_sync_writer_is_refused_instead_of_running_unguarded() -> Non
         execute_run(object(), operation="sync", confirm_writes=True)  # ty: ignore[no-matching-overload]
 
 
-def test_the_apply_overload_requires_a_write_ownership_boundary() -> None:
+def test_the_apply_overload_requires_its_boundary_and_its_completion_sink() -> None:
     """The declaration the type checker reads is what refuses an unguarded apply first.
 
-    Plan and verify write nothing, so making the keyword unconditionally required would be
-    worse than the defect it fixes. Declaring it required on the apply overload alone — and
-    leaving `apply` out of every other overload — is what makes the gate's own type check
-    reject an omitted boundary, before any of this runs.
+    Plan and verify write nothing, so making either keyword unconditionally required would
+    be worse than the defect it fixes. Declaring both required on the apply overload alone
+    — and leaving `apply` out of every other overload — is what makes the gate's own type
+    check reject an apply that proves nothing or reports nowhere, before any of this runs.
     """
     module = ast.parse(Path(execution.__file__).read_text(encoding="utf-8"))
     overloads = [
@@ -486,13 +486,12 @@ def test_the_apply_overload_requires_a_write_ownership_boundary() -> None:
     )
     keywords = accepting_apply[0].args.kwonlyargs
     defaults = accepting_apply[0].args.kw_defaults
-    ownership = next(
-        (argument for argument, default in zip(keywords, defaults, strict=True) if argument.arg == "ownership"),
-        None,
-    )
-    assert ownership is not None, "the apply overload does not declare an ownership boundary"
-    required = [argument.arg for argument, default in zip(keywords, defaults, strict=True) if default is None]
-    assert "ownership" in required, "the apply overload's ownership boundary has a default"
+    declared = {argument.arg for argument in keywords}
+    required = {argument.arg for argument, default in zip(keywords, defaults, strict=True) if default is None}
+
+    for name, what in (("ownership", "write-ownership boundary"), ("record_applied", "completion sink")):
+        assert name in declared, f"the apply overload does not declare a {what}"
+        assert name in required, f"the apply overload's {what} has a default, so it can be omitted"
 
 
 def _operation_literals(node: ast.FunctionDef) -> set[str]:

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -443,3 +443,20 @@ def test_a_managed_apply_without_an_ownership_boundary_is_refused() -> None:
             run_id="managed-apply",
             confirm_writes=True,
         )
+
+
+def test_a_stale_approved_checksum_is_refused_before_any_guard_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A request that was never going to succeed must not make another writer wait."""
+    prepared = _prepare(tmp_path, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="checksum"):
+        service_sync_run.fn(
+            prepared.run_id, "apply", *prepared.binding, expected_checksum="b" * 64, confirm_writes=True
+        )
+
+    assert prepared.session is None
+    assert prepared.events == []
+    run = _stored(prepared)
+    assert run.reconciliation_required is False

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -1,0 +1,438 @@
+"""The managed write path holds the configuration guard, and says what it may have done.
+
+Two properties are under test together, because neither is safe alone. First, ordering:
+the guard is held before the live schema read a managed write validates against, so a plan
+cannot be checked against a snapshot taken while another writer still owned the
+configuration. Second, classification: once the engine has proven ownership and started a
+destination operation, no caught failure may be reported as a clean failure — it becomes
+ambiguous, and the product run records that reconciliation is required.
+
+The guard runs for real against one scripted direct-session fake, the same shape the guard's
+own unit suite drives. Its provider facts are proven against a real server in
+`tests/integration/test_managed_write_guard_integration.py`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("prefect")
+pytest.importorskip("opsmill_prefect_extras")
+psycopg: Any = pytest.importorskip("psycopg")
+
+from infrahub_sync.configuration import ConfigurationPackage  # noqa: E402
+from infrahub_sync.configuration.runtime import resolve_runtime_instance  # noqa: E402
+from infrahub_sync.execution import RunResult, RunValidationError, execute_run  # noqa: E402
+from infrahub_sync.plan.config_version import resolve_config_version  # noqa: E402
+from infrahub_sync.plan.review import read_saved_plan  # noqa: E402
+from infrahub_sync.plan.writer import write_plan_artifact  # noqa: E402
+from infrahub_sync.product_store import (  # noqa: E402
+    MutationReceipt,
+    PrefectExecutionLink,
+    ProductRun,
+    local_product_projection,
+)
+from infrahub_sync.runtime_schema import RuntimeModelPlan, RuntimeSideModels  # noqa: E402
+from infrahub_sync.service import flow as service_flow  # noqa: E402
+from infrahub_sync.service.apply_guard import ApplyGuardContentionError  # noqa: E402
+from infrahub_sync.service.flow import service_sync_run  # noqa: E402
+from tests.configuration.validation_packages import package  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+FLOW_RUN_ID = "b0c0a2d4-6f31-4a58-9b0e-2d4e6f318a55"
+WORKER_ID = "4d9a1c77-2f8e-4d3b-9c11-6a0e7b2f9d40"
+SCHEMA_FINGERPRINT = "d" * 64
+
+
+class _FakeCursor:
+    def __init__(self, row: tuple[Any, ...] | None) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+
+class _FakeGuardSession:
+    """One scripted direct-PostgreSQL session that records the guard's statements."""
+
+    def __init__(self, events: list[str], *, acquire_failure: BaseException | None = None) -> None:
+        self.events = events
+        self.closed = False
+        self.held = True
+        self._acquire_failure = acquire_failure
+
+    def execute(self, query: str, params: Sequence[Any] | None = None) -> _FakeCursor:
+        _ = params
+        if "pg_advisory_lock" in query:
+            if self._acquire_failure is not None:
+                raise self._acquire_failure
+            self.events.append("guard-acquired")
+            return _FakeCursor((None,))
+        if "pg_locks" in query:
+            self.events.append("guard-proved")
+            return _FakeCursor((1234, self.held))
+        if "pg_advisory_unlock" in query:
+            self.events.append("guard-released")
+            return _FakeCursor((True, 1234))
+        return _FakeCursor(("configured",))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _lock_timeout() -> BaseException:
+    """The exact driver failure PostgreSQL raises when `lock_timeout` expires."""
+    return psycopg.errors.LockNotAvailable("canceling statement due to lock timeout")
+
+
+def _receipt(receipt_id: str, *, run_id: str, operation: str) -> MutationReceipt:
+    now = datetime.now(timezone.utc)
+    return MutationReceipt(
+        receipt_id=receipt_id,
+        actor="owner",
+        key_digest=sha256(receipt_id.encode()).hexdigest(),
+        operation=operation,
+        target_run_id=run_id,
+        request_fingerprint=sha256(f"{operation}:{run_id}".encode()).hexdigest(),
+        reason="managed write guard contract",
+        resource_id=run_id,
+        run_id=run_id,
+        prefect_key=sha256(f"prefect:{receipt_id}".encode()).hexdigest(),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class _ManagedStage:
+    """One prepared managed write stage, with every collaborator recorded."""
+
+    def __init__(self, run_id: str, binding: tuple[str, int, str], checksum: str, events: list[str]) -> None:
+        self.run_id = run_id
+        self.binding = binding
+        self.checksum = checksum
+        self.events = events
+        self.session: _FakeGuardSession | None = None
+        self.projection: Any = None
+
+
+def _prepare(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stage: str = "apply",
+    acquire_failure: BaseException | None = None,
+    engine: Any = None,  # noqa: ANN401 - the double receives the engine's own keyword mapping.
+) -> _ManagedStage:
+    """Wire one bound managed run whose guard, schema read, and engine are observable."""
+    monkeypatch.setenv("NETBOX_TOKEN", "managed-netbox-canary")
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "managed-infrahub-canary")
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path / "runs"))
+    events: list[str] = []
+    projection = local_product_projection(tmp_path / "product")
+    registered = projection.create_configuration(package())
+    binding = (registered.config_id, registered.registry_version, registered.package_checksum)
+    run_id = f"managed-{stage}"
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation="apply" if stage == "apply" else "sync",
+            configuration_reference=f"{binding[0]}@{binding[1]}",
+            config_id=binding[0],
+            registry_version=binding[1],
+            package_checksum=binding[2],
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="planned",
+        )
+    )
+    admitted, _created = projection.reserve_mutation(
+        _receipt("m-write", run_id=run_id, operation=stage), admit_write=True
+    )
+    projection.add_prefect_execution(
+        run_id,
+        PrefectExecutionLink(
+            flow_run_id=FLOW_RUN_ID, purpose=stage, attempt=1, submitted_at=datetime.now(timezone.utc)
+        ),
+        receipt_id=admitted.receipt_id,
+    )
+    stored = projection.lookup_configuration_version(binding[0], binding[1]).value
+    assert stored is not None
+    runtime = resolve_runtime_instance(
+        ConfigurationPackage.model_validate(stored.declared_content), directory=str(tmp_path)
+    )
+    runtime._configuration_binding = binding
+    manifest = write_plan_artifact(
+        run_dir=tmp_path / "runs" / runtime.name / run_id,
+        run_id=run_id,
+        config_version=resolve_config_version(runtime),
+        source_snapshot=[],
+        deletes_computed=True,
+        operations=[],
+        configuration_binding=binding,
+        schema_fingerprint=SCHEMA_FINGERPRINT,
+    )
+    prepared = _ManagedStage(run_id, binding, manifest.plan_checksum, events)
+    prepared.projection = projection
+
+    def guard_session() -> _FakeGuardSession:
+        session = _FakeGuardSession(events, acquire_failure=acquire_failure)
+        prepared.session = session
+        return session
+
+    def build_models(**_kwargs: object) -> RuntimeModelPlan:
+        events.append("live-schema-read")
+        return RuntimeModelPlan(
+            branch="main",
+            schema_fingerprint=SCHEMA_FINGERPRINT,
+            destination=RuntimeSideModels(adapter_class=object, models={}),
+            source=None,
+        )
+
+    def saved_plan() -> Any:  # noqa: ANN401 - the engine's own SavedPlan record.
+        return read_saved_plan(sync_name=runtime.name, run_id=run_id, config=runtime)
+
+    def fake_execute_run(_instance: object, **kwargs: object) -> Any:  # noqa: ANN401 - result shape follows the stage.
+        operation = kwargs.get("operation")
+        events.append(f"execute-run:{operation}")
+        if operation == "verify":
+            return saved_plan()
+        if engine is not None:
+            engine(kwargs)
+        return RunResult(
+            sync_name=runtime.name,
+            operation="apply",
+            run_id=run_id,
+            status="no-change",
+            changed=False,
+            summary={"create": 0, "update": 0, "delete": 0},
+            artifact_path=str(tmp_path / "runs" / runtime.name / run_id),
+        )
+
+    def fake_plan(*_args: object, **_kwargs: object) -> Any:  # noqa: ANN401 - the engine's own SavedPlan record.
+        events.append("plan")
+        return saved_plan()
+
+    monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
+    monkeypatch.setenv("PREFECT__WORKER_ID", WORKER_ID)
+    monkeypatch.setattr(service_flow, "_prefect_flow_run_id", lambda: FLOW_RUN_ID)
+    monkeypatch.setattr(service_flow, "_require_current_worker_identity", lambda *_args: None)
+    monkeypatch.setattr(service_flow, "build_runtime_model_plan", build_models)
+    monkeypatch.setattr(service_flow, "execute_run", fake_execute_run)
+    monkeypatch.setattr(service_flow, "_plan", fake_plan)
+    monkeypatch.setattr(service_flow, "_publish_plan", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service_flow, "service_guard_session", guard_session)
+    monkeypatch.setattr(service_flow, "service_guard_secrets", lambda: ())
+    return prepared
+
+
+def _stored(prepared: _ManagedStage) -> ProductRun:
+    run = prepared.projection.lookup_run(prepared.run_id).value
+    assert run is not None
+    return run
+
+
+def _apply(prepared: _ManagedStage) -> dict[str, Any]:
+    return service_sync_run.fn(
+        prepared.run_id, "apply", *prepared.binding, expected_checksum=prepared.checksum, confirm_writes=True
+    )
+
+
+def test_a_managed_apply_holds_the_guard_before_its_live_schema_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A schema snapshot taken before a contended wait may describe a stale destination."""
+    prepared = _prepare(tmp_path, monkeypatch)
+
+    _apply(prepared)
+
+    assert prepared.events.index("guard-acquired") < prepared.events.index("live-schema-read")
+    assert prepared.events.index("live-schema-read") < prepared.events.index("execute-run:apply")
+    assert prepared.events[-1] == "guard-released"
+
+
+def test_a_managed_apply_confirms_release_before_the_product_success_writeback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A success published while the key may still be held is a success nobody can trust."""
+    prepared = _prepare(tmp_path, monkeypatch)
+
+    _apply(prepared)
+
+    run = _stored(prepared)
+    assert (run.phase, run.outcome) == ("applied", "no-change")
+    assert prepared.session is not None
+    assert prepared.session.closed is True
+    assert run.reconciliation_required is False
+
+
+def test_guard_contention_touches_no_destination_and_creates_no_success_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Another writer's hold is a clean refusal: nothing read, nothing written, no ambiguity."""
+    prepared = _prepare(tmp_path, monkeypatch, acquire_failure=_lock_timeout())
+
+    with pytest.raises(ApplyGuardContentionError):
+        _apply(prepared)
+
+    assert "live-schema-read" not in prepared.events
+    assert "execute-run:apply" not in prepared.events
+    run = _stored(prepared)
+    assert run.reconciliation_required is False
+    assert run.outcome == "failed"
+
+
+def test_a_failure_before_the_first_dispatch_stays_an_ordinary_failed_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal under the guard that never dispatched is not an uncertain write."""
+
+    def refuse(_kwargs: dict[str, object]) -> None:
+        msg = "the destination refused the plan before any operation"
+        raise ValueError(msg)
+
+    prepared = _prepare(tmp_path, monkeypatch, engine=refuse)
+
+    with pytest.raises(ValueError, match="before any operation"):
+        _apply(prepared)
+
+    run = _stored(prepared)
+    assert run.reconciliation_required is False
+    assert run.outcome == "failed"
+    link = run.prefect_executions[0]
+    assert (link.terminal_state, link.terminal_outcome) == ("failed", "failed")
+
+
+def test_a_failure_after_the_first_dispatch_becomes_durable_ambiguity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once one operation has been dispatched, no caught failure may claim a clean stop."""
+
+    def dispatch_then_fail(kwargs: dict[str, Any]) -> None:
+        kwargs["ownership"].before_operation()
+        msg = "the destination failed after the first operation"
+        raise ValueError(msg)
+
+    prepared = _prepare(tmp_path, monkeypatch, engine=dispatch_then_fail)
+
+    with pytest.raises(ValueError, match="after the first operation"):
+        _apply(prepared)
+
+    run = _stored(prepared)
+    assert run.reconciliation_required is True
+    assert run.outcome == "ambiguous"
+    link = run.prefect_executions[0]
+    assert (link.terminal_state, link.terminal_outcome) == ("interrupted", "ambiguous")
+
+
+def test_a_lost_session_after_the_first_dispatch_becomes_durable_ambiguity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A guard that cannot prove itself after a dispatch leaves the destination uncertain."""
+    prepared_holder: list[_ManagedStage] = []
+
+    def dispatch_then_lose(kwargs: dict[str, Any]) -> None:
+        ownership = kwargs["ownership"]
+        ownership.before_operation()
+        session = prepared_holder[0].session
+        assert session is not None
+        session.held = False
+        ownership.before_operation()
+
+    prepared = _prepare(tmp_path, monkeypatch, engine=dispatch_then_lose)
+    prepared_holder.append(prepared)
+
+    with pytest.raises(Exception):  # noqa: B017 - the guard's own ownership failure.
+        _apply(prepared)
+
+    run = _stored(prepared)
+    assert run.reconciliation_required is True
+    assert run.outcome == "ambiguous"
+
+
+def test_a_managed_sync_holds_one_guard_across_planning_and_applying(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plan generated outside the guard could go stale behind another writer."""
+    prepared = _prepare(tmp_path, monkeypatch, stage="sync")
+
+    service_sync_run.fn(prepared.run_id, "sync", *prepared.binding, confirm_writes=True)
+
+    acquired = prepared.events.index("guard-acquired")
+    assert acquired < prepared.events.index("plan")
+    assert acquired < prepared.events.index("live-schema-read")
+    assert acquired < prepared.events.index("execute-run:apply")
+    assert prepared.events[-1] == "guard-released"
+
+
+def test_a_managed_write_without_a_registered_binding_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A guard keyed on a configuration cannot serialize a run that names none."""
+    monkeypatch.setenv("PREFECT__WORKER_ID", WORKER_ID)
+    monkeypatch.setattr(service_flow, "_prefect_flow_run_id", lambda: FLOW_RUN_ID)
+    monkeypatch.setattr(service_flow, "_require_current_worker_identity", lambda *_args: None)
+    monkeypatch.setenv("INFRAHUB_SYNC_CACHE_DIR", str(tmp_path / "runs"))
+    projection = local_product_projection(tmp_path / "product")
+    run_id = "legacy-apply"
+    projection.create_run(
+        ProductRun(
+            run_id=run_id,
+            operation="apply",
+            configuration_reference="legacy-config-version",
+            actor="owner",
+            started_at=datetime.now(timezone.utc),
+            phase="planned",
+            summary={"sync_name": "legacy-inventory"},
+        )
+    )
+    reserved, _created = projection.reserve_mutation(
+        _receipt("m-legacy", run_id=run_id, operation="apply"), admit_write=True
+    )
+    projection.add_prefect_execution(
+        run_id,
+        PrefectExecutionLink(
+            flow_run_id=FLOW_RUN_ID, purpose="apply", attempt=1, submitted_at=datetime.now(timezone.utc)
+        ),
+        receipt_id=reserved.receipt_id,
+    )
+    guard_sessions: list[object] = []
+    monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
+    monkeypatch.setattr(service_flow, "service_guard_session", lambda: guard_sessions.append(object()))
+
+    with pytest.raises(ValueError, match="registered configuration"):
+        service_sync_run.fn(run_id, "apply", expected_checksum="a" * 64, confirm_writes=True)
+
+    assert guard_sessions == []
+
+
+def test_the_managed_write_path_takes_no_local_pipeline_lock() -> None:
+    """One correctness guard, not two: the file lock is gone from the supported path."""
+    source = service_flow.__loader__.get_source(service_flow.__name__)  # ty: ignore[possibly-unbound-attribute]
+    assert source is not None
+    assert "bounded_run_lock" not in source
+
+
+def test_the_direct_sync_writer_is_refused_instead_of_running_unguarded() -> None:
+    """The unsupported direct write path cannot prove any per-operation ownership."""
+    with pytest.raises(RunValidationError, match="sync"):
+        execute_run(object(), operation="sync", confirm_writes=True)  # ty: ignore[invalid-argument-type]
+
+
+def test_a_managed_apply_without_an_ownership_boundary_is_refused() -> None:
+    """`execute_run` refuses a write it cannot prove, before it builds anything."""
+    with pytest.raises(RunValidationError, match="ownership"):
+        execute_run(  # ty: ignore[invalid-argument-type]
+            object(),
+            operation="apply",
+            run_id="managed-apply",
+            confirm_writes=True,
+        )

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -65,7 +65,6 @@ class _FakeGuardSession:
 
     def __init__(self, events: list[str], *, acquire_failure: BaseException | None = None) -> None:
         self.events = events
-        self.closed = False
         self.held = True
         self._acquire_failure = acquire_failure
 
@@ -85,7 +84,7 @@ class _FakeGuardSession:
         return _FakeCursor(("configured",))
 
     def close(self) -> None:
-        self.closed = True
+        """Close the dedicated session."""
 
 
 def _lock_timeout() -> BaseException:
@@ -257,21 +256,6 @@ def test_a_managed_apply_holds_the_guard_before_its_live_schema_read(
     assert prepared.events.index("guard-acquired") < prepared.events.index("live-schema-read")
     assert prepared.events.index("live-schema-read") < prepared.events.index("execute-run:apply")
     assert prepared.events[-1] == "guard-released"
-
-
-def test_a_managed_apply_confirms_release_before_the_product_success_writeback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A success published while the key may still be held is a success nobody can trust."""
-    prepared = _prepare(tmp_path, monkeypatch)
-
-    _apply(prepared)
-
-    run = _stored(prepared)
-    assert (run.phase, run.outcome) == ("applied", "no-change")
-    assert prepared.session is not None
-    assert prepared.session.closed is True
-    assert run.reconciliation_required is False
 
 
 def test_guard_contention_touches_no_destination_and_creates_no_success_evidence(

--- a/tests/service/test_managed_write_guard.py
+++ b/tests/service/test_managed_write_guard.py
@@ -14,6 +14,7 @@ own unit suite drives. Its provider facts are proven against a real server in
 
 from __future__ import annotations
 
+import ast
 from datetime import datetime, timezone
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
@@ -31,6 +32,7 @@ from infrahub_sync.configuration import ConfigurationPackage  # noqa: E402
 from infrahub_sync.configuration.runtime import resolve_runtime_instance  # noqa: E402
 from infrahub_sync.execution import RunResult, RunValidationError, execute_run  # noqa: E402
 from infrahub_sync.plan.config_version import resolve_config_version  # noqa: E402
+from infrahub_sync.plan.models import ApplyRecord  # noqa: E402
 from infrahub_sync.plan.review import read_saved_plan  # noqa: E402
 from infrahub_sync.plan.writer import write_plan_artifact  # noqa: E402
 from infrahub_sync.product_store import (  # noqa: E402
@@ -63,10 +65,17 @@ class _FakeCursor:
 class _FakeGuardSession:
     """One scripted direct-PostgreSQL session that records the guard's statements."""
 
-    def __init__(self, events: list[str], *, acquire_failure: BaseException | None = None) -> None:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        acquire_failure: BaseException | None = None,
+        release_failure: BaseException | None = None,
+    ) -> None:
         self.events = events
         self.held = True
         self._acquire_failure = acquire_failure
+        self._release_failure = release_failure
 
     def execute(self, query: str, params: Sequence[Any] | None = None) -> _FakeCursor:
         _ = params
@@ -79,6 +88,8 @@ class _FakeGuardSession:
             self.events.append("guard-proved")
             return _FakeCursor((1234, self.held))
         if "pg_advisory_unlock" in query:
+            if self._release_failure is not None:
+                raise self._release_failure
             self.events.append("guard-released")
             return _FakeCursor((True, 1234))
         return _FakeCursor(("configured",))
@@ -122,12 +133,14 @@ class _ManagedStage:
         self.projection: Any = None
 
 
-def _prepare(
+def _prepare(  # noqa: PLR0913 - one harness knob per collaborator a case scripts.
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     *,
     stage: str = "apply",
     acquire_failure: BaseException | None = None,
+    release_failure: BaseException | None = None,
+    commit_failure: BaseException | None = None,
     engine: Any = None,  # noqa: ANN401 - the double receives the engine's own keyword mapping.
 ) -> _ManagedStage:
     """Wire one bound managed run whose guard, schema read, and engine are observable."""
@@ -182,7 +195,7 @@ def _prepare(
     prepared.projection = projection
 
     def guard_session() -> _FakeGuardSession:
-        session = _FakeGuardSession(events, acquire_failure=acquire_failure)
+        session = _FakeGuardSession(events, acquire_failure=acquire_failure, release_failure=release_failure)
         prepared.session = session
         return session
 
@@ -230,13 +243,43 @@ def _prepare(
     monkeypatch.setattr(service_flow, "_publish_plan", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(service_flow, "service_guard_session", guard_session)
     monkeypatch.setattr(service_flow, "service_guard_secrets", lambda: ())
+    if commit_failure is not None:
+        prepared.projection = _FailingSuccessCommit(projection, commit_failure)
+        monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), prepared.projection))
     return prepared
+
+
+class _FailingSuccessCommit:
+    """A projection whose *success* commit fails, and whose every other call passes through.
+
+    Only the succeeded verdict is refused, so the failure boundary's own terminal commit —
+    the ambiguous one — still reaches the store, which is exactly the path under test.
+    """
+
+    def __init__(self, projection: Any, failure: BaseException) -> None:  # noqa: ANN401 - the real projection.
+        self._projection = projection
+        self._failure = failure
+
+    def commit_claimed_execution(self, *args: Any, **kwargs: Any) -> bool:  # noqa: ANN401 - the store's own shape.
+        if kwargs.get("terminal_outcome") == "succeeded":
+            raise self._failure
+        return self._projection.commit_claimed_execution(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401 - every other call is the real one.
+        return getattr(self._projection, name)
 
 
 def _stored(prepared: _ManagedStage) -> ProductRun:
     run = prepared.projection.lookup_run(prepared.run_id).value
     assert run is not None
     return run
+
+
+def _drive(prepared: _ManagedStage, stage: str) -> dict[str, Any]:
+    """Run whichever managed write stage this case prepared."""
+    if stage == "apply":
+        return _apply(prepared)
+    return service_sync_run.fn(prepared.run_id, "sync", *prepared.binding, confirm_writes=True)
 
 
 def _apply(prepared: _ManagedStage) -> dict[str, Any]:
@@ -418,8 +461,56 @@ def test_the_direct_sync_writer_is_refused_instead_of_running_unguarded() -> Non
         execute_run(object(), operation="sync", confirm_writes=True)  # ty: ignore[no-matching-overload]
 
 
-def test_a_managed_apply_without_an_ownership_boundary_is_refused() -> None:
-    """`execute_run` refuses a write it cannot prove, before it builds anything."""
+def test_the_apply_overload_requires_a_write_ownership_boundary() -> None:
+    """The declaration the type checker reads is what refuses an unguarded apply first.
+
+    Plan and verify write nothing, so making the keyword unconditionally required would be
+    worse than the defect it fixes. Declaring it required on the apply overload alone — and
+    leaving `apply` out of every other overload — is what makes the gate's own type check
+    reject an omitted boundary, before any of this runs.
+    """
+    module = ast.parse(Path(execution.__file__).read_text(encoding="utf-8"))
+    overloads = [
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "execute_run"
+        and any(isinstance(item, ast.Name) and item.id == "overload" for item in node.decorator_list)
+    ]
+    assert overloads, "execute_run declares no overloads for the type checker to read"
+
+    accepting_apply = [node for node in overloads if "apply" in _operation_literals(node)]
+    assert len(accepting_apply) == 1, (
+        f"{len(accepting_apply)} overloads accept operation='apply'; one of them would let an "
+        f"unguarded apply type-check"
+    )
+    keywords = accepting_apply[0].args.kwonlyargs
+    defaults = accepting_apply[0].args.kw_defaults
+    ownership = next(
+        (argument for argument, default in zip(keywords, defaults, strict=True) if argument.arg == "ownership"),
+        None,
+    )
+    assert ownership is not None, "the apply overload does not declare an ownership boundary"
+    required = [argument.arg for argument, default in zip(keywords, defaults, strict=True) if default is None]
+    assert "ownership" in required, "the apply overload's ownership boundary has a default"
+
+
+def _operation_literals(node: ast.FunctionDef) -> set[str]:
+    """Return the operation names one overload's `operation` annotation admits."""
+    annotation = next((argument.annotation for argument in node.args.kwonlyargs if argument.arg == "operation"), None)
+    return (
+        {
+            element.value
+            for element in ast.walk(annotation)
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        }
+        if annotation is not None
+        else set()
+    )
+
+
+def test_a_managed_apply_without_an_ownership_boundary_is_refused_at_run_time() -> None:
+    """The runtime refusal stands behind the type-level one, for a caller that ignores it."""
     with pytest.raises(RunValidationError, match="ownership"):
         execute_run(  # ty: ignore[no-matching-overload]
             object(),
@@ -444,3 +535,76 @@ def test_a_stale_approved_checksum_is_refused_before_any_guard_session(
     assert prepared.events == []
     run = _stored(prepared)
     assert run.reconciliation_required is False
+
+
+def _dispatch_and_complete(kwargs: dict[str, Any]) -> None:
+    """Stand in for the engine: dispatch once, then report what it completed.
+
+    `_run_apply_lifecycle` reports the completed record to the write scope before its own
+    sidecar write, which is the only reason a failure raised *after* the engine returned can
+    still say what was written. The double does the same thing at the same point.
+    """
+    ownership = kwargs["ownership"]
+    ownership.before_operation()
+    ownership.after_final_operation()
+    ownership.record_applied(ApplyRecord(applied_operations=("op-live-1",), skipped_delete_operations=("op-live-2",)))
+
+
+@pytest.mark.parametrize("stage", ["apply", "sync"])
+def test_a_release_that_cannot_be_confirmed_after_a_dispatch_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    """An unconfirmable unlock after a write is uncertainty, and it still names the write.
+
+    The engine returned cleanly and the applied sidecar is written, so nothing in the
+    failure that unwinds carries a record — only the scope does. Losing it here would leave
+    an operator an ambiguous run with no account of what reached the destination.
+    """
+    prepared = _prepare(
+        tmp_path,
+        monkeypatch,
+        stage=stage,
+        release_failure=psycopg.OperationalError("the guard session died before it could unlock"),
+        engine=_dispatch_and_complete,
+    )
+
+    with pytest.raises(RuntimeError, match="ApplyGuardReleaseError"):
+        _drive(prepared, stage)
+
+    run = _stored(prepared)
+    assert run.reconciliation_required is True
+    assert run.outcome == "ambiguous"
+    assert run.prefect_executions[0].terminal_state == "interrupted"
+    failure = run.results[f"{stage}_failure"]
+    assert failure["applied_operations"] == ["op-live-1"]
+    assert failure["skipped_delete_operations"] == ["op-live-2"]
+
+
+@pytest.mark.parametrize("stage", ["apply", "sync"])
+def test_a_success_writeback_that_stores_nothing_after_a_dispatch_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    """A product commit that did not land is not a run left for someone else to notice.
+
+    The guard released cleanly and the write is done; only the success record failed. The
+    run has to reach a terminal ambiguous verdict here, carrying the same record, rather
+    than sitting non-terminal until a liveness pass eventually interrupts it.
+    """
+    prepared = _prepare(
+        tmp_path,
+        monkeypatch,
+        stage=stage,
+        commit_failure=RuntimeError("the product store refused the success commit"),
+        engine=_dispatch_and_complete,
+    )
+
+    with pytest.raises(RuntimeError, match="refused the success commit"):
+        _drive(prepared, stage)
+
+    run = _stored(prepared)
+    assert run.reconciliation_required is True
+    assert run.outcome == "ambiguous"
+    assert run.prefect_executions[0].terminal_state == "interrupted"
+    failure = run.results[f"{stage}_failure"]
+    assert failure["applied_operations"] == ["op-live-1"]
+    assert failure["skipped_delete_operations"] == ["op-live-2"]

--- a/tests/service/test_registered_plan_apply.py
+++ b/tests/service/test_registered_plan_apply.py
@@ -23,7 +23,7 @@ from infrahub_sync.service import flow as service_flow
 from infrahub_sync.service.flow import service_sync_run
 from tests.configuration.validation_packages import package
 from tests.plan.artifact_fixtures import operation_record
-from tests.service.execution_fixtures import append_execution
+from tests.service.execution_fixtures import append_execution, bind_granting_guard
 
 FLOW_RUN_ID = "ed4778cb-f2cf-4b1f-a87b-68be37659e93"
 WORKER_ID = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
@@ -84,6 +84,7 @@ def _registered_apply(
     )
     calls: list[str] = []
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
     monkeypatch.setenv("PREFECT__WORKER_ID", WORKER_ID)
     monkeypatch.setattr(service_flow, "_prefect_flow_run_id", lambda: FLOW_RUN_ID)
@@ -225,6 +226,7 @@ def test_a_registered_saved_apply_runs_without_the_source_credential(
 
     monkeypatch.setattr("infrahub_sync.utils.import_adapter", _refuse_adapter_import)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
     monkeypatch.setattr(service_flow, "_prefect_flow_run_id", lambda: FLOW_RUN_ID)
     monkeypatch.setattr(service_flow, "_require_current_worker_identity", lambda *_args: None)

--- a/tests/service/test_registered_plan_apply.py
+++ b/tests/service/test_registered_plan_apply.py
@@ -23,6 +23,7 @@ from infrahub_sync.service import flow as service_flow
 from infrahub_sync.service.flow import service_sync_run
 from tests.configuration.validation_packages import package
 from tests.plan.artifact_fixtures import operation_record
+from tests.service.execution_fixtures import append_execution
 
 FLOW_RUN_ID = "ed4778cb-f2cf-4b1f-a87b-68be37659e93"
 WORKER_ID = "8c1da53d-0e6b-4d3d-a0f1-97b6a9ccebf0"
@@ -56,7 +57,8 @@ def _registered_apply(
             phase="planned",
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         run_id,
         PrefectExecutionLink(
             flow_run_id=FLOW_RUN_ID, purpose="apply", attempt=1, submitted_at=datetime.now(timezone.utc)
@@ -172,7 +174,8 @@ def test_a_registered_saved_apply_runs_without_the_source_credential(
             phase="planned",
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         run_id,
         PrefectExecutionLink(
             flow_run_id=FLOW_RUN_ID, purpose="apply", attempt=1, submitted_at=datetime.now(timezone.utc)

--- a/tests/service/test_registered_schema_guard.py
+++ b/tests/service/test_registered_schema_guard.py
@@ -34,6 +34,7 @@ from infrahub_sync.plan.canonical import canonical_json_bytes
 from infrahub_sync.plan.checksum import compute_plan_checksum
 from infrahub_sync.plan.config_version import resolve_config_version
 from infrahub_sync.plan.errors import PlanSchemaChangedError
+from infrahub_sync.plan.ownership import WriteDispatchTracker
 from infrahub_sync.plan.review import read_saved_plan
 from infrahub_sync.plan.writer import MANIFEST_FILE_NAME, OPERATIONS_FILE_NAME, PLAN_DIR_NAME, write_plan_artifact
 from infrahub_sync.product_store import PrefectExecutionLink, ProductRun, local_product_projection
@@ -44,7 +45,7 @@ from infrahub_sync.service.flow import service_sync_run
 from infrahub_sync.service.service import PLAN_ARTIFACT_ID
 from tests.configuration.validation_packages import package_data
 from tests.plan.artifact_fixtures import duplicated_key_manifest_bytes
-from tests.service.execution_fixtures import append_execution
+from tests.service.execution_fixtures import append_execution, bind_granting_guard
 
 if TYPE_CHECKING:
     from infrahub_sync import SyncInstance
@@ -205,6 +206,7 @@ def _harness(
     spy = _SnapshotSpy()
     monkeypatch.setattr(worker_module, "read_destination_schema_snapshot", spy)
     monkeypatch.setattr(service_flow, "_runtime", lambda: (str(tmp_path), projection))
+    bind_granting_guard(monkeypatch, service_flow)
     monkeypatch.setattr(service_flow, "_run_logger", lambda: (service_flow.logger, False))
     monkeypatch.setattr(service_flow, "_prefect_flow_run_id", lambda: FLOW_RUN_ID)
     monkeypatch.setattr(service_flow, "_require_current_worker_identity", lambda *_args: None)
@@ -258,6 +260,7 @@ def _execute_apply_stage(harness: _Harness) -> tuple[dict[str, Any], Any]:
         secrets=[],
         config_directory=str(harness.run_dir.parents[2]),
         projection=harness.projection,
+        tracker=WriteDispatchTracker(),
     )
 
 

--- a/tests/service/test_registered_schema_guard.py
+++ b/tests/service/test_registered_schema_guard.py
@@ -44,6 +44,7 @@ from infrahub_sync.service.flow import service_sync_run
 from infrahub_sync.service.service import PLAN_ARTIFACT_ID
 from tests.configuration.validation_packages import package_data
 from tests.plan.artifact_fixtures import duplicated_key_manifest_bytes
+from tests.service.execution_fixtures import append_execution
 
 if TYPE_CHECKING:
     from infrahub_sync import SyncInstance
@@ -174,7 +175,8 @@ def _harness(
             phase="planned",
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         RUN_ID,
         PrefectExecutionLink(
             flow_run_id=FLOW_RUN_ID, purpose="apply", attempt=1, submitted_at=datetime.now(timezone.utc)

--- a/tests/service/test_service_worker.py
+++ b/tests/service/test_service_worker.py
@@ -26,6 +26,7 @@ from prefect.workers.process import ProcessWorker
 from infrahub_sync.product_store import PrefectExecutionLink, ProductRun, local_product_projection
 from infrahub_sync.service import flow as service_flow
 from infrahub_sync.service.worker import ServiceProcessWorker, ServiceWorkerIdentityError, service_worker_name
+from tests.service.execution_fixtures import append_execution
 
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun, WorkPool
@@ -376,7 +377,8 @@ async def test_child_refuses_stale_identity_after_start_before_claim(
             phase="accepted",
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         run_id,
         PrefectExecutionLink(flow_run_id=str(FLOW_ID), purpose="plan", attempt=1, submitted_at=now),
     )

--- a/tests/service/test_worker_claim.py
+++ b/tests/service/test_worker_claim.py
@@ -22,6 +22,7 @@ from prefect.workers.process import ProcessJobConfiguration, ProcessWorker
 
 from infrahub_sync.product_store import PrefectExecutionLink, ProductRun, local_product_projection
 from infrahub_sync.service import flow as service_flow
+from tests.service.execution_fixtures import append_execution
 
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
@@ -89,7 +90,8 @@ def _projection(tmp_path: Path, *, submitted_at: datetime | None = None, migrate
             phase="accepted",
         )
     )
-    projection.add_prefect_execution(
+    append_execution(
+        projection,
         "run-worker-claim",
         PrefectExecutionLink(
             flow_run_id=FLOW_ID,

--- a/tests/test_execution_surface.py
+++ b/tests/test_execution_surface.py
@@ -1165,7 +1165,11 @@ def test_the_composed_sync_writer_is_refused_before_the_engine_is_built(
     factory = _SpyFactory(cache_root=cache_root)
 
     with pytest.raises(RunValidationError) as excinfo:
-        execute_run(instance, operation="sync", confirm_writes=confirm_writes, potenda_factory=factory)
+        # Deliberately ill-typed: no overload accepts `sync`, and this case is about the
+        # runtime refusal that stands behind that type-level one.
+        execute_run(  # ty: ignore[no-matching-overload]
+            instance, operation="sync", confirm_writes=confirm_writes, potenda_factory=factory
+        )
 
     assert "operation=sync is not supported here" in str(excinfo.value)
     assert factory.calls == []

--- a/tests/test_execution_surface.py
+++ b/tests/test_execution_surface.py
@@ -1152,14 +1152,22 @@ def test_a_resolution_failure_that_is_not_a_refusal_is_wrapped_and_sanitized(
 # --------------------------------------------------------------------------- #
 
 
-def test_unconfirmed_sync_is_refused_before_the_engine_is_built(config_dir: str, cache_root: Path) -> None:
+@pytest.mark.parametrize("confirm_writes", [False, True])
+def test_the_composed_sync_writer_is_refused_before_the_engine_is_built(
+    config_dir: str,
+    cache_root: Path,
+    confirm_writes: bool,  # noqa: FBT001 - one parametrized dimension of the refusal.
+) -> None:
+    """A composed sync produces its own plan and applies it in one call, so it can offer
+    no per-operation ownership proof over a reviewed artifact. Confirming the write does
+    not make it supported; the Sync API composes plan, verify, and apply instead."""
     instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
     factory = _SpyFactory(cache_root=cache_root)
 
     with pytest.raises(RunValidationError) as excinfo:
-        execute_run(instance, operation="sync", potenda_factory=factory)
+        execute_run(instance, operation="sync", confirm_writes=confirm_writes, potenda_factory=factory)
 
-    assert "confirm_writes=true is required to run operation=sync" in str(excinfo.value)
+    assert "operation=sync is not supported here" in str(excinfo.value)
     assert factory.calls == []
     assert not cache_root.exists()
 
@@ -1553,39 +1561,6 @@ def test_empty_plan_reports_no_change(config_dir: str, cache_root: Path) -> None
     assert RunFile.load_or_default(cache_root / RUN_ID / "run.json").status == "dry-run"
 
 
-def test_nested_only_diff_reports_no_change_even_though_the_sync_ran(
-    config_dir: Path, cache_root: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Materialized rows are the result contract's fidelity boundary (contract step 7).
-
-    `Potenda._diff_to_rows` walks only the diff root's direct children while
-    `Diff.has_diffs()` is recursive, so a diff whose only changes sit in nested
-    child elements gates the sync ON but materializes ZERO rows — and the result
-    fields, which derive from the rows, therefore report no change.
-    """
-    from infrahub_sync.utils import get_instance
-
-    sync_instance: SyncInstance | None = get_instance(name=SYNC_NAME, directory=str(config_dir))
-    assert sync_instance is not None
-    run_dir = cache_root / RUN_ID
-    factory = _factory(run_dir, [], has_diffs=True)
-
-    with caplog.at_level(logging.INFO, logger="infrahub_sync.execution"):
-        result = execute_run(
-            sync_instance,
-            operation="sync",
-            confirm_writes=True,
-            potenda_factory=factory,
-        )
-
-    engine = factory()
-    assert engine.synced is True, "has_diffs() gates execution exactly as it does today"
-    assert result.status == "no-change"
-    assert result.changed is False
-    assert dict(result.summary) == {"create": 0, "update": 0, "delete": 0}
-    assert "No difference found. Nothing to sync" not in [record.getMessage() for record in caplog.records]
-
-
 def test_plan_uses_a_valid_writer_summary_without_materializing_fallback_rows(
     config_dir: str,
     cache_root: Path,
@@ -1939,233 +1914,3 @@ NO_DIFF_LOG = "No difference found. Nothing to sync"
 
 def _fixture_creates() -> list[dict[str, Any]]:
     return [_plan_row("create", name) for name in FIXTURE_DEVICES]
-
-
-def test_confirmed_sync_applies_and_writes_the_serial_lifecycle(config_dir: str, cache_root: Path) -> None:
-    """`operation="sync"` + `confirm_writes=True` applies the plan and reports it."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _SpyFactory(cache_root=cache_root, rows=_fixture_creates())
-
-    result = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-
-    run_dir = cache_root / RUN_ID
-    assert result == RunResult(
-        sync_name=SYNC_NAME,
-        operation="sync",
-        run_id=RUN_ID,
-        status="applied",
-        changed=True,
-        summary={"create": 5, "update": 0, "delete": 0},
-        artifact_path=str(run_dir),
-    )
-    assert (run_dir / "plan.parquet").exists()
-    run_file = RunFile.load_or_default(run_dir / "run.json")
-    assert run_file.mode == "sync"
-    assert run_file.status == "applied"
-    assert run_file.summary == {"resources": 1, "mode": "serial"}
-    assert run_file.finished_at is not None
-    engine = factory.engine
-    assert engine is not None
-    assert engine.force_full_extract is True
-    assert engine.loaded is True
-    assert engine.synced is True
-    assert engine.baseline_persisted is True
-    assert engine.guardrail_allow_drop is False
-
-
-def test_confirmed_sync_summary_counts_every_action(config_dir: str, cache_root: Path) -> None:
-    """The per-action summary is derived from the in-memory plan rows."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    rows = [
-        _plan_row("create", "core01"),
-        _plan_row("create", "core02"),
-        _plan_row("update", "edge01"),
-        _plan_row("delete", "edge02"),
-    ]
-    factory = _SpyFactory(cache_root=cache_root, rows=rows)
-
-    result = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-
-    assert result.status == "applied"
-    assert dict(result.summary) == {"create": 2, "update": 1, "delete": 1}
-
-
-def test_confirmed_parallel_sync_returns_its_aggregated_plan_counts(config_dir: str, cache_root: Path) -> None:
-    """A tier-parallel write reports the materialized plan instead of no-change."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    rows = [_plan_row("create", "core01"), _plan_row("update", "edge01"), _plan_row("delete", "edge02")]
-    factory = _SpyFactory(cache_root=cache_root, rows=rows)
-
-    def parallel_factory(**kwargs: object) -> Any:  # noqa: ANN401
-        engine = factory(**kwargs)
-        engine.tiers = [{"InfraDevice"}]
-        return engine
-
-    result = execute_run(
-        instance,
-        operation="sync",
-        confirm_writes=True,
-        parallel=True,
-        potenda_factory=parallel_factory,
-    )
-
-    assert result.status == "applied"
-    assert result.changed is True
-    assert dict(result.summary) == {"create": 1, "update": 1, "delete": 1}
-    assert RunFile.load_or_default(cache_root / RUN_ID / "run.json").summary == {
-        "resources": 1,
-        "mode": "parallel",
-    }
-
-
-def test_confirmed_sync_rejects_a_malformed_writer_summary_before_writing(
-    config_dir: str,
-    cache_root: Path,
-) -> None:
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _SpyFactory(
-        cache_root=cache_root,
-        rows=[_plan_row("create", "core01")],
-        write_result={"create": True, "update": 0, "delete": 0},
-    )
-
-    with pytest.raises(ValueError, match="non-negative integer"):
-        execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-
-    assert factory.engine is not None
-    assert factory.engine.synced is False
-    assert factory.engine.diff_rows_materialized == 0
-    assert RunFile.load_or_default(cache_root / RUN_ID / "run.json").status == "failed"
-
-
-@pytest.mark.parametrize("print_diff", [True, False])
-def test_confirmed_sync_logs_the_timing_line_when_the_diff_has_changes(
-    config_dir: str,
-    cache_root: Path,
-    caplog: pytest.LogCaptureFixture,
-    *,
-    print_diff: bool,
-) -> None:
-    """`print_diff` gates the diff rendering only — the timing line is unconditional."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _SpyFactory(cache_root=cache_root, rows=_fixture_creates())
-
-    with caplog.at_level(logging.INFO, logger="infrahub_sync.execution"):
-        execute_run(
-            instance,
-            operation="sync",
-            confirm_writes=True,
-            print_diff=print_diff,
-            potenda_factory=factory,
-        )
-
-    assert TIMING_LOG_PREFIX in caplog.text
-    assert NO_DIFF_LOG not in caplog.text
-    assert ("fake-diff(5 rows)" in caplog.text) is print_diff
-
-
-def test_sync_over_an_unchanged_destination_skips_the_sync_and_the_timing_log(
-    config_dir: str,
-    cache_root: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """No diffs: no engine `sync`, no timing line — but the baseline is still persisted."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _SpyFactory(cache_root=cache_root, rows=[])
-
-    with caplog.at_level(logging.INFO, logger="infrahub_sync.execution"):
-        result = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-
-    assert result.status == "no-change"
-    assert result.changed is False
-    assert dict(result.summary) == {"create": 0, "update": 0, "delete": 0}
-    assert NO_DIFF_LOG in caplog.text
-    assert TIMING_LOG_PREFIX not in caplog.text
-    engine = factory.engine
-    assert engine is not None
-    assert engine.synced is False
-    assert engine.baseline_persisted is True
-
-
-def test_second_confirmed_sync_converges_to_no_change(
-    config_dir: str,
-    cache_root: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Idempotent reconciliation: apply, then re-run against the synchronized state."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _ConvergingFactory(cache_root=cache_root, rows=_fixture_creates())
-
-    # `caplog` captures for the whole test, so the two runs' records are separated
-    # explicitly — otherwise the first run's timing line would still be in
-    # `caplog.text` while the second run is being asserted about.
-    with caplog.at_level(logging.INFO, logger="infrahub_sync.execution"):
-        first = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-        first_logs = caplog.text
-        caplog.clear()
-        second = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-        second_logs = caplog.text
-
-    assert first.status == "applied"
-    assert first.changed is True
-    assert dict(first.summary) == {"create": 5, "update": 0, "delete": 0}
-    assert TIMING_LOG_PREFIX in first_logs
-
-    assert second.status == "no-change"
-    assert second.changed is False
-    assert dict(second.summary) == {"create": 0, "update": 0, "delete": 0}
-    assert second.run_id != first.run_id
-    assert NO_DIFF_LOG in second_logs
-    assert TIMING_LOG_PREFIX not in second_logs
-
-    assert factory.engines[0].synced is True
-    assert factory.engines[1].synced is False
-    # Both runs record mode="sync"/status="applied" in run.json: run.json reports
-    # that the sync lifecycle ran to completion, while RunResult.status reports
-    # whether the destination actually differed.
-    for engine in factory.engines:
-        run_file = RunFile.load_or_default(engine.run_dir / "run.json")
-        assert run_file.mode == "sync"
-        assert run_file.status == "applied"
-        assert run_file.summary == {"resources": 1, "mode": "serial"}
-
-
-def test_follow_up_plan_after_a_confirmed_sync_reports_no_change(config_dir: str, cache_root: Path) -> None:
-    """The DBA-005 convergence leg: a plan over the synchronized state is empty."""
-    instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
-    factory = _ConvergingFactory(cache_root=cache_root, rows=_fixture_creates())
-
-    applied = execute_run(instance, operation="sync", confirm_writes=True, potenda_factory=factory)
-    planned = execute_run(instance, operation="plan", potenda_factory=factory)
-
-    assert applied.status == "applied"
-    assert planned.operation == "plan"
-    assert planned.status == "no-change"
-    assert planned.changed is False
-    assert dict(planned.summary) == {"create": 0, "update": 0, "delete": 0}
-    assert RunFile.load_or_default(factory.engines[1].run_dir / "run.json").mode == "diff"
-
-
-def test_confirmed_sync_through_the_remote_composition_returns_applied(config_dir: str, cache_root: Path) -> None:
-    """The remote path reaches the same applied result the CLI serial branch does."""
-    factory = _ConvergingFactory(cache_root=cache_root, rows=_fixture_creates())
-
-    result = run_remote_request(
-        SYNC_NAME,
-        "sync",
-        confirm_writes=True,
-        config_directory=config_dir,
-        _potenda_factory=factory,
-    )
-
-    assert result.operation == "sync"
-    assert result.status == "applied"
-    assert result.changed is True
-    assert dict(result.summary) == {"create": 5, "update": 0, "delete": 0}
-    assert Path(result.artifact_path).name == result.run_id
-    assert factory.calls[0]["show_progress"] is False
-    assert factory.engines[0].synced is True
-    # The remote path's safety defaults, asserted on the engine the run actually
-    # used: mass-deletion protection stays armed, and the extract stays full.
-    assert factory.engines[0].guardrail_allow_drop is False
-    assert factory.engines[0].force_full_extract is True

--- a/tests/test_execution_surface.py
+++ b/tests/test_execution_surface.py
@@ -1183,7 +1183,9 @@ def test_unconfirmed_apply_is_refused(config_dir: str, cache_root: Path) -> None
     instance = resolve_sync_instance(SYNC_NAME, directory=config_dir)
     factory = _SpyFactory(cache_root=cache_root)
     with pytest.raises(RunValidationError):
-        execute_run(instance, operation="apply", potenda_factory=factory)
+        # Deliberately ill-typed: the apply overload requires a write-ownership boundary, and
+        # this case is about the runtime refusal that stands behind that type-level one.
+        execute_run(instance, operation="apply", potenda_factory=factory)  # ty: ignore[no-matching-overload]
     assert factory.calls == []
 
 

--- a/tests/test_potenda_plan_artifact.py
+++ b/tests/test_potenda_plan_artifact.py
@@ -861,8 +861,13 @@ def test_delete_only_saved_plan_drives_the_execution_result(monkeypatch: pytest.
     assert dict(result.summary) == {"create": 0, "update": 0, "delete": 1}
 
 
-def test_delete_only_serial_sync_reports_the_live_no_change_result(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A derived delete is saved, but default serial sync neither executes nor reports it."""
+def test_delete_only_live_sync_saves_the_delete_and_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A derived delete is saved, and a live sync over that diff executes nothing.
+
+    Driven on the engine directly: the destination-only object reaches the saved plan,
+    while the diff rows a live sync acts on stay empty, so the destination is never
+    asked to synchronize anything.
+    """
     config = build_config(order=["BuiltinTag"])
     run_id = "20260726T1151-de1e7e02"
     destination = destination_with_orphan()
@@ -875,18 +880,17 @@ def test_delete_only_serial_sync_reports_the_live_no_change_result(monkeypatch: 
     )
     pin_extraction_decisions(monkeypatch, [False, False])
 
-    def factory(**_kwargs: object) -> Potenda:
-        return potenda
-
-    result = execute_run(config, operation="sync", confirm_writes=True, potenda_factory=factory)
+    potenda.load_both_sides()
+    live_diff = potenda.diff()
+    potenda.write_plan(live_diff)
+    if live_diff.has_diffs():
+        potenda.sync(diff=live_diff)
     saved_summary = read_saved_plan(sync_name=config.name, run_id=run_id, config=config).summary()
 
     assert saved_summary.total == 1
     assert saved_summary.by_action == {"delete": 1}
     assert destination.sync_calls == []
-    assert result.status == "no-change"
-    assert result.changed is False
-    assert dict(result.summary) == {"create": 0, "update": 0, "delete": 0}
+    assert potenda._diff_to_rows(live_diff) == []
 
 
 # =======================================================================================


### PR DESCRIPTION
## Problem

Unit 1A landed the PostgreSQL apply guard as a reviewed primitive with no production caller. Nothing serialized writes: two managed applies for one configuration could dispatch to the same destination concurrently, a run could accept competing work after it already held a write reservation, and a write interrupted after dispatch left no durable signal that the destination might have changed. The managed path also carried a local filesystem lock, which is a second correctness guard that cannot serialize across hosts.

## Solution

The managed HTTP service now holds the Unit 1A guard across every destination-sensitive step, proves ownership immediately before each dispatch and once after the last, and confirms release before any product success. A write reservation is arbitrated in one store transaction behind the run's own row lock, so the loser stores a `409` and never reaches Prefect. Any failure once a dispatch may have started leaves the run `interrupted`/`ambiguous` with `reconciliation_required=true` and whatever `ApplyRecord` exists, committed together. The filesystem lock is gone rather than kept alongside the guard.

There is no retry, replay, or recovery. One write per run; an uncertain write is reconciled by an operator creating a new plan run. `INFP-650` owns crash-safe apply and governed replay.

```python
# before — the engine applied a plan with nothing proving the caller still owned the write
record = potenda.apply_plan(config_version=version)

# after — ownership is proved before every dispatch, and the completed record
# reaches the failure boundary before the sidecar, release, or product commit
record = potenda.apply_plan(ownership=ownership, config_version=version)
```

## User-visible changes

**API responses**

- `PublicRunResource` and `ProductRun` gain `reconciliation_required` (non-null, `false` by default, never cleared). An operator reads it directly instead of parsing failure evidence.
- `apply-already-admitted` and the `refused-apply-admission` audit outcome are replaced by a generic `409 run-execution-conflict` / `refused-run-execution-conflict`. Two codes for one condition was one mechanism too many.
- Cancelling a claimed write now answers `409 cancellation-ambiguous` and terminalizes the run as ambiguous, instead of acknowledging and waiting for a clean `cancelled`.
- Emitted run and plan resources are recursively bounded: a field the resource does not declare is dropped rather than returned. Client parsers stay forward-compatible, so a newer server can still add fields.

**Behaviour**

- `execute_run(operation="sync")` — the unsupported direct write path — refuses with a specific validation error. It could not prove per-operation ownership over a reviewed artifact, so it is refused rather than kept as a second write mechanism. `infrahub-sync sync` is unaffected: it reaches the Sync API over HTTP.
- A legacy run with no registered configuration binding can no longer write. It names no configuration, so there is no key to serialize it against. Reads still work.
- `apply` requires an explicit write-ownership boundary and completion sink at the type level; `ty` rejects an omission.

**Schema** — `product_runs.reconciliation_required` is added to the clean table definition only. V3 has no production users and development databases are recreated; there is no migration.

## Verification

- `3499 passed, 17 skipped, 1 xfailed, 0 failed`; `pytest -m integration` `50 passed, 16 skipped`, **no PostgreSQL case skipped**.
- Real PostgreSQL 16.15 for every guard and reservation claim, and two live legs on a real preview stack proving two workers serialize on one `config_id` from two different runs — measured from `pg_locks`, not from run outcomes, because two *unrelated* configurations still both succeed on worker start-up stagger alone.
- Every test written after the code it covers was proven by breaking its property and capturing the failure. One test was **deleted** for passing while its property was broken, and one assertion was removed for proving nothing.
- `invoke format`, `invoke lint` (ruff, pylint, yamllint, ty) exit 0; Vale 0/0/0 on five changed prose paths; docs generate and build.

Full evidence, including the mutation table and both review rounds: `opsmill/infrahub-sync-lab` at `.planning/evidence/qualification/ph3-unit-1b/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed write protection to serialize writes for each configuration.
  * Added durable interrupted and ambiguous write outcomes with reconciliation indicators and evidence.
  * Added ownership checks before and after write operations.
  * Added conflict responses when concurrent run stages compete for execution.

* **Bug Fixes**
  * Prevented unsupported composed sync writes from executing.
  * Improved recovery when workers stop during or after a write.

* **Documentation**
  * Documented write admission, reconciliation, execution receipts, and plan-only remote runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->