### PR TITLE
fix: fail closed on unkeyed Infrahub writes

### DIFF
--- a/changelog/+preview-safety.fixed.md
+++ b/changelog/+preview-safety.fixed.md
@@ -1,0 +1,1 @@
+Prevented saved-plan applies from issuing unkeyed Infrahub mutations and prevented declared secret values from appearing in validation diagnostics.

--- a/dev/knowledge/planned-write-and-apply.md
+++ b/dev/knowledge/planned-write-and-apply.md
@@ -110,37 +110,20 @@ Two checks protect the key, and they check different things:
   than the render call's own `"data"` key: `_generate_input_data(...)["data"]` is `{"data": {...}}`, a
   one-key mapping, so a check written against it would fire on every operation ever rendered.
 
-The gate branches on the kind's HFID shape, and the branch is the point:
+The gate applies one invariant to every kind: a render carrying neither `id` nor `hfid` raises
+`UnkeyedWriteRefusedError`, naming the operation and its kind. An unkeyed convergent write duplicates
+its object on a re-apply, and no HFID shape makes that safe.
 
-| HFID shape | Render carries neither `id` nor `hfid` |
-|---|---|
-| **All direct** components | **Raise**, naming the kind — it can only mean the payload lost its identity components, which is always a defect |
-| **Crosses a relationship** | **Warn once per kind** and proceed |
-| **No HFID declared** | **Warn once per kind** and proceed — never raise; for such a kind, unkeyed is a schema fact, not a defect |
+Two shapes cannot render keyed and are therefore unsupported for planned writes:
 
-The relationship-crossing row is not a shrug. The SDK cannot form an `hfid` client-side from a peer
-supplied as a resolved id: rendering a relationship value handed in as a bare id produces `{"id": ...}`
-with no `__typename`, so the store read that would resolve the peer is never attempted. Refusing would
-withdraw the relationship-bearing kinds from what this path supports. The write is issued, and the server
-may still key it: against one live destination, thirteen `InterfacePhysical` upserts rendered unkeyed, were
-issued with the warning, and a second apply of the identical plan produced no duplicate — because that
-kind declares a `device-name` uniqueness constraint the destination resolved the upsert on. That is one
-destination's answer. A relationship-crossing key with no covering uniqueness constraint would still
-duplicate.
+- **A key that crosses a relationship.** The SDK cannot form an `hfid` client-side from a peer supplied
+  as a resolved id: rendering a relationship value handed in as a bare id produces `{"id": ...}` with no
+  `__typename`, so the store read that would resolve the peer is never attempted.
+- **No HFID declared.** There is no convergence key to render.
 
-**So state the guarantee narrowly.** No write is issued whose payload is missing an HFID component, and
-no render is issued unkeyed where being unkeyed can only be a defect. "An unkeyed write is never issued"
-is false, and was struck from three places where it had been written.
-
-The warning is at **warning level** and fires **once per destination kind**, with the dedup set living on
-the adapter instance for the lifetime of the apply. Both properties are pinned rather than described:
-`--quiet` floors the package logger at warning level, so an info-level emission satisfies every prose
-description of the obligation and vanishes for exactly the scripted and CI runs where it is the only
-signal; and once-per-operation would put a line on every row of a large apply. The content names the
-kind, that the write is issued anyway, which of the two conditions applies, and what to watch for. It
-is phrased in the present tense because the gate reads the *rendered* mutation: the warning is emitted
-at step 5b, before the upsert at step 6 and the relationship flush at step 7e, so a past-tense "the
-write was issued" would be claiming a write that has not happened yet and may still fail.
+Apply is sequential, so the guarantee is stated per operation: an operation whose render is unkeyed makes
+zero mutation calls, and no later operation executes. Operations applied before it stay written, and the
+apply record reports them.
 
 ## Peer resolution
 

--- a/dev/knowledge/planned-write-and-apply.md
+++ b/dev/knowledge/planned-write-and-apply.md
@@ -110,16 +110,23 @@ Two checks protect the key, and they check different things:
   than the render call's own `"data"` key: `_generate_input_data(...)["data"]` is `{"data": {...}}`, a
   one-key mapping, so a check written against it would fire on every operation ever rendered.
 
-The gate applies one invariant to every kind: a render carrying neither `id` nor `hfid` raises
+The gate applies one invariant to every kind: a render carrying no **usable** `id` or `hfid` raises
 `UnkeyedWriteRefusedError`, naming the operation and its kind. An unkeyed convergent write duplicates
-its object on a re-apply, and no HFID shape makes that safe.
+its object on a re-apply, and no HFID shape makes that safe. The key has to carry a value rather than
+merely be present, because a present-but-empty key keys nothing at the destination.
 
-Two shapes cannot render keyed and are therefore unsupported for planned writes:
+`hfid` is the only key a planned write can genuinely render. The plan carries no destination UUID —
+FR-012 forbids the load that would supply one — and a payload field named `id` is not a substitute:
+`generate_payload_create` wraps every payload field into an attribute block, so such a field renders
+as an empty `id: {}`. That shape is refused rather than treated as keyed.
+
+Three shapes cannot render a usable key and are therefore unsupported for planned writes:
 
 - **A key that crosses a relationship.** The SDK cannot form an `hfid` client-side from a peer supplied
   as a resolved id: rendering a relationship value handed in as a bare id produces `{"id": ...}` with no
   `__typename`, so the store read that would resolve the peer is never attempted.
 - **No HFID declared.** There is no convergence key to render.
+- **A payload field named `id`.** It renders as `id: {}` — a key with no value.
 
 Apply is sequential, so the guarantee is stated per operation: an operation whose render is unkeyed makes
 zero mutation calls, and no later operation executes. Operations applied before it stay written, and the

--- a/dev/knowledge/schema-mapping.md
+++ b/dev/knowledge/schema-mapping.md
@@ -81,12 +81,13 @@ review because both numbers are real counts of something.
 
 Two practical consequences:
 
-- A kind whose HFID crosses a relationship may not be able to render a client-side `hfid` at all, in
-  which case whether the write converges depends on a destination-side uniqueness constraint covering
-  the components as sent.
-- A kind that declares no HFID is unkeyed as a matter of schema, not as a defect.
+- A kind whose HFID crosses a relationship cannot render a client-side `hfid` at all: the SDK cannot
+  form one from a peer supplied as a resolved node id. Its planned write carries neither `id` nor
+  `hfid` and is refused before it mutates the destination.
+- A kind that declares no HFID has no convergence key to render, so its planned write is refused on
+  the same terms.
 
-Both are handled on the apply path rather than at mapping time; see
+Both are refused by the apply keyedness gate rather than at mapping time; see
 [Planned writes and apply](planned-write-and-apply.md).
 
 ## Filters

--- a/docs/docs/migrating-from-netbox-or-nautobot.mdx
+++ b/docs/docs/migrating-from-netbox-or-nautobot.mdx
@@ -95,8 +95,30 @@ convergent when different sites contain racks with the same name: the
 configuration identifies a rack by `name` and `site`, while the current
 schema-library revision keys it by `name` alone.
 
-To exercise the saved-plan write surface against a live Infrahub, use the two
-qualifications that need no external source system:
+Three live qualifications exercise the saved-plan write surface.
+
+`tests/integration/test_saved_plan_apply_integration.py` runs the full
+NetBox → Infrahub path on a **keyed slice**: `BuiltinTag`, `LocationSite`,
+`LocationRack`, `OrganizationManufacturer`, `DcimPlatform` and `DcimDeviceType`
+are seeded, and `DcimDevice` is the kind under test. Every one declares
+`human_friendly_id: ['name__value']`, so every planned write renders a key. It
+needs the pinned schema library loaded, a NetBox carrying the deterministic
+dataset (sites `site-a`/`site-b`/`site-c`, devices `dev-01`…`dev-40`, tags
+`tag-01`…`tag-10`), and `NETBOX_URL` / `NETBOX_TOKEN` alongside the Infrahub
+variables. **Six tests must pass.** A seventh is optional: SC-016's ambiguous-peer
+half skips when the destination schema admits no genuinely ambiguous peer, which
+is the case on a keyed slice, since every kind is filtered on exactly the
+component its uniqueness constraint pins. The skip message names the constraint
+that establishes it.
+
+**It needs a fresh disposable Infrahub for each run.** The suite writes and does
+not clean up: it perturbs the destination with a per-run canary and then asserts
+the derived plan carries the create, update and delete those perturbations imply.
+A second run against the same instance sees the first run's canary and fails in
+setup. Reset between runs.
+
+Two further qualifications need no source system, only `INFRAHUB_ADDRESS` and
+`INFRAHUB_API_TOKEN`:
 
 - `tests/integration/test_infrahub_replace_set_shrink_integration.py` — keyed
   planned writes, applied and re-applied convergently;
@@ -104,10 +126,8 @@ qualifications that need no external source system:
   operation refused with the destination count unchanged, on a branch the run
   creates and deletes.
 
-Both run with `INFRAHUB_ADDRESS` and `INFRAHUB_API_TOKEN` set. The older
-NetBox-sourced suite in `tests/integration/test_saved_plan_apply_integration.py`
-is skipped: its slice qualifies through relationship-crossing kinds, which this
-contract no longer applies.
+The interface kinds are covered by that refusal rather than by an apply: they are
+the shapes this contract does not write.
 
 :::
 

--- a/docs/docs/migrating-from-netbox-or-nautobot.mdx
+++ b/docs/docs/migrating-from-netbox-or-nautobot.mdx
@@ -121,10 +121,10 @@ Two further qualifications need no source system, only `INFRAHUB_ADDRESS` and
 `INFRAHUB_API_TOKEN`:
 
 - `tests/integration/test_infrahub_replace_set_shrink_integration.py` — keyed
-  planned writes, applied and re-applied convergently;
-- `tests/integration/test_infrahub_unkeyed_refusal_integration.py` — an unkeyed
-  operation refused with the destination count unchanged, on a branch the run
-  creates and deletes.
+  planned writes, applied and re-applied with the same result;
+- `tests/integration/test_infrahub_unkeyed_refusal_integration.py` — an operation
+  without a usable key, refused with the destination count unchanged on a branch
+  the run creates and deletes.
 
 The interface kinds are covered by that refusal rather than by an apply: they are
 the shapes this contract does not write.

--- a/docs/docs/migrating-from-netbox-or-nautobot.mdx
+++ b/docs/docs/migrating-from-netbox-or-nautobot.mdx
@@ -74,22 +74,40 @@ infrahub-sync configs register <package.yml> --reason "register migration"
 infrahub-sync diff --config-id <config-id> --version <version> --reason "review migration"
 ```
 
-:::warning Current NetBox saved-plan limits
+:::warning Saved-plan applies require a keyed destination kind
 
-The current `from-netbox` mapping and schema-library revision cannot apply saved
-`IpamPrefix` or `IpamIPAddress` operations: their plan identities omit the
-`ip_namespace` component required by the destination human-friendly ID. Apply
-refuses the first affected operation and records any earlier writes in
-`run.json`.
+A saved-plan apply converges on the destination kind's `human_friendly_id`. The
+client has to render that key before the write, so two shapes cannot be applied
+and are refused before they touch Infrahub:
 
-`LocationRack` is also not convergent when different sites contain racks with
-the same name. The configuration identifies a rack by `name` and `site`, while
-the current schema-library revision keys it by `name` alone.
+- a kind whose human-friendly ID **crosses a relationship**, because the peer is
+  supplied as a resolved node id and no key can be formed from it; and
+- a kind that **declares no human-friendly ID**, because there is no key to render.
 
-Use the bounded live test in
-`tests/integration/test_saved_plan_apply_integration.py` to exercise the saved-plan
-workflow without those unsupported relationships. Treat the public NetBox demo
-as changing external data: its tokens and named fixture devices can change.
+Apply is sequential: the refused operation writes nothing, operations applied
+before it stay written, and no later operation runs. `run.json` records what was
+applied.
+
+On the current `from-netbox` mapping and schema-library revision this covers
+`IpamPrefix` and `IpamIPAddress`, whose plan identities omit the `ip_namespace`
+component the destination key requires. Separately, `LocationRack` is not
+convergent when different sites contain racks with the same name: the
+configuration identifies a rack by `name` and `site`, while the current
+schema-library revision keys it by `name` alone.
+
+To exercise the saved-plan write surface against a live Infrahub, use the two
+qualifications that need no external source system:
+
+- `tests/integration/test_infrahub_replace_set_shrink_integration.py` — keyed
+  planned writes, applied and re-applied convergently;
+- `tests/integration/test_infrahub_unkeyed_refusal_integration.py` — an unkeyed
+  operation refused with the destination count unchanged, on a branch the run
+  creates and deletes.
+
+Both run with `INFRAHUB_ADDRESS` and `INFRAHUB_API_TOKEN` set. The older
+NetBox-sourced suite in `tests/integration/test_saved_plan_apply_integration.py`
+is skipped: its slice qualifies through relationship-crossing kinds, which this
+contract no longer applies.
 
 :::
 

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -1189,21 +1189,25 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         return data
 
     def _require_keyed_render(self, *, node: InfrahubNodeSync, operation: PlannedOperation) -> None:
-        """Refuse the operation unless the rendered mutation input carries `id` or `hfid`.
+        """Refuse the operation unless the rendered mutation carries a usable `id` or `hfid`.
 
         Keyedness is a property of the rendered mutation rather than of the assembled data, so
         it is read here, immediately before the SDK write. An unkeyed convergent write
         duplicates its object on a re-apply whatever the kind's human-friendly-ID shape is.
 
+        The key must carry a value, not merely be present. Every payload field is rendered as
+        an attribute block, so a field named `id` renders as an empty `id: {}` that the
+        destination can converge on no better than an absent one.
+
         Raises:
-            UnkeyedWriteRefusedError: the rendered mutation carries neither key.
+            UnkeyedWriteRefusedError: the rendered mutation carries no usable key.
         """
         rendered = node._generate_input_data(exclude_hfid=False)["data"]["data"]
-        if "id" in rendered or "hfid" in rendered:
+        if rendered.get("id") or rendered.get("hfid"):
             return
         msg = (
             f"Operation {operation.operation_id!r} for destination kind {operation.kind!r} rendered a "
-            "mutation carrying neither 'id' nor 'hfid', so the convergent write would be unkeyed and a "
+            "mutation carrying no usable 'id' or 'hfid', so the convergent write would be unkeyed and a "
             "re-apply would duplicate the object. The operation was refused before the SDK write and "
             "attempted no destination mutation."
         )

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -772,18 +772,6 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
     # one attempt was exhausted; a string is the resolved DiffSync identity.
     _peer_unique_ids: dict[tuple[str, str], str | None]
 
-    # AD078 — destination kinds whose rendered mutation has already been reported as
-    # unkeyed. The report is once per kind, not once per operation, because
-    # `apply_planned_operation` is entered once per operation and a four-thousand-operation
-    # apply would otherwise emit one line per row. The set is created at the start of an
-    # apply and discarded with it, the same lifetime as `PeerResolver`'s memo — which is why
-    # `new_peer_resolver` allocates it and `__init__` does not: an adapter instance can serve
-    # more than one apply in-process, and a set living for the instance would suppress the
-    # second apply's report of a kind the first already named. `None` is the not-in-an-apply
-    # state, which the report site allocates into for a caller that dispatches an operation
-    # without going through the resolver factory.
-    _unkeyed_render_reported: set[str] | None = None
-
     def __init__(
         self,
         target: str,
@@ -1201,75 +1189,26 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
 
         return data
 
-    def _report_unkeyed_render(self, *, node: InfrahubNodeSync, node_schema: NodeSchemaAPI) -> None:
-        """The keyedness gate: read the rendered mutation input and branch on it (AD066).
+    def _require_keyed_render(self, *, node: InfrahubNodeSync, operation: PlannedOperation) -> None:
+        """Refuse the operation unless the rendered mutation input carries `id` or `hfid`.
 
-        Keyedness is a property of the **rendered mutation**, not of the assembled data: the
-        SDK keys the upsert on `data["id"]` if the node has one and otherwise on
-        `data["hfid"]`, and `get_human_friendly_id()` returns `None` as soon as any component
-        resolves to `None`. All of that is client-side, so the render is readable before the
-        write is issued.
-
-        **The render is read two levels deep (AD076).** `_generate_input_data` returns
-        `{"data": mutation_payload, "variables": …, "mutation_variables": …}` where
-        `mutation_payload` is itself `{"data": data}` — so a check against `…["data"]` alone
-        tests a one-key mapping, is true for every operation ever rendered, and would make
-        the raising arm below fire on all of them.
-
-        Three arms, by the destination kind's HFID shape:
-
-        - **all components direct** — a render carrying neither key can only mean the payload
-          lost its identity components, so it **raises**;
-        - **a component crosses a relationship** — the render carries neither key today for a
-          reason this outcome does not control (the SDK cannot form the `hfid` from a peer
-          supplied as a resolved node id), so it **warns once per kind and proceeds**;
-          refusing would withdraw every relationship-bearing kind from what planned apply
-          delivers, and the destination's convergent write may still key server-side;
-        - **no HFID declared at all** — unkeyed is a schema fact rather than a defect, and
-          FR-024 explicitly permits such a kind and requires the run to survive it, so it
-          **warns on the same terms and never raises (AD076)**.
+        Keyedness is a property of the rendered mutation rather than of the assembled data, so
+        it is read here, immediately before the SDK write. An unkeyed convergent write
+        duplicates its object on a re-apply whatever the kind's human-friendly-ID shape is.
 
         Raises:
-            UnkeyedWriteRefusedError: the render is unkeyed for an all-direct HFID kind.
+            UnkeyedWriteRefusedError: the rendered mutation carries neither key.
         """
         rendered = node._generate_input_data(exclude_hfid=False)["data"]["data"]
         if "id" in rendered or "hfid" in rendered:
             return
-
-        kind = node_schema.kind
-        components = _hfid_components(node_schema)
-
-        if components and all(len(_component_segments(component)) == 1 for component in components):
-            msg = (
-                f"The mutation rendered for kind {kind!r} carries neither 'id' nor 'hfid', so the "
-                f"convergent write would be unkeyed and a re-apply would duplicate the object. Every "
-                f"human-friendly-ID component of that kind ({', '.join(components)}) is a direct "
-                f"attribute, so this can only mean the operation's payload lost its identity components."
-            )
-            raise UnkeyedWriteRefusedError(msg)
-
-        condition = (
-            "the kind declares no human-friendly ID, so there is no convergence key to render"
-            if not components
-            else f"the kind's convergence key crosses a relationship ({', '.join(components)}), which the "
-            "client cannot render from a peer supplied as a resolved node id"
+        msg = (
+            f"Operation {operation.operation_id!r} for destination kind {operation.kind!r} rendered a "
+            "mutation carrying neither 'id' nor 'hfid', so the convergent write would be unkeyed and a "
+            "re-apply would duplicate the object. The operation was refused before the SDK write and "
+            "attempted no destination mutation."
         )
-        # Allocated by `new_peer_resolver` at an apply's start (AD078). The fallback covers a
-        # caller that dispatches without asking for a resolver first: it still deduplicates.
-        reported = self._unkeyed_render_reported
-        if reported is None:
-            reported = self._unkeyed_render_reported = set()
-        if kind in reported:
-            return
-        reported.add(kind)
-        logger.warning(
-            "Planned write: the mutation rendered for destination kind %s carries neither 'id' nor "
-            "'hfid' because %s. The write is issued anyway. Watch for a duplicate object of kind %s at "
-            "the destination if it does not key on the identity components as sent.",
-            kind,
-            condition,
-            kind,
-        )
+        raise UnkeyedWriteRefusedError(msg)
 
     def new_peer_resolver(self) -> PeerResolver:
         """Build the peer resolver for one apply (FR-014, AD086).
@@ -1280,11 +1219,8 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         resolver's dependency is the one that builds it.
 
         One resolver per apply, created at its start and discarded with it — never persisted,
-        never shared between applies. The keyedness report's dedup set is allocated here for
-        the same reason (AD078): its contract is "once per destination kind **per apply**",
-        and on an adapter instance it would silence every disclosure on a second apply.
+        never shared between applies.
         """
-        self._unkeyed_render_reported = set()
         return PeerResolver(self)
 
     def apply_planned_operation(self, *, operation: PlannedOperation, peers: PeerResolver) -> str:
@@ -1308,7 +1244,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
 
         Two checks sit before the write and they are different checks (AD066): the
         per-component **diagnostic** below, which names *which* human-friendly-ID component
-        is unaccounted for, and `_report_unkeyed_render`'s **gate** on the rendered mutation.
+        is unaccounted for, and `_require_keyed_render`'s **gate** on the rendered mutation.
 
         The write is not the last destination interaction: every cardinality-many
         relationship is then written explicitly as a replace-set by a single targeted
@@ -1320,8 +1256,8 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
                 limitation, not a failure), and no skip is recorded — see above.
             UnaccountedIdentityComponentError: a human-friendly-ID component of the
                 destination kind is not accounted for by the payload and the operation.
-            UnkeyedWriteRefusedError: the rendered mutation is unkeyed for a kind whose
-                human-friendly ID is all-direct.
+            UnkeyedWriteRefusedError: the rendered mutation carries neither 'id' nor
+                'hfid', so no destination mutation was attempted for it.
             NullRelationshipValueError: a mandatory cardinality-one relationship is null
                 in the planned payload.
             PeerNotFoundError: a peer identity matches no destination object.
@@ -1404,7 +1340,7 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
             schema=node_schema, data=data, source=source_id, owner=owner_id, is_protected=True
         )
         node = self.client.create(kind=operation.kind, data=create_data)
-        self._report_unkeyed_render(node=node, node_schema=node_schema)
+        self._require_keyed_render(node=node, operation=operation)
         node.save(allow_upsert=True)
 
         # Every cardinality-many relationship is written explicitly as a replace-set rather
@@ -1434,8 +1370,8 @@ class InfrahubAdapter(DiffSyncMixin, Adapter):
         changed since. It is the only check that can say *which* component is missing, which
         is why it is kept alongside the rendered-mutation gate rather than replaced by it.
 
-        A kind that declares no human-friendly ID has no components and so passes here; that
-        case is the gate's third arm (AD076).
+        A kind that declares no human-friendly ID has no components and so passes here; the
+        rendered-mutation gate is what refuses it.
 
         Raises:
             UnaccountedIdentityComponentError: naming the kind and the missing components.

--- a/infrahub_sync/adapters/infrahub.py
+++ b/infrahub_sync/adapters/infrahub.py
@@ -449,9 +449,8 @@ class PeerResolver:
         # The canonical identity is unhashable, so the memo key carries its canonical JSON
         # encoding — the same normalization the operation identifier hashes (FR-028.3).
         self._memo: dict[tuple[str, bytes], str] = {}
-        # Kinds whose partial filter has been warned about, once per kind per apply — the
-        # same lifetime rule as the adapter's unkeyed-render report (AD078), and it holds
-        # here for the same reason: the resolver lives for exactly one apply.
+        # Kinds whose partial filter has been warned about, once per kind per apply: the
+        # resolver lives for exactly one apply, so the set does too.
         self._partial_filter_reported: set[str] = set()
 
     @staticmethod

--- a/infrahub_sync/configuration/credentials.py
+++ b/infrahub_sync/configuration/credentials.py
@@ -15,10 +15,10 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
-from .models import is_renderable_setting_path, safe_pointer_component
+from .models import REDACTED, is_renderable_setting_path, safe_pointer_component
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Mapping, Sequence
 
     from .models import ConfigurationPackage, CredentialReference
 
@@ -93,6 +93,18 @@ def _bounded_component(name: object) -> str:
     return safe_pointer_component(text)
 
 
+def _rendered_component(name: object, secrets: Sequence[str]) -> str:
+    """Render one caller-declared key, replacing it whole when it carries a collected value.
+
+    Redaction happens on the complete key, before the bound below cuts it: whole-value
+    matching at a later boundary cannot find a 64-character prefix of a longer secret.
+    """
+    text = str(name)
+    if any(secret in text for secret in secrets):
+        return REDACTED
+    return _bounded_component(text)
+
+
 def _bounded_location(location: str) -> str:
     """Bound one accumulated pointer so nesting depth cannot grow the message."""
     if len(location) <= _MAX_DIAGNOSTIC_LOCATION_LENGTH:
@@ -100,9 +112,9 @@ def _bounded_location(location: str) -> str:
     return location[:_MAX_DIAGNOSTIC_LOCATION_LENGTH] + _TRUNCATION_MARKER
 
 
-def _render_setting_name_list(names: Iterable[str]) -> str:
+def _render_setting_name_list(names: Iterable[str], secrets: Sequence[str] = ()) -> str:
     """Render bounded escaped setting names with unambiguous, JSON-decodable boundaries."""
-    escaped_names = sorted(_bounded_component(name) for name in names)
+    escaped_names = sorted(_rendered_component(name, secrets) for name in names)
     listed = escaped_names[:_MAX_DIAGNOSTIC_NAME_ENTRIES]
     rendered = json.dumps(listed, ensure_ascii=True)
     omitted = len(escaped_names) - len(listed)

--- a/infrahub_sync/configuration/models.py
+++ b/infrahub_sync/configuration/models.py
@@ -58,6 +58,9 @@ _MAX_CONTEXT_STRING_LENGTH = 256
 _MAX_CONTEXT_INTEGER = 2**63 - 1
 # Findings are rendered straight into a raised message, so they carry the same bound.
 _MAX_FINDING_TEXT_LENGTH = 256
+# What replaces a collected secret wherever one is removed. Held here because both the
+# finding producer and the boundaries that redact its output need the same token.
+REDACTED = "***"
 _UNSUPPORTED_DECLARED_FIELDS_ERROR = "unsupported_declared_fields"
 _INVALID_UNICODE_SURROGATE_ERROR = "invalid_unicode_surrogate"
 _INVALID_JSON_VALUE_ERROR = "invalid_json_value"

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -591,7 +591,10 @@ def _accumulate_store(
             _accumulated(
                 code=_CODE_MISSING_STORE_CAPABILITIES,
                 location="/configuration/store",
-                message=f"store type {store.type!r} has no configuration capability declaration",
+                message=(
+                    f"store type {_rendered_component(store.type, secrets)!r} has no configuration "
+                    "capability declaration"
+                ),
             )
         ]
     prefix = "/configuration/store/settings"
@@ -600,7 +603,7 @@ def _accumulate_store(
         allowed_settings=capabilities.allowed_settings,
         prefix=prefix,
         render=lambda names: (
-            f"store type {store.type!r} contains unsupported declared settings: "
+            f"store type {_rendered_component(store.type, secrets)!r} contains unsupported declared settings: "
             f"{_render_setting_name_list(names, secrets)}"
         ),
         owned_locations=owned_locations,
@@ -701,7 +704,10 @@ def _accumulate(package: ConfigurationPackage, secrets: Sequence[str] = ()) -> t
                         _accumulated(
                             code=_CODE_MISSING_ADAPTER,
                             location=f"/configuration/{role}",
-                            message=f"adapter {adapter.name!r} has no configuration capability declaration",
+                            message=(
+                                f"adapter {_rendered_component(adapter.name, secrets)!r} has no configuration "
+                                "capability declaration"
+                            ),
                         )
                     ],
                 )

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -264,7 +264,8 @@ def _accumulate_reference_declarations(
                     location=location,
                     unbounded_location=unbounded,
                     message=(
-                        f"credential reference {name!r} uses provider {reference.provider!r}, which is not installed"
+                        f"credential reference {_rendered_component(name, secrets)!r} uses provider "
+                        f"{_rendered_component(reference.provider, secrets)!r}, which is not installed"
                     ),
                 )
             )
@@ -274,7 +275,10 @@ def _accumulate_reference_declarations(
                     code=_CODE_MALFORMED_CREDENTIAL_REFERENCE,
                     location=location,
                     unbounded_location=unbounded,
-                    message=f"credential reference {name!r} has an invalid environment identifier",
+                    message=(
+                        f"credential reference {_rendered_component(name, secrets)!r} has an invalid "
+                        "environment identifier"
+                    ),
                 )
             )
     return accumulated
@@ -323,6 +327,7 @@ def _accumulate_reference_node(
     *,
     location: str,
     unbounded_location: str,
+    secrets: Sequence[str],
 ) -> list[_AccumulatedFinding]:
     """Validate one node at a declared credential-bearing setting path."""
     if not isinstance(value, Mapping) or "$credential" not in value:
@@ -351,7 +356,10 @@ def _accumulate_reference_node(
                 code=_CODE_UNKNOWN_CREDENTIAL_REFERENCE,
                 location=location,
                 unbounded_location=unbounded_location,
-                message=f"{location} names unknown credential reference {node.reference_name!r}",
+                message=(
+                    f"{location} names unknown credential reference "
+                    f"{_rendered_component(node.reference_name, secrets)!r}"
+                ),
             )
         ]
     return []
@@ -380,6 +388,7 @@ def _accumulate_credential_paths(
                 value,
                 location=_settings_pointer(prefix, path, secrets),
                 unbounded_location=unbounded,
+                secrets=secrets,
             )
         )
     return accumulated
@@ -469,12 +478,16 @@ def _contained_validator_failure(
     *,
     role: AdapterRole,
     detail: str,
+    secrets: Sequence[str],
 ) -> _AccumulatedFinding:
     """Report a validator that failed, without carrying anything the validator said."""
     return _accumulated(
         code=_CODE_ADAPTER_VALIDATOR_FINDING,
         location=f"/configuration/{role}",
-        message=f"adapter {adapter_name!r} configuration validator {detail} for the {role} role",
+        message=(
+            f"adapter {_rendered_component(adapter_name, secrets)!r} configuration validator {detail} "
+            f"for the {role} role"
+        ),
     )
 
 
@@ -483,6 +496,7 @@ def _accumulate_adapter_validator(
     capabilities: AdapterConfigurationCapabilities,
     *,
     role: AdapterRole,
+    secrets: Sequence[str],
 ) -> list[_AccumulatedFinding]:
     """Run one adapter-owned validator, keeping its own codes and locations."""
     validator = capabilities.validator
@@ -503,7 +517,7 @@ def _accumulate_adapter_validator(
         # Past the call, anything that goes wrong is about what came back, not about the run.
         detail = "returned an unsupported result"
         if not _is_finding_sequence(result):
-            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail, secrets=secrets)]
         findings = sort_findings([_revalidated_finding(item) for item in result])
         permitted = (f"/configuration/{role}", *_ROLE_INDEPENDENT_VALIDATOR_PREFIXES)
         if not all(_is_within(item.location, permitted) for item in findings):
@@ -512,11 +526,11 @@ def _accumulate_adapter_validator(
             # in the other role's subtree, the store's, or the credential declarations would
             # delete the core's own finding there — including a credential-safety one. That
             # is not precedence being wrong; it is a finding with no standing at that pointer.
-            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+            return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail, secrets=secrets)]
         legacy_message = "; ".join(f"{_bounded_location(item.location)}: {item.message}" for item in findings)
     # A third-party validator may raise anything at all; containing it is the contract.
     except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail)]
+        return [_contained_validator_failure(capabilities.adapter_name, role=role, detail=detail, secrets=secrets)]
     # One adapter can serve both roles, and a validator that cannot tell them apart reports the
     # same package-level defect twice. Which of the two survives is decided at the presentation
     # boundary, never here: the wrapper's message is element zero of this list.
@@ -539,7 +553,10 @@ def _accumulate_adapter(
             _accumulated(
                 code=_CODE_ADAPTER_ROLE_MISMATCH,
                 location=f"/configuration/{role}",
-                message=f"adapter {capabilities.adapter_name!r} does not support the {role} role",
+                message=(
+                    f"adapter {_rendered_component(capabilities.adapter_name, secrets)!r} does not support "
+                    f"the {role} role"
+                ),
             )
         )
     prefix = f"/configuration/{role}/settings"
@@ -549,7 +566,8 @@ def _accumulate_adapter(
             allowed_settings=capabilities.allowed_settings,
             prefix=prefix,
             render=lambda names: (
-                f"adapter {capabilities.adapter_name!r} contains unsupported declared settings "
+                f"adapter {_rendered_component(capabilities.adapter_name, secrets)!r} contains unsupported "
+                "declared settings "
                 f"for the {role} role: {_render_setting_name_list(names, secrets)}"
             ),
             owned_locations=owned_locations,
@@ -563,7 +581,7 @@ def _accumulate_adapter(
         location = _settings_pointer(prefix, setting_name, secrets)
         owned_locations.append(_unbounded_settings_pointer(prefix, setting_name))
         accumulated.extend(_accumulate_url_setting(value, setting_name=setting_name, location=location))
-    accumulated.extend(_accumulate_adapter_validator(package, capabilities, role=role))
+    accumulated.extend(_accumulate_adapter_validator(package, capabilities, role=role, secrets=secrets))
     paths = capabilities.credential_setting_paths
     accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations, secrets=secrets))
     return accumulated

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -29,9 +29,11 @@ from .credentials import (
     _bounded_component,
     _bounded_location,
     _render_setting_name_list,
+    _rendered_component,
 )
 from .models import (
     _MAX_FINDING_TEXT_LENGTH,
+    REDACTED,
     ConfigurationPackage,
     CredentialReferenceNode,
     ValidationFinding,
@@ -153,8 +155,11 @@ def _finding_location(location: str, unbounded_location: str | None = None) -> s
     """
     safe = location.replace(_TRUNCATION_MARKER, _LOCATION_TRUNCATION_MARKER)
     # "~2" survives escaping only as a truncation marker, so its presence means a declared key
-    # was cut; an over-long pointer is the other bound. Either way information was dropped.
-    if _TRUNCATION_MARKER not in location and len(safe) <= _MAX_FINDING_TEXT_LENGTH:
+    # was cut; a redacted component is the second lossy transform and an over-long pointer the
+    # third bound. Either way information was dropped, and two distinct pointers must not
+    # collapse onto one.
+    lossy = _TRUNCATION_MARKER in location or REDACTED in location
+    if not lossy and len(safe) <= _MAX_FINDING_TEXT_LENGTH:
         return safe
     return _marked_location(safe, location if unbounded_location is None else unbounded_location)
 
@@ -231,12 +236,14 @@ def _settings_pointer(prefix: str, path: str) -> str:
     return prefix + "".join(f"/{_bounded_component(component)}" for component in path.split("."))
 
 
-def _accumulate_reference_declarations(package: ConfigurationPackage) -> list[_AccumulatedFinding]:
+def _accumulate_reference_declarations(
+    package: ConfigurationPackage, secrets: Sequence[str]
+) -> list[_AccumulatedFinding]:
     """Validate provider names and identifiers without resolving credential values."""
     accumulated: list[_AccumulatedFinding] = []
     # Insertion order, not sorted: it decides which defect the wrapper reports.
     for name, reference in package.credentials.items():
-        location = f"/credentials/{_bounded_component(name)}"
+        location = f"/credentials/{_rendered_component(name, secrets)}"
         unbounded = f"/credentials/{_unbounded_component(name)}"
         if reference.provider != "env":
             accumulated.append(
@@ -268,6 +275,7 @@ def _accumulate_undeclared_settings(
     prefix: str,
     render: Callable[[Iterable[str]], str],
     owned_locations: list[str],
+    secrets: Sequence[str],
 ) -> list[_AccumulatedFinding]:
     """Report one finding per undeclared name, so N undeclared settings give N findings.
 
@@ -283,13 +291,13 @@ def _accumulate_undeclared_settings(
     legacy_message = render(unsupported)
     accumulated: list[_AccumulatedFinding] = []
     for name in sorted(unsupported):
-        location = f"{prefix}/{_bounded_component(name)}"
-        owned_locations.append(location)
+        unbounded = f"{prefix}/{_unbounded_component(name)}"
+        owned_locations.append(unbounded)
         accumulated.append(
             _accumulated(
                 code=_CODE_UNDECLARED_SETTING,
-                location=location,
-                unbounded_location=f"{prefix}/{_unbounded_component(name)}",
+                location=f"{prefix}/{_rendered_component(name, secrets)}",
+                unbounded_location=unbounded,
                 message=render({name}),
                 legacy_message=legacy_message,
             )
@@ -497,6 +505,7 @@ def _accumulate_adapter(
     role: AdapterRole,
     settings: Mapping[str, object],
     owned_locations: list[str],
+    secrets: Sequence[str],
 ) -> list[_AccumulatedFinding]:
     """Run every check a declared adapter surface supports, in the shipped order."""
     accumulated: list[_AccumulatedFinding] = []
@@ -516,9 +525,10 @@ def _accumulate_adapter(
             prefix=prefix,
             render=lambda names: (
                 f"adapter {capabilities.adapter_name!r} contains unsupported declared settings "
-                f"for the {role} role: {_render_setting_name_list(names)}"
+                f"for the {role} role: {_render_setting_name_list(names, secrets)}"
             ),
             owned_locations=owned_locations,
+            secrets=secrets,
         )
     )
     for setting_name in sorted(capabilities.allowed_settings & _URL_SETTING_NAMES):
@@ -534,7 +544,9 @@ def _accumulate_adapter(
     return accumulated
 
 
-def _accumulate_store(package: ConfigurationPackage, owned_locations: list[str]) -> list[_AccumulatedFinding]:
+def _accumulate_store(
+    package: ConfigurationPackage, owned_locations: list[str], secrets: Sequence[str]
+) -> list[_AccumulatedFinding]:
     """Refuse inline values and undeclared names at the declared store surface."""
     store = package.configuration.store
     if store is None:
@@ -563,9 +575,11 @@ def _accumulate_store(package: ConfigurationPackage, owned_locations: list[str])
         allowed_settings=capabilities.allowed_settings,
         prefix=prefix,
         render=lambda names: (
-            f"store type {store.type!r} contains unsupported declared settings: {_render_setting_name_list(names)}"
+            f"store type {store.type!r} contains unsupported declared settings: "
+            f"{_render_setting_name_list(names, secrets)}"
         ),
         owned_locations=owned_locations,
+        secrets=secrets,
     )
     paths = capabilities.credential_setting_paths
     accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations))
@@ -584,6 +598,7 @@ def _accumulate_reference_nodes(
     unbounded_location: str,
     owned_locations: tuple[str, ...],
     accumulated: list[_AccumulatedFinding],
+    secrets: Sequence[str],
 ) -> None:
     """Report every use of the reserved ``$credential`` key no surface check has authority over.
 
@@ -591,10 +606,14 @@ def _accumulate_reference_nodes(
     owned pointer belongs to a defect that check already reported — or sits in a subtree no
     surface exists to judge. Reporting it here would give one defect a second, vaguer finding
     at a deeper pointer.
+
+    Ownership is decided on the **unbounded** pointer. Truncation and redaction both map
+    distinct declared keys onto one rendered component, and a check that owned a rendered
+    pointer would prune an unrelated node that merely renders the same way.
     """
     # The one question, asked once per node. Pruning here rather than at the "$credential"
     # test below is the same answer: every descendant of an owned pointer is within it too.
-    if _is_within(location, owned_locations):
+    if _is_within(unbounded_location, owned_locations):
         return
     if isinstance(value, Mapping):
         if "$credential" in value:
@@ -611,10 +630,11 @@ def _accumulate_reference_nodes(
         for key, item in value.items():
             _accumulate_reference_nodes(
                 item,
-                location=f"{location}/{_bounded_component(key)}",
+                location=f"{location}/{_rendered_component(key, secrets)}",
                 unbounded_location=f"{unbounded_location}/{_unbounded_component(key)}",
                 owned_locations=owned_locations,
                 accumulated=accumulated,
+                secrets=secrets,
             )
     elif isinstance(value, list):
         for index, item in enumerate(value):
@@ -624,18 +644,19 @@ def _accumulate_reference_nodes(
                 unbounded_location=f"{unbounded_location}/{index}",
                 owned_locations=owned_locations,
                 accumulated=accumulated,
+                secrets=secrets,
             )
 
 
-def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...]:
+def _accumulate(package: ConfigurationPackage, secrets: Sequence[str] = ()) -> tuple[_AccumulatedFinding, ...]:
     """Run every check in the shipped execution order, never raising for a declared defect."""
     accumulated: list[_AccumulatedFinding] = []
-    # Every pointer a surface check has authority over. A check appends the setting it judged,
-    # and a surface that turns out not to exist appends its whole settings subtree — the case
-    # where a check could not judge. The walk below reports nowhere within them.
+    # Every unbounded pointer a surface check has authority over. A check appends the setting
+    # it judged, and a surface that turns out not to exist appends its whole settings subtree —
+    # the case where a check could not judge. The walk below reports nowhere within them.
     owned_locations: list[str] = []
-    accumulated.extend(_from_check(_CHECK_CREDENTIALS, _accumulate_reference_declarations(package)))
-    accumulated.extend(_from_check(_CHECK_STORE, _accumulate_store(package, owned_locations)))
+    accumulated.extend(_from_check(_CHECK_CREDENTIALS, _accumulate_reference_declarations(package, secrets)))
+    accumulated.extend(_from_check(_CHECK_STORE, _accumulate_store(package, owned_locations, secrets)))
     source = package.configuration.source
     destination = package.configuration.destination
     source_capabilities = BUILTIN_ADAPTER_CAPABILITIES.get(source.name)
@@ -671,6 +692,7 @@ def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...
                     role=role,
                     settings=adapter.settings or {},
                     owned_locations=owned_locations,
+                    secrets=secrets,
                 ),
             )
         )
@@ -683,6 +705,7 @@ def _accumulate(package: ConfigurationPackage) -> tuple[_AccumulatedFinding, ...
         unbounded_location="",
         owned_locations=tuple(owned_locations),
         accumulated=walked,
+        secrets=secrets,
     )
     accumulated.extend(_from_check(_CHECK_WALK, walked))
     # The warning families run last, appended after the shipped execution order, so a
@@ -715,8 +738,12 @@ def _one_check_per_location(accumulated: tuple[_AccumulatedFinding, ...]) -> lis
     return kept
 
 
-def collect_findings(package: ConfigurationPackage) -> tuple[ValidationFinding, ...]:
+def collect_findings(package: ConfigurationPackage, secrets: Sequence[str] = ()) -> tuple[ValidationFinding, ...]:
     """Return every declared defect as a finding, in the stable cross-interface order.
+
+    ``secrets`` are the collected values a caller-declared key must not disclose. They are
+    read here and never stored: a key carrying one is replaced whole before the length
+    bounds cut it, which is the only point at which the complete key is still available.
 
     Bounded at 256. Accumulation itself never stops early, because truncating in execution
     order would make the surviving findings depend on the order the defects were declared in;
@@ -728,7 +755,7 @@ def collect_findings(package: ConfigurationPackage) -> tuple[ValidationFinding, 
     # sort_findings orders by (location, severity, code), and _one_check_per_location has
     # already made (code, location) unique, so no two findings can tie there. Uniqueness is
     # structural, which is why nothing breaks a tie before the cut below.
-    findings = sort_findings(_one_check_per_location(_accumulate(package)))
+    findings = sort_findings(_one_check_per_location(_accumulate(package, secrets)))
     if len(findings) <= _MAX_REPORTED_FINDINGS:
         return findings
     suppressed = findings[_MAX_REPORTED_FINDINGS:]

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -761,7 +761,7 @@ def _accumulate(package: ConfigurationPackage, secrets: Sequence[str] = ()) -> t
     # package carrying any legacy defect keeps its shipped first-error message at the
     # wrapper. Warnings before an error here are what the wrapper's first-*error* rule
     # exists for.
-    accumulated.extend(_from_module(_CHECK_OMISSIONS, accumulate_intentional_omissions(package)))
+    accumulated.extend(_from_module(_CHECK_OMISSIONS, accumulate_intentional_omissions(package, secrets)))
     accumulated.extend(_from_module(_CHECK_OPTIONAL_FEATURES, accumulate_unqualified_optional_features(package)))
     return tuple(accumulated)
 

--- a/infrahub_sync/configuration/validation.py
+++ b/infrahub_sync/configuration/validation.py
@@ -26,7 +26,6 @@ from .credentials import (
     _STORE_CAPABILITIES,
     _TRUNCATION_MARKER,
     CredentialConfigurationError,
-    _bounded_component,
     _bounded_location,
     _render_setting_name_list,
     _rendered_component,
@@ -226,14 +225,27 @@ def _setting_at_path(settings: Mapping[str, object], path: str) -> tuple[bool, o
     return True, current
 
 
-def _settings_pointer(prefix: str, path: str) -> str:
+def _settings_pointer(prefix: str, path: str, secrets: Sequence[str] = ()) -> str:
     """Build one settings pointer the same way the declared-content walk builds it.
 
     The only place a declared setting path becomes a pointer. An owned location and the walk
     must produce byte-identical strings, or a reference is accepted by one check and refused
     by the next; a second formatter is how that divergence gets reintroduced.
+
+    A declared path is caller-influenced content like any other: redaction happens per
+    component here, before the pointer is assembled and before any bound cuts it, because a
+    bound that cuts through an unredacted component leaves a prefix nothing downstream matches.
     """
-    return prefix + "".join(f"/{_bounded_component(component)}" for component in path.split("."))
+    return prefix + "".join(f"/{_rendered_component(component, secrets)}" for component in path.split("."))
+
+
+def _unbounded_settings_pointer(prefix: str, path: str) -> str:
+    """The same pointer with nothing redacted and nothing bounded.
+
+    Ownership and the location digest are both decided on this form: two paths that redact or
+    truncate onto one rendered pointer are still distinct settings.
+    """
+    return prefix + "".join(f"/{_unbounded_component(component)}" for component in path.split("."))
 
 
 def _accumulate_reference_declarations(
@@ -310,6 +322,7 @@ def _accumulate_reference_node(
     value: object,
     *,
     location: str,
+    unbounded_location: str,
 ) -> list[_AccumulatedFinding]:
     """Validate one node at a declared credential-bearing setting path."""
     if not isinstance(value, Mapping) or "$credential" not in value:
@@ -317,6 +330,7 @@ def _accumulate_reference_node(
             _accumulated(
                 code=_CODE_INLINE_CREDENTIAL_VALUE,
                 location=location,
+                unbounded_location=unbounded_location,
                 message=f"{location} contains an inline credential value",
             )
         ]
@@ -327,6 +341,7 @@ def _accumulate_reference_node(
             _accumulated(
                 code=_CODE_MALFORMED_CREDENTIAL_REFERENCE,
                 location=location,
+                unbounded_location=unbounded_location,
                 message=f"{location} contains a malformed credential reference",
             )
         ]
@@ -335,6 +350,7 @@ def _accumulate_reference_node(
             _accumulated(
                 code=_CODE_UNKNOWN_CREDENTIAL_REFERENCE,
                 location=location,
+                unbounded_location=unbounded_location,
                 message=f"{location} names unknown credential reference {node.reference_name!r}",
             )
         ]
@@ -347,6 +363,8 @@ def _accumulate_credential_paths(
     paths: tuple[str, ...],
     prefix: str,
     owned_locations: list[str],
+    *,
+    secrets: Sequence[str],
 ) -> list[_AccumulatedFinding]:
     """Judge every declared credential-bearing path present in these settings, and own it."""
     accumulated: list[_AccumulatedFinding] = []
@@ -354,9 +372,16 @@ def _accumulate_credential_paths(
         present, value = _setting_at_path(settings, path)
         if not present or value is None:
             continue
-        location = _settings_pointer(prefix, path)
-        owned_locations.append(location)
-        accumulated.extend(_accumulate_reference_node(package, value, location=location))
+        unbounded = _unbounded_settings_pointer(prefix, path)
+        owned_locations.append(unbounded)
+        accumulated.extend(
+            _accumulate_reference_node(
+                package,
+                value,
+                location=_settings_pointer(prefix, path, secrets),
+                unbounded_location=unbounded,
+            )
+        )
     return accumulated
 
 
@@ -535,12 +560,12 @@ def _accumulate_adapter(
         value = settings.get(setting_name)
         if value is None:
             continue
-        location = _settings_pointer(prefix, setting_name)
-        owned_locations.append(location)
+        location = _settings_pointer(prefix, setting_name, secrets)
+        owned_locations.append(_unbounded_settings_pointer(prefix, setting_name))
         accumulated.extend(_accumulate_url_setting(value, setting_name=setting_name, location=location))
     accumulated.extend(_accumulate_adapter_validator(package, capabilities, role=role))
     paths = capabilities.credential_setting_paths
-    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations))
+    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations, secrets=secrets))
     return accumulated
 
 
@@ -582,7 +607,7 @@ def _accumulate_store(
         secrets=secrets,
     )
     paths = capabilities.credential_setting_paths
-    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations))
+    accumulated.extend(_accumulate_credential_paths(package, settings, paths, prefix, owned_locations, secrets=secrets))
     return accumulated
 
 

--- a/infrahub_sync/configuration/warnings.py
+++ b/infrahub_sync/configuration/warnings.py
@@ -23,10 +23,14 @@ needed to determine safety is an error, not a warning — so this family reports
 where that error already owns the role.
 
 Messages are fixed templates. The only declared content that reaches one is the omission
-``reason``, verbatim: its model bound keeps template plus reason inside the finding-text
-limit, so nothing here needs the core's message truncation. Locations are fixed literals
-and list indices, never declared keys, so nothing here needs the core's pointer bounding
-either.
+``reason``, and it is replaced whole when it carries a collected value, before the finding
+is built. That ordering is the point: ``ValidationFinding`` declares
+``str_strip_whitespace``, so a reason ending in whitespace is stored one character shorter
+than it was declared, and a whole-value match at any later boundary would then look for a
+string the message no longer contains. Its model bound keeps template plus reason inside
+the finding-text limit, so nothing here needs the core's message truncation. Locations are
+fixed literals and list indices, never declared keys, so nothing here needs the core's
+pointer bounding either.
 """
 
 from __future__ import annotations
@@ -34,10 +38,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .capabilities import BUILTIN_ADAPTER_CAPABILITIES
-from .models import ConfigurationPackage, ValidationFinding
+from .models import REDACTED, ConfigurationPackage, ValidationFinding
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
     from .models import _OmissionDeclaration
 
@@ -72,11 +76,31 @@ def _contradicts(omission: _OmissionDeclaration, mapped: Mapping[str, frozenset[
     return any(field_name in mapped_fields for field_name in omission.fields)
 
 
-def accumulate_intentional_omissions(package: ConfigurationPackage) -> tuple[ValidationFinding, ...]:
+def _redacted_reason(reason: str | None, secrets: Sequence[str]) -> str | None:
+    """Replace a declared reason whole when it carries a collected value.
+
+    The same rule the declared-key renderer applies, on free text rather than on a pointer
+    component: no escaping and no length bound, because a reason is prose the model already
+    bounds and the pointer escaping would rewrite it. Replacing it *whole* here is what makes
+    the later whole-value boundaries able to agree with this one — the model stores a stripped
+    copy of what it is given, so a secret still present at that point is one no whole-value
+    match can find afterwards.
+    """
+    if reason is None:
+        return None
+    return REDACTED if any(secret in reason for secret in secrets) else reason
+
+
+def accumulate_intentional_omissions(
+    package: ConfigurationPackage, secrets: Sequence[str] = ()
+) -> tuple[ValidationFinding, ...]:
     """Report each declared omission at its declaration: a warning, or the contradiction error.
 
     Declaration order, matching the core's insertion-order rule: when a contradiction is
     the first error in execution order, its position here decides what the wrapper raises.
+
+    ``secrets`` are the collected values the reason must not disclose. The reason is replaced
+    whole before the finding is constructed, because the model normalizes what it stores.
     """
     mapped = _mapped_field_names(package)
     findings: list[ValidationFinding] = []
@@ -92,7 +116,8 @@ def accumulate_intentional_omissions(package: ConfigurationPackage) -> tuple[Val
                 )
             )
             continue
-        message = _OMISSION_MESSAGE if omission.reason is None else f"{_OMISSION_MESSAGE}: {omission.reason}"
+        reason = _redacted_reason(omission.reason, secrets)
+        message = _OMISSION_MESSAGE if reason is None else f"{_OMISSION_MESSAGE}: {reason}"
         findings.append(
             ValidationFinding(
                 code=_CODE_INTENTIONAL_OMISSION,

--- a/infrahub_sync/execution.py
+++ b/infrahub_sync/execution.py
@@ -47,6 +47,7 @@ from infrahub_sync import SyncConfig, SyncInstance
 from infrahub_sync.cache.locks import pipeline_lock
 from infrahub_sync.cache.paths import cache_root_for
 from infrahub_sync.cache.sidecars import RunFile
+from infrahub_sync.configuration.models import REDACTED
 from infrahub_sync.plan.config_version import resolve_config_version
 from infrahub_sync.plan.errors import (
     ApplyRecordInvariantError,
@@ -116,7 +117,6 @@ OPERATIONS: tuple[Operation, ...] = ("plan", "sync", "verify", "apply")
 SYNC_UNSUPPORTED = "operation=sync is not supported here; compose plan, verify, and apply through the Sync API"
 ACTION_KEYS: tuple[ActionKey, ...] = ("create", "update", "delete")
 
-REDACTED = "***"
 # Shortest collected value that is redacted. A short value — the `1` of a
 # `SKIP_TOKEN=1` feature flag, say — would turn redaction into a substring
 # shredder over every message ("within 6***.0 seconds"), and no real credential

--- a/infrahub_sync/plan/errors.py
+++ b/infrahub_sync/plan/errors.py
@@ -239,19 +239,16 @@ class UnaccountedIdentityComponentError(PlanArtifactError):
 
 
 class UnkeyedWriteRefusedError(PlanArtifactError):
-    """The rendered mutation carries no key for a kind whose HFID is all-direct (AD066).
+    """The rendered mutation carries neither `id` nor `hfid`.
 
-    Keyedness is a property of the rendered mutation input rather than of the assembled
-    data, so it is read there. For a kind every one of whose human-friendly-ID components is
-    a direct attribute, a render carrying neither `id` nor `hfid` can only mean the payload
-    lost its identity components, so the write is refused. A kind whose components cross a
-    relationship, and a kind declaring no human-friendly ID at all, are **warned** about and
-    proceed instead (AD076).
+    An unkeyed convergent write duplicates its object on a re-apply, so it is refused for
+    every destination kind. The refused operation attempts no destination mutation.
     """
 
     next_action = (
-        "Re-plan and re-apply: the operation's payload must carry the identity components. If a fresh "
-        "plan renders the same way, report it — the payload is losing them between derivation and write."
+        "Re-plan so the operation's payload carries the destination kind's identity components. A kind "
+        "whose human-friendly ID crosses a relationship, or that declares none at all, cannot render a "
+        "keyed mutation and is not supported for planned writes."
     )
 
 

--- a/infrahub_sync/plan/errors.py
+++ b/infrahub_sync/plan/errors.py
@@ -239,10 +239,11 @@ class UnaccountedIdentityComponentError(PlanArtifactError):
 
 
 class UnkeyedWriteRefusedError(PlanArtifactError):
-    """The rendered mutation carries neither `id` nor `hfid`.
+    """The rendered mutation carries no usable `id` or `hfid`.
 
     An unkeyed convergent write duplicates its object on a re-apply, so it is refused for
-    every destination kind. The refused operation attempts no destination mutation.
+    every destination kind. A key rendered without a value keys nothing and is refused on the
+    same terms. The refused operation attempts no destination mutation.
     """
 
     next_action = (

--- a/infrahub_sync/product_store/configs.py
+++ b/infrahub_sync/product_store/configs.py
@@ -843,12 +843,17 @@ def validate(
     registry_version: int,
     projection: ProductProjection,
     destination_schema: DestinationSchemaOptions | None = None,
+    secrets: Sequence[str] = (),
 ) -> ValidationReport:
     """Report every declared defect in one registered version, in contract order.
 
     The version is re-read from the registry and validated against the *current* adapter
     declarations, which is why a package that was accepted at registration can report
     findings later.
+
+    ``secrets`` are the collected values the finding producer must not disclose. They are a
+    presentation argument: passed through to the producer for this call, never persisted and
+    never placed in a finding.
 
     ``destination_schema`` is the explicit opt-in for the destination schema checks:
     ``None`` — the default — keeps the declared-content-only behavior byte-identical, with
@@ -867,7 +872,7 @@ def validate(
         msg = f"configuration {config_id!r} has no registered version {registry_version} ({lookup.reason})"
         raise ConfigsNotFoundError(msg)
     parsed = _parse(stored.declared_content)
-    findings = collect_findings(parsed)
+    findings = collect_findings(parsed, secrets)
     fingerprint: str | None = None
     if destination_schema is not None:
         schema_validation = collect_destination_schema_findings(parsed)

--- a/infrahub_sync/service/config_routes.py
+++ b/infrahub_sync/service/config_routes.py
@@ -143,10 +143,19 @@ class ConfigurationRoutes:
     def validate(
         self, config_id: str, registry_version: int, *, offset: int = 0, limit: int = _MAX_PAGE_LIMIT
     ) -> ValidationReportResource:
-        """Validate a version and return the requested ordered findings page."""
+        """Validate a version and return the requested ordered findings page.
 
-        report = self._call(self._service.validate, config_id=config_id, registry_version=registry_version)
-        findings = report.findings[offset : offset + limit]
+        This server's collected secrets reach the producer, which can replace a declared key
+        whole before the diagnostic bounds cut it, and the same set is applied again to every
+        finding on the returned page.
+        """
+
+        report = self._call(
+            self._service.validate, config_id=config_id, registry_version=registry_version, secrets=self._secrets
+        )
+        findings = tuple(
+            configs.redact_finding(finding, self._secrets) for finding in report.findings[offset : offset + limit]
+        )
         return ValidationReportResource.model_validate(
             {
                 "config_id": report.config_id,

--- a/infrahub_sync/service/serve.py
+++ b/infrahub_sync/service/serve.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 import uvicorn
 from prefect.client.orchestration import get_client
 
+from infrahub_sync.execution import collect_secret_values
+
 from .app import create_app
 from .auth import EnvironmentPrincipalResolver
 from .config_routes import ConfigurationRoutes
@@ -52,7 +54,10 @@ def build_app(
     policy = LivenessPolicy.from_environment(worker_query_seconds=os.environ.get("PREFECT_WORKER_QUERY_SECONDS", "10"))
     projection = projection_factory()
     resolver = resolver_factory()
-    configuration_routes = configuration_routes_factory(product_projection=projection, secrets=resolver.secret_values)
+    # The configuration diagnostics quote declared keys, so this surface needs the ordinary
+    # environment secrets as well as the principal resolver's bearer tokens.
+    configuration_secrets = tuple(dict.fromkeys((*collect_secret_values(), *resolver.secret_values)))
+    configuration_routes = configuration_routes_factory(product_projection=projection, secrets=configuration_secrets)
     orchestration = _ClientPerCallOrchestration()
     service = run_service_factory(
         projection,

--- a/tests/adapters/test_infrahub_planned_write.py
+++ b/tests/adapters/test_infrahub_planned_write.py
@@ -73,6 +73,7 @@ APPLY_RUN_ID = "20260727T1130-77e0b4c2"
 SITE_KIND = "TestSite"
 TAG_KIND = "TestTag"
 DEVICE_KIND = "TestDevice"
+SERVER_KIND = "TestServer"
 KEYLESS_KIND = "TestKeyless"
 ORPHAN_KIND = "TestOrphan"
 TEAM_KIND = "TestTeam"
@@ -151,6 +152,29 @@ DEVICE_SCHEMA = NodeSchemaAPI(
     ],
 )
 
+# An all-direct human-friendly ID on a kind that still carries a cardinality-one relationship,
+# so peer resolution is exercised on a kind whose render is keyed.
+SERVER_SCHEMA = NodeSchemaAPI(
+    id="server-schema",
+    name="Server",
+    namespace="Test",
+    label="Server",
+    default_filter="name__value",
+    human_friendly_id=["name__value"],
+    attributes=[_text("server-name", "name", optional=False)],
+    relationships=[
+        RelationshipSchemaAPI(
+            id="server-site",
+            name="site",
+            peer=SITE_KIND,
+            cardinality="one",
+            kind=RelationshipKind.ATTRIBUTE,
+            optional=False,
+            identifier="server__site",
+        )
+    ],
+)
+
 # No human-friendly ID at all — the gate's third arm (AD076). FR-024 permits such a kind and
 # requires the run to survive it.
 KEYLESS_SCHEMA = NodeSchemaAPI(
@@ -219,6 +243,7 @@ SCHEMAS: dict[str, NodeSchemaAPI] = {
     SITE_KIND: SITE_SCHEMA,
     TAG_KIND: TAG_SCHEMA,
     DEVICE_KIND: DEVICE_SCHEMA,
+    SERVER_KIND: SERVER_SCHEMA,
     KEYLESS_KIND: KEYLESS_SCHEMA,
     ORPHAN_KIND: ORPHAN_SCHEMA,
     TEAM_KIND: TEAM_SCHEMA,
@@ -345,7 +370,6 @@ def make_adapter(client: RecordingClient, *, source: str | None = None, owner: s
     adapter.source_node = make_node(client, SITE_KIND, source) if source else None
     adapter.owner_node = make_node(client, SITE_KIND, owner) if owner else None
     adapter.schema = dict(SCHEMAS)
-    adapter._unkeyed_render_reported = set()
     return adapter
 
 
@@ -375,6 +399,18 @@ def device_operation(name: str, site_name: str = "site-a") -> PlannedOperation:
     return make_operation(
         kind=DEVICE_KIND,
         identity={"name": name, "site": {"peer_kind": SITE_KIND, "identity": {"name": site_name}}},
+        payload={"name": name},
+        relationships=[
+            RelationshipReference(field="site", peer_kind=SITE_KIND, cardinality="one", peers=[{"name": site_name}])
+        ],
+    )
+
+
+def server_operation(name: str, site_name: str = "site-a") -> PlannedOperation:
+    """A `TestServer` create: a keyed render that still resolves a cardinality-one peer."""
+    return make_operation(
+        kind=SERVER_KIND,
+        identity={"name": name},
         payload={"name": name},
         relationships=[
             RelationshipReference(field="site", peer_kind=SITE_KIND, cardinality="one", peers=[{"name": site_name}])
@@ -438,11 +474,6 @@ def issued_reads(client: RecordingClient) -> list[dict[str, Any]]:
     return [payload for name, payload in client.events if name == "get"]
 
 
-def unkeyed_reports(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
-    """The keyedness gate's reports among the captured records (AD078)."""
-    return [record for record in caplog.records if "carries neither 'id' nor 'hfid'" in record.getMessage()]
-
-
 @pytest.fixture(autouse=True)
 def _forbid_live_sync_update() -> Iterator[None]:
     """`InfrahubModel.update` is never reached by the planned-write path (FR-013).
@@ -483,14 +514,14 @@ def test_the_write_is_client_create_then_an_upsert_of_payload_plus_resolved_peer
     peers = PeerResolver(adapter)
     peers.remember(SITE_KIND, {"name": "site-a"}, "site-id-1")
 
-    node_id = adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
+    node_id = adapter.apply_planned_operation(operation=server_operation("server-a"), peers=peers)
 
     assert node_id == NODE_ID
-    assert client.mutation_names == [f"{DEVICE_KIND}Upsert"], (
+    assert client.mutation_names == [f"{SERVER_KIND}Upsert"], (
         "A create with no cardinality-many relationship is exactly one convergent upsert."
     )
     _, query = client.mutations[0]
-    assert 'value: "device-a"' in query, f"The payload's attributes must reach the write. Rendered:\n{query}"
+    assert 'value: "server-a"' in query, f"The payload's attributes must reach the write. Rendered:\n{query}"
     assert rendered_related_id(query, "site") == "site-id-1", (
         f"The relationship must reach the write as the resolved destination node id. Rendered:\n{query}"
     )
@@ -628,118 +659,79 @@ def test_a_payload_missing_an_identity_component_is_refused_before_any_write() -
     assert not client.mutations, "Nothing may reach the destination once the payload is refused."
 
 
-def test_an_unkeyed_render_for_an_all_direct_hfid_kind_raises_naming_lost_components() -> None:
-    """AD066: the gate's raising arm reads the **rendered mutation**, not the assembled data."""
+def test_an_unkeyed_render_for_an_all_direct_hfid_kind_is_refused() -> None:
+    """The gate reads the **rendered mutation**, not the assembled data."""
     client = RecordingClient()
     adapter = make_adapter(client)
+    operation = make_operation(kind=SITE_KIND, identity={"name": "site-a"}, payload={"name": "site-a"})
     node = client.create(kind=SITE_KIND, data={"description": {"value": "carries no name at all"}})
 
     with pytest.raises(UnkeyedWriteRefusedError) as excinfo:
-        adapter._report_unkeyed_render(node=node, node_schema=SITE_SCHEMA)
+        adapter._require_keyed_render(node=node, operation=operation)
 
     message = str(excinfo.value)
-    assert "name__value" in message
-    assert "lost its identity components" in message
+    assert SITE_KIND in message
+    assert operation.operation_id in message
+    assert "attempted no destination mutation" in message
     assert not client.mutations, "The gate runs before the write is issued."
 
 
-def test_a_kind_declaring_no_human_friendly_id_is_written_and_never_refused(
-    captured_logs: pytest.LogCaptureFixture,
-) -> None:
-    """AD076: the gate's third arm — no human-friendly ID is a schema fact, not a defect."""
+def test_a_kind_declaring_no_human_friendly_id_is_refused_before_its_own_mutation() -> None:
+    """A kind with no convergence key cannot render one, so its write is not issued."""
     client = RecordingClient()
     adapter = make_adapter(client)
 
     operation = make_operation(kind=KEYLESS_KIND, identity={"name": "keyless-a"}, payload={"name": "keyless-a"})
-    node_id = adapter.apply_planned_operation(operation=operation, peers=PeerResolver(adapter))
 
-    assert node_id == NODE_ID
-    assert client.mutation_names == [f"{KEYLESS_KIND}Upsert"], (
-        "An absent human-friendly ID must not refuse the operation: the write is issued."
-    )
-    reports = unkeyed_reports(captured_logs)
-    assert len(reports) == 1
-    message = reports[0].getMessage()
-    assert "declares no human-friendly ID" in message
-    assert "no convergence key" in message
-    assert "lost its identity components" not in message, (
-        "The kind declares no convergence key at all; naming a lost payload component sends the "
-        "operator after a cause that does not exist."
-    )
+    with pytest.raises(UnkeyedWriteRefusedError):
+        adapter.apply_planned_operation(operation=operation, peers=PeerResolver(adapter))
+
+    assert not client.mutations, "The refused operation makes zero mutation calls."
 
 
-def test_the_unkeyed_render_is_reported_once_per_kind_at_warning_level(
-    captured_logs: pytest.LogCaptureFixture,
-) -> None:
-    """AD078: one report per destination kind, at `WARNING`, saying what to watch for."""
+def test_a_relationship_crossing_kind_is_refused_before_its_own_mutation() -> None:
+    """A key the client cannot form from a resolved peer id is refused, not written unkeyed."""
     client = RecordingClient()
     adapter = make_adapter(client)
     peers = PeerResolver(adapter)
     peers.remember(SITE_KIND, {"name": "site-a"}, "site-id-1")
 
-    for name in ("device-a", "device-b"):
-        adapter.apply_planned_operation(operation=device_operation(name), peers=peers)
-
-    assert client.mutation_names == [f"{DEVICE_KIND}Upsert"] * 2, "Both operations are written."
-
-    reports = unkeyed_reports(captured_logs)
-    assert len(reports) == 1, (
-        f"Two operations of one kind must produce exactly one report, got {[r.getMessage() for r in reports]}."
-    )
-    record = reports[0]
-    assert record.levelno >= logging.WARNING, (
-        f"The report is pinned to WARNING because --quiet floors the logger there; it was emitted at "
-        f"{record.levelname}."
-    )
-    message = record.getMessage()
-    assert DEVICE_KIND in message, "The report must name the destination kind."
-    assert "The write is issued anyway" in message, (
-        "The report must say the write is not withheld — in the present tense, because it is emitted "
-        "from the render gate, before the upsert and the relationship flush it precedes."
-    )
-    assert "Watch for a duplicate" in message, "The report must say what to watch for at the destination."
-    assert "crosses a relationship" in message, "The report must name the condition that produced it."
-
-
-def test_the_unkeyed_render_report_is_deduplicated_per_kind_not_per_run(
-    captured_logs: pytest.LogCaptureFixture,
-) -> None:
-    """AD078: two unkeyed kinds produce two reports."""
-    client = RecordingClient()
-    adapter = make_adapter(client)
-    peers = PeerResolver(adapter)
-    peers.remember(SITE_KIND, {"name": "site-a"}, "site-id-1")
-
-    adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
-    keyless = make_operation(kind=KEYLESS_KIND, identity={"name": "keyless-a"}, payload={"name": "keyless-a"})
-    adapter.apply_planned_operation(operation=keyless, peers=peers)
-
-    reports = unkeyed_reports(captured_logs)
-    assert len(reports) == 2, (
-        f"Each unkeyed destination kind is reported once, got {[r.getMessage() for r in reports]}."
-    )
-    assert {DEVICE_KIND, KEYLESS_KIND} == {
-        kind for kind in (DEVICE_KIND, KEYLESS_KIND) if any(kind in r.getMessage() for r in reports)
-    }
-    assert all(record.levelno >= logging.WARNING for record in reports)
-
-
-def test_the_dedup_set_lives_for_one_apply_and_not_for_the_adapter_instance(
-    captured_logs: pytest.LogCaptureFixture,
-) -> None:
-    """T102 / AD078: "once per kind" is once per **apply**, and the state's lifetime says so."""
-    client = RecordingClient()
-    adapter = make_adapter(client)
-
-    for _ in range(2):
-        peers = adapter.new_peer_resolver()
-        peers.remember(SITE_KIND, {"name": "site-a"}, "site-id-1")
+    with pytest.raises(UnkeyedWriteRefusedError):
         adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
 
-    reports = unkeyed_reports(captured_logs)
-    assert len(reports) == 2, f"Each apply discloses the kind once, got {[record.getMessage() for record in reports]}."
-    assert all(DEVICE_KIND in record.getMessage() for record in reports)
-    assert all(record.levelno >= logging.WARNING for record in reports)
+    assert not client.mutations, "The refused operation makes zero mutation calls."
+
+
+@pytest.mark.parametrize("action", ["create", "update"])
+def test_the_gate_precedes_the_sdk_mutation_for_both_write_actions(action: str) -> None:
+    """Create and update route through the same upsert, so they take the same gate."""
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    keyed = make_operation(kind=SITE_KIND, action=action, identity={"name": "site-a"}, payload={"name": "site-a"})
+    assert adapter.apply_planned_operation(operation=keyed, peers=PeerResolver(adapter)) == NODE_ID
+    assert client.mutation_names == [f"{SITE_KIND}Upsert"], "A keyed render is written."
+
+    unkeyed = make_operation(
+        kind=KEYLESS_KIND, action=action, identity={"name": "keyless-a"}, payload={"name": "keyless-a"}
+    )
+    with pytest.raises(UnkeyedWriteRefusedError):
+        adapter.apply_planned_operation(operation=unkeyed, peers=PeerResolver(adapter))
+
+    assert client.mutation_names == [f"{SITE_KIND}Upsert"], "The unkeyed operation added no mutation."
+
+
+def test_a_render_keyed_on_a_destination_id_is_written() -> None:
+    """`id` is the other key the convergent upsert accepts, and it is honoured."""
+    client = RecordingClient()
+    adapter = make_adapter(client)
+    node = client.create(kind=KEYLESS_KIND, data={"name": {"value": "keyless-a"}})
+    node.id = "keyless-node-1"
+    operation = make_operation(kind=KEYLESS_KIND, identity={"name": "keyless-a"}, payload={"name": "keyless-a"})
+
+    adapter._require_keyed_render(node=node, operation=operation)
+
+    assert not client.mutations, "The gate itself issues nothing; it only permits the write."
 
 
 # ---------------------------------------------------------------------------------------
@@ -872,7 +864,7 @@ def test_a_completed_operation_resolves_a_later_reference_with_no_destination_qu
 
     site = make_operation(kind=SITE_KIND, identity={"name": "site-a"}, payload={"name": "site-a"})
     adapter.apply_planned_operation(operation=site, peers=peers)
-    adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
+    adapter.apply_planned_operation(operation=server_operation("server-a"), peers=peers)
 
     assert client.resolver_queries == [], (
         "The peer was created by this same apply, so its identity must resolve from the memo."
@@ -889,8 +881,8 @@ def test_a_failed_lookup_is_not_memoized_and_the_next_reference_reattempts() -> 
     peers = PeerResolver(adapter)
 
     with pytest.raises(PeerNotFoundError):
-        adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
-    adapter.apply_planned_operation(operation=device_operation("device-b"), peers=peers)
+        adapter.apply_planned_operation(operation=server_operation("server-a"), peers=peers)
+    adapter.apply_planned_operation(operation=server_operation("server-b"), peers=peers)
 
     assert len(client.resolver_queries) == 2, (
         "The failed lookup must not be cached, so the second reference queries the destination again."
@@ -912,7 +904,7 @@ def test_a_failed_write_is_not_memoized_and_a_later_reference_queries_the_destin
 
     client.write_error = None
     client.filter_results = [[make_node(client, SITE_KIND, "site-id-7")]]
-    adapter.apply_planned_operation(operation=device_operation("device-a"), peers=peers)
+    adapter.apply_planned_operation(operation=server_operation("server-a"), peers=peers)
 
     assert len(client.resolver_queries) == 1, (
         "The failed write must leave no memo entry, so the reference falls through to the destination."
@@ -1250,6 +1242,28 @@ def test_a_mid_apply_rejection_surfaces_the_rejection_not_the_knowability_invari
 # the partial record on a rejection — lives at `tests/cache/test_apply_plan.py`, against the
 # engine rather than through this adapter.
 # ---------------------------------------------------------------------------------------
+
+
+def test_a_refused_operation_stops_the_apply_and_leaves_the_prior_write_recorded(tmp_path: Path) -> None:
+    """Apply is sequential: an earlier keyed write stands, and no later operation executes."""
+    directory = apply_run_dir(tmp_path)
+    keyed = operation_record(kind=SITE_KIND, identity={"name": "site-a"})
+    unkeyed = operation_record(kind=KEYLESS_KIND, identity={"name": "keyless-a"})
+    later = operation_record(kind=TAG_KIND, identity={"name": "tag-z"})
+    write_artifact(directory, [keyed, unkeyed, later], run_id=APPLY_RUN_ID, source_snapshot=[])
+
+    client = RecordingClient()
+    adapter = make_adapter(client)
+    state, outcome = apply_and_record_state(engine_over(directory, adapter))
+
+    assert state == "failed"
+    assert isinstance(outcome, OperationApplyFailedError)
+    assert client.mutation_names == [f"{SITE_KIND}Upsert"], (
+        "The keyed operation wrote, the refused one made zero mutation calls, and the operation after it never ran."
+    )
+    record = outcome.apply_record
+    assert list(record.applied_operations) == [keyed["operation_id"]]
+    assert record.failed_operation == unkeyed["operation_id"]
 
 
 def test_the_reviewed_operation_identifiers_equal_the_applied_record_in_the_same_order(

--- a/tests/adapters/test_infrahub_planned_write.py
+++ b/tests/adapters/test_infrahub_planned_write.py
@@ -721,17 +721,48 @@ def test_the_gate_precedes_the_sdk_mutation_for_both_write_actions(action: str) 
     assert client.mutation_names == [f"{SITE_KIND}Upsert"], "The unkeyed operation added no mutation."
 
 
-def test_a_render_keyed_on_a_destination_id_is_accepted() -> None:
-    """`id` is the other key the convergent upsert accepts, and it is honoured."""
+def test_a_keyed_hfid_render_is_written_through_the_real_transport() -> None:
+    """The positive arm, end to end: a keyed render reaches the wire carrying its `hfid`.
+
+    `hfid` is the only key a planned write can genuinely render. The plan carries no destination
+    UUID — a saved-plan apply performs no destination load, so nothing can supply one — and a
+    payload field literally named `id` is not one either: `generate_payload_create` wraps it as
+    an attribute block, which is the case the next test pins.
+    """
     client = RecordingClient()
     adapter = make_adapter(client)
-    node = client.create(kind=KEYLESS_KIND, data={"name": {"value": "keyless-a"}})
-    node.id = "keyless-node-1"
-    operation = make_operation(kind=KEYLESS_KIND, identity={"name": "keyless-a"}, payload={"name": "keyless-a"})
+    operation = make_operation(kind=SITE_KIND, identity={"name": "site-a"}, payload={"name": "site-a"})
 
-    adapter._require_keyed_render(node=node, operation=operation)
+    node_id = adapter.apply_planned_operation(operation=operation, peers=PeerResolver(adapter))
 
-    assert not client.mutations, "The gate itself issues nothing; it only permits the write."
+    assert client.mutation_names == [f"{SITE_KIND}Upsert"], "The keyed render is issued as one convergent upsert."
+    _, query = client.mutations[0]
+    assert re.search(r'hfid:\s*\[\s*"site-a",?\s*\]', query), (
+        f"The mutation must carry the human-friendly ID. Rendered:\n{query}"
+    )
+    assert 'value: "site-a"' in query, f"The payload's attributes must reach the write. Rendered:\n{query}"
+    assert node_id == NODE_ID
+
+
+def test_a_payload_field_named_id_does_not_satisfy_the_gate() -> None:
+    """A key whose rendered value is empty keys nothing, so it is refused (the `id: {}` case).
+
+    `generate_payload_create` wraps every payload field into an attribute block, so a field
+    named `id` renders as `id: {}`. That is a present key with no value: the destination cannot
+    converge on it, and a gate testing presence alone would pass an unkeyed write.
+    """
+    client = RecordingClient()
+    adapter = make_adapter(client)
+    operation = make_operation(
+        kind=KEYLESS_KIND,
+        identity={"name": "keyless-a"},
+        payload={"name": "keyless-a", "id": "keyless-node-1"},
+    )
+
+    with pytest.raises(UnkeyedWriteRefusedError):
+        adapter.apply_planned_operation(operation=operation, peers=PeerResolver(adapter))
+
+    assert not client.mutations, "The refused operation makes zero mutation calls."
 
 
 # ---------------------------------------------------------------------------------------

--- a/tests/adapters/test_infrahub_planned_write.py
+++ b/tests/adapters/test_infrahub_planned_write.py
@@ -744,6 +744,40 @@ def test_a_keyed_hfid_render_is_written_through_the_real_transport() -> None:
     assert node_id == NODE_ID
 
 
+def test_a_render_carrying_a_usable_id_reaches_the_write_and_returns_its_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate's `id` arm, proven at the transport rather than at the helper.
+
+    **This is gate-contract coverage, not a saved-plan path.** A saved plan carries no
+    destination UUID — FR-012 forbids the load that would supply one — so no ordinary apply
+    reaches the gate this way. The gate nonetheless permits `id`, and the only honest way to
+    show what "permits" means is to put a node carrying one in front of it and watch the write
+    happen. The node id is injected at `client.create`, which is where a destination-aware
+    caller would supply it; nothing else about the path is replaced.
+    """
+    client = RecordingClient()
+    adapter = make_adapter(client)
+    real_create = client.create
+
+    def create_with_destination_id(*args: Any, **kwargs: Any) -> InfrahubNodeSync:  # noqa: ANN401
+        node = real_create(*args, **kwargs)
+        node.id = "keyless-node-1"
+        return node
+
+    monkeypatch.setattr(client, "create", create_with_destination_id)
+    operation = make_operation(kind=KEYLESS_KIND, identity={"name": "keyless-a"}, payload={"name": "keyless-a"})
+
+    node_id = adapter.apply_planned_operation(operation=operation, peers=PeerResolver(adapter))
+
+    assert client.mutation_names == [f"{KEYLESS_KIND}Upsert"], (
+        "A usable 'id' permits the write, so exactly one convergent upsert is issued."
+    )
+    _, query = client.mutations[0]
+    assert 'id: "keyless-node-1"' in query, f"The mutation must carry the destination id. Rendered:\n{query}"
+    assert node_id == NODE_ID, "The write surface returns the destination node id."
+
+
 def test_a_payload_field_named_id_does_not_satisfy_the_gate() -> None:
     """A key whose rendered value is empty keys nothing, so it is refused (the `id: {}` case).
 

--- a/tests/adapters/test_infrahub_planned_write.py
+++ b/tests/adapters/test_infrahub_planned_write.py
@@ -175,8 +175,8 @@ SERVER_SCHEMA = NodeSchemaAPI(
     ],
 )
 
-# No human-friendly ID at all — the gate's third arm (AD076). FR-024 permits such a kind and
-# requires the run to survive it.
+# No human-friendly ID at all, so no convergence key can be rendered for it and the keyedness
+# gate refuses its planned write.
 KEYLESS_SCHEMA = NodeSchemaAPI(
     id="keyless-schema",
     name="Keyless",
@@ -721,7 +721,7 @@ def test_the_gate_precedes_the_sdk_mutation_for_both_write_actions(action: str) 
     assert client.mutation_names == [f"{SITE_KIND}Upsert"], "The unkeyed operation added no mutation."
 
 
-def test_a_render_keyed_on_a_destination_id_is_written() -> None:
+def test_a_render_keyed_on_a_destination_id_is_accepted() -> None:
     """`id` is the other key the convergent upsert accepts, and it is honoured."""
     client = RecordingClient()
     adapter = make_adapter(client)

--- a/tests/data/apply_conformance_schemas.json
+++ b/tests/data/apply_conformance_schemas.json
@@ -15,7 +15,7 @@
     "              shape in the fixture the harness cannot see that, which is how the defect",
     "              reached the tree. Do not remove it;",
     "  ConfDevice- a human-friendly ID that CROSSES A RELATIONSHIP, which cannot render keyed",
-    "              today and is the xfail(strict=True) arm (AD067)."
+    "              client-side, so the keyedness gate refuses its planned write (AD066)."
   ],
   "nodes": [
     {

--- a/tests/integration/test_infrahub_unkeyed_refusal_integration.py
+++ b/tests/integration/test_infrahub_unkeyed_refusal_integration.py
@@ -198,6 +198,13 @@ class UnkeyedScope:
     device_name: str
 
 
+def _raise_for_status_without_redirect(response: requests.Response) -> None:
+    """Refuse redirects before checking the response status."""
+    if response.is_redirect or response.is_permanent_redirect:
+        pytest.fail(f"Infrahub returned an unexpected redirect (HTTP {response.status_code})")
+    response.raise_for_status()
+
+
 def _branch_exists(address: str, token: str, branch: str) -> bool:
     """Whether the destination still lists `branch`."""
     response = requests.post(
@@ -205,8 +212,9 @@ def _branch_exists(address: str, token: str, branch: str) -> bool:
         headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
         json={"query": "query { Branch { name } }"},
         timeout=30,
+        allow_redirects=False,
     )
-    response.raise_for_status()
+    _raise_for_status_without_redirect(response)
     branches = response.json().get("data", {}).get("Branch") or []
     return any(entry.get("name") == branch for entry in branches)
 
@@ -236,8 +244,9 @@ def unkeyed_scope() -> Iterator[UnkeyedScope]:
             headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
             json={"schemas": [_SCHEMA]},
             timeout=60,
+            allow_redirects=False,
         )
-        schema_response.raise_for_status()
+        _raise_for_status_without_redirect(schema_response)
         _await_schema_kinds(client, branch, (SITE_KIND, DEVICE_KIND, MOUNT_KIND))
 
         site_name = f"unkeyed-site-{suffix}"
@@ -356,8 +365,13 @@ def test_the_run_writes_nothing_outside_the_branch_it_owns(unkeyed_scope: Unkeye
     scope = unkeyed_scope
     address, token = _env_or_skip()
 
-    response = requests.get(f"{address}/api/schema?branch=main", headers={"X-INFRAHUB-KEY": token}, timeout=30)
-    response.raise_for_status()
+    response = requests.get(
+        f"{address}/api/schema?branch=main",
+        headers={"X-INFRAHUB-KEY": token},
+        timeout=30,
+        allow_redirects=False,
+    )
+    _raise_for_status_without_redirect(response)
     main_kinds = {node["kind"] for node in response.json().get("nodes", [])}
 
     assert main_kinds & {SITE_KIND, DEVICE_KIND} == set(), (

--- a/tests/integration/test_infrahub_unkeyed_refusal_integration.py
+++ b/tests/integration/test_infrahub_unkeyed_refusal_integration.py
@@ -45,12 +45,19 @@ pytestmark = pytest.mark.integration
 
 SITE_KIND = "TestUnkeyedSite"
 DEVICE_KIND = "TestUnkeyedDevice"
+MOUNT_KIND = "TestUnkeyedMount"
 
 # `TestUnkeyedDevice`'s human-friendly ID crosses the `site` relationship, which is exactly the
 # shape the SDK cannot render a key for: a peer supplied as a resolved node id renders as
 # `{"id": ...}` with no `__typename`, so `get_human_friendly_id()` resolves to None. The site is
 # all-direct so the peer it references is itself writable and the refusal under test is the
 # device's alone.
+#
+# `TestUnkeyedMount` is the third shape, and it is what keeps the nested-peer *read* covered.
+# Its own human-friendly ID is all-direct, so it renders a key and is written; the peer it
+# references is the crossing kind. Resolving that peer is the only place PD-004's nested
+# `<rel>__<attr>__value` filter spelling and AD043's nested `{peer_kind, identity}` walk run
+# against a real destination — a kind may be unwritable and still be perfectly readable.
 _SCHEMA = {
     "version": "1.0",
     "nodes": [
@@ -71,6 +78,22 @@ _SCHEMA = {
                 {
                     "name": "site",
                     "peer": SITE_KIND,
+                    "cardinality": "one",
+                    "kind": "Attribute",
+                    "optional": False,
+                },
+            ],
+        },
+        {
+            "name": "UnkeyedMount",
+            "namespace": "Test",
+            "include_in_menu": False,
+            "human_friendly_id": ["name__value"],
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+            "relationships": [
+                {
+                    "name": "device",
+                    "peer": DEVICE_KIND,
                     "cardinality": "one",
                     "kind": "Attribute",
                     "optional": False,
@@ -142,6 +165,28 @@ def _device_operation(device_name: str, site_name: str) -> PlannedOperation:
     )
 
 
+def _mount_operation(mount_name: str, device_name: str, site_name: str) -> PlannedOperation:
+    """One planned create for the keyed consumer, referencing the crossing peer.
+
+    The reference carries the peer's identity as AD043 records it — a nested
+    `{peer_kind, identity}` pair, because the peer's own key crosses `site` — so resolving it
+    is what forces the nested filter spelling at the destination.
+    """
+    peer_identity = {"name": device_name, "site": {"peer_kind": SITE_KIND, "identity": {"name": site_name}}}
+    identity = canonical_identity({"name": mount_name}, kind=MOUNT_KIND)
+    return PlannedOperation(
+        operation_id=operation_id("create", MOUNT_KIND, identity),
+        action="create",
+        kind=MOUNT_KIND,
+        identity=identity,
+        tier=0,
+        payload={"name": mount_name},
+        relationships=[
+            RelationshipReference(field="device", peer_kind=DEVICE_KIND, cardinality="one", peers=[peer_identity])
+        ],
+    )
+
+
 @dataclass(frozen=True)
 class UnkeyedScope:
     """One run's isolated destination scope."""
@@ -150,6 +195,7 @@ class UnkeyedScope:
     adapter: InfrahubAdapter
     branch: str
     site_name: str
+    device_name: str
 
 
 def _branch_exists(address: str, token: str, branch: str) -> bool:
@@ -167,11 +213,16 @@ def _branch_exists(address: str, token: str, branch: str) -> bool:
 
 @pytest.fixture
 def unkeyed_scope() -> Iterator[UnkeyedScope]:
-    """A branch this run owns, carrying the throwaway schema and one site.
+    """A branch this run owns, carrying the throwaway schema, one site and one device.
 
     The branch is the unit of isolation *and* of cleanup: deleting it removes the schema and
     every object created against it, so no teardown has to enumerate objects by kind and
     therefore none can remove another run's. `main` is never written.
+
+    The device is created **directly through the SDK**, not through a planned apply: its key
+    crosses a relationship, so the write surface would refuse it — which is the very thing the
+    refusal case asserts. Seeding it directly is what makes it a *pre-existing* peer, which is
+    the only state in which the nested-peer read can be exercised at all.
     """
     address, token = _env_or_skip()
     suffix = uuid.uuid4().hex[:8]
@@ -187,18 +238,21 @@ def unkeyed_scope() -> Iterator[UnkeyedScope]:
             timeout=60,
         )
         schema_response.raise_for_status()
-        _await_schema_kinds(client, branch, (SITE_KIND, DEVICE_KIND))
+        _await_schema_kinds(client, branch, (SITE_KIND, DEVICE_KIND, MOUNT_KIND))
 
         site_name = f"unkeyed-site-{suffix}"
         site = client.create(kind=SITE_KIND, branch=branch, data={"name": site_name})
         site.save()
+        device_name = f"unkeyed-device-{suffix}"
+        device = client.create(kind=DEVICE_KIND, branch=branch, data={"name": device_name, "site": site.id})
+        device.save()
 
         adapter = InfrahubAdapter.__new__(InfrahubAdapter)
         adapter.client = client
         adapter.schema = client.schema.all(branch=branch)
         adapter.source_node = None
         adapter.owner_node = None
-        yield UnkeyedScope(client=client, adapter=adapter, branch=branch, site_name=site_name)
+        yield UnkeyedScope(client=client, adapter=adapter, branch=branch, site_name=site_name, device_name=device_name)
     finally:
         client.branch.delete(branch_name=branch)
         assert not _branch_exists(address, token, branch), (
@@ -235,6 +289,53 @@ def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destinatio
     assert scope.client.filters(kind=DEVICE_KIND, branch=scope.branch, populate_store=False) == [], (
         f"A refused operation left an object of kind {DEVICE_KIND} at the destination."
     )
+
+
+def test_a_keyed_consumer_resolves_a_crossing_peer_through_the_nested_filter(
+    unkeyed_scope: UnkeyedScope,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kind that cannot be written can still be read, and resolving it is nested (AD043/PD-004).
+
+    This is the semantic half the refusal case cannot cover. The consumer's own key is
+    all-direct, so its planned write renders keyed and is issued; the peer it names is the
+    crossing kind, which pre-exists at the destination. Resolving that peer is the only place
+    the nested `{peer_kind, identity}` walk turns into a nested `<rel>__<attr>__value` filter
+    against a real server, and no offline harness can settle how the destination answers it.
+    """
+    scope = unkeyed_scope
+    mount_name = f"unkeyed-mount-{scope.branch.rsplit('-', maxsplit=1)[-1]}"
+    queries: list[dict[str, Any]] = []
+    real_filters = scope.client.filters
+
+    def recording_filters(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 — SDK passthrough
+        queries.append(dict(kwargs))
+        return real_filters(*args, **kwargs)
+
+    monkeypatch.setattr(scope.client, "filters", recording_filters)
+    node_id = scope.adapter.apply_planned_operation(
+        operation=_mount_operation(mount_name, scope.device_name, scope.site_name),
+        peers=scope.adapter.new_peer_resolver(),
+    )
+    monkeypatch.undo()
+
+    nested = [
+        query
+        for query in queries
+        if query.get("kind") == DEVICE_KIND and query.get("site__name__value") == scope.site_name
+    ]
+    assert nested, (
+        f"No destination query resolved {DEVICE_KIND!r} through the nested "
+        f"'site__name__value' filter. PD-004's spelling was not exercised. Queries issued: {queries}"
+    )
+    assert nested[0].get("name__value") == scope.device_name, (
+        f"The nested query must also pin the peer's own direct component: {nested[0]}"
+    )
+
+    written = scope.client.get(kind=MOUNT_KIND, id=node_id, branch=scope.branch, include=["device"])
+    assert written.name.value == mount_name, "The keyed consumer was not written as planned."
+    assert written.device.id is not None, "The consumer was written without the peer it referenced."
+    assert scope.client.count(kind=MOUNT_KIND, branch=scope.branch) == 1
 
 
 def test_the_run_writes_nothing_outside_the_branch_it_owns(unkeyed_scope: UnkeyedScope) -> None:

--- a/tests/integration/test_infrahub_unkeyed_refusal_integration.py
+++ b/tests/integration/test_infrahub_unkeyed_refusal_integration.py
@@ -1,0 +1,200 @@
+"""An unkeyed planned operation is refused before it touches a live destination.
+
+The offline harnesses prove the gate reads the SDK's rendered mutation and raises. What they
+cannot prove is that nothing reached the server: a fixture holds no destination state, so
+"zero mutation calls" is asserted against a recording transport rather than against Infrahub.
+This module closes that gap on the smallest possible fixture — one throwaway schema, one
+planned create, one count read back.
+
+Same posture as its siblings: a throwaway schema is loaded, everything it creates is deleted
+afterwards, and the module skips itself without a configured destination. Only the destination
+is needed; the operation is a hand-built plan record driven straight through
+`InfrahubAdapter.apply_planned_operation`, so no source adapter is involved. Run with::
+
+    INFRAHUB_ADDRESS=http://localhost:8000 \\
+    INFRAHUB_API_TOKEN=<token> \\
+    uv run pytest -m integration tests/integration/test_infrahub_unkeyed_refusal_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import requests
+
+from infrahub_sync.adapters.infrahub import InfrahubAdapter
+from infrahub_sync.plan.errors import UnkeyedWriteRefusedError
+from infrahub_sync.plan.identity import canonical_identity, operation_id
+from infrahub_sync.plan.models import PlannedOperation, RelationshipReference
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.integration
+
+DESTINATION_BRANCH = "main"
+SITE_KIND = "TestUnkeyedSite"
+DEVICE_KIND = "TestUnkeyedDevice"
+
+# `TestUnkeyedDevice`'s human-friendly ID crosses the `site` relationship, which is exactly the
+# shape the SDK cannot render a key for: a peer supplied as a resolved node id renders as
+# `{"id": ...}` with no `__typename`, so `get_human_friendly_id()` resolves to None. The site is
+# all-direct so the peer it references is itself writable and the refusal under test is the
+# device's alone.
+_SCHEMA = {
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "UnkeyedSite",
+            "namespace": "Test",
+            "include_in_menu": False,
+            "human_friendly_id": ["name__value"],
+            "attributes": [{"name": "name", "kind": "Text", "unique": True}],
+        },
+        {
+            "name": "UnkeyedDevice",
+            "namespace": "Test",
+            "include_in_menu": False,
+            "human_friendly_id": ["site__name__value", "name__value"],
+            "attributes": [{"name": "name", "kind": "Text", "unique": False}],
+            "relationships": [
+                {
+                    "name": "site",
+                    "peer": SITE_KIND,
+                    "cardinality": "one",
+                    "kind": "Attribute",
+                    "optional": False,
+                },
+            ],
+        },
+    ],
+}
+
+
+def _env_or_skip() -> tuple[str, str]:
+    address = os.environ.get("INFRAHUB_ADDRESS")
+    token = os.environ.get("INFRAHUB_API_TOKEN")
+    if not address or not token:
+        pytest.skip("INFRAHUB_ADDRESS and INFRAHUB_API_TOKEN must be set")
+    return address, token
+
+
+def _await_schema_kinds(address: str, token: str, kinds: tuple[str, ...], timeout: float = 90.0) -> None:
+    """Block until the destination serves every one of `kinds`.
+
+    `POST /api/schema/load` returns once the payload is accepted, not once the kinds it
+    declares are queryable, and a create issued in that window fails as a missing schema rather
+    than as the refusal under test.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        response = requests.get(
+            f"{address}/api/schema?branch={DESTINATION_BRANCH}",
+            headers={"X-INFRAHUB-KEY": token},
+            timeout=30,
+        )
+        response.raise_for_status()
+        missing = set(kinds) - {node["kind"] for node in response.json().get("nodes", [])}
+        if not missing:
+            return
+        if time.monotonic() >= deadline:
+            msg = f"Destination did not serve {sorted(missing)} within {timeout:.0f}s of a successful schema load."
+            raise AssertionError(msg)
+        time.sleep(1.0)
+
+
+def _make_client(address: str, token: str) -> Any:  # noqa: ANN401 — the SDK client is dynamically typed
+    """A sync Infrahub client, imported lazily so unit-only runs need no SDK extras."""
+    from infrahub_sdk import Config, InfrahubClientSync
+
+    return InfrahubClientSync(config=Config(address=address, api_token=token))
+
+
+def _device_operation(device_name: str, site_name: str) -> PlannedOperation:
+    """One planned create for the kind whose convergence key crosses `site`."""
+    identity = canonical_identity(
+        {"name": device_name, "site": {"peer_kind": SITE_KIND, "identity": {"name": site_name}}},
+        kind=DEVICE_KIND,
+    )
+    return PlannedOperation(
+        operation_id=operation_id("create", DEVICE_KIND, identity),
+        action="create",
+        kind=DEVICE_KIND,
+        identity=identity,
+        tier=0,
+        payload={"name": device_name},
+        relationships=[
+            RelationshipReference(field="site", peer_kind=SITE_KIND, cardinality="one", peers=[{"name": site_name}])
+        ],
+    )
+
+
+@pytest.fixture
+def live_unkeyed_fixture() -> Iterator[tuple[Any, InfrahubAdapter, str]]:
+    """Throwaway schema plus one site at the destination; torn down afterwards.
+
+    Yields `(client, adapter, site_name)`. No device is created: whether one can be is the
+    question under test.
+    """
+    address, token = _env_or_skip()
+    suffix = uuid.uuid4().hex[:8]
+
+    schema_response = requests.post(
+        f"{address}/api/schema/load?branch={DESTINATION_BRANCH}",
+        headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
+        json={"schemas": [_SCHEMA]},
+        timeout=60,
+    )
+    schema_response.raise_for_status()
+    _await_schema_kinds(address, token, (SITE_KIND, DEVICE_KIND))
+
+    client = _make_client(address, token)
+    site_name = f"unkeyed-site-{suffix}"
+    site = client.create(kind=SITE_KIND, branch=DESTINATION_BRANCH, data={"name": site_name})
+    site.save()
+    try:
+        adapter = InfrahubAdapter.__new__(InfrahubAdapter)
+        adapter.client = client
+        adapter.schema = client.schema.all(branch=DESTINATION_BRANCH)
+        adapter.source_node = None
+        adapter.owner_node = None
+        yield client, adapter, site_name
+    finally:
+        for device in client.filters(kind=DEVICE_KIND, branch=DESTINATION_BRANCH, populate_store=False):
+            device.delete()
+        site.delete()
+
+
+def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destination(
+    live_unkeyed_fixture: tuple[Any, InfrahubAdapter, str],
+) -> None:
+    """The refusal is proven against a live server, not against a recording transport.
+
+    The count is read back from the destination on both sides of the refusal, so "no mutation
+    was attempted" is a statement about Infrahub's state rather than about what the client
+    chose to send. A second apply is included because the failure this gate exists to prevent
+    is a *duplicate* on re-apply: an unkeyed write that silently succeeded would show here as
+    a count that climbed.
+    """
+    client, adapter, site_name = live_unkeyed_fixture
+    before = client.count(kind=DEVICE_KIND, branch=DESTINATION_BRANCH)
+
+    for attempt in range(2):
+        with pytest.raises(UnkeyedWriteRefusedError) as refusal:
+            adapter.apply_planned_operation(
+                operation=_device_operation("unkeyed-device-a", site_name),
+                peers=adapter.new_peer_resolver(),
+            )
+        assert DEVICE_KIND in str(refusal.value), f"The refusal must name the destination kind: {refusal.value}"
+        assert client.count(kind=DEVICE_KIND, branch=DESTINATION_BRANCH) == before, (
+            f"Apply attempt {attempt + 1} changed the destination count for {DEVICE_KIND}, so the "
+            "operation mutated the destination before the gate refused it."
+        )
+
+    assert client.filters(kind=DEVICE_KIND, branch=DESTINATION_BRANCH, populate_store=False) == [], (
+        f"A refused operation left an object of kind {DEVICE_KIND} at the destination."
+    )

--- a/tests/integration/test_infrahub_unkeyed_refusal_integration.py
+++ b/tests/integration/test_infrahub_unkeyed_refusal_integration.py
@@ -273,11 +273,12 @@ def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destinatio
     """
     scope = unkeyed_scope
     before = scope.client.count(kind=DEVICE_KIND, branch=scope.branch)
+    refused_name = f"refused-{scope.device_name}"
 
     for attempt in range(2):
         with pytest.raises(UnkeyedWriteRefusedError) as refusal:
             scope.adapter.apply_planned_operation(
-                operation=_device_operation("unkeyed-device-a", scope.site_name),
+                operation=_device_operation(refused_name, scope.site_name),
                 peers=scope.adapter.new_peer_resolver(),
             )
         assert DEVICE_KIND in str(refusal.value), f"The refusal must name the destination kind: {refusal.value}"
@@ -286,8 +287,14 @@ def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destinatio
             "operation mutated the destination before the gate refused it."
         )
 
-    assert scope.client.filters(kind=DEVICE_KIND, branch=scope.branch, populate_store=False) == [], (
-        f"A refused operation left an object of kind {DEVICE_KIND} at the destination."
+    # The fixture seeds one device as the pre-existing peer, so "nothing was written" is that the
+    # set is still exactly that one — a stronger claim than an unchanged count, which a write
+    # paired with a delete could also satisfy.
+    remaining = sorted(
+        node.name.value for node in scope.client.filters(kind=DEVICE_KIND, branch=scope.branch, populate_store=False)
+    )
+    assert remaining == [scope.device_name], (
+        f"A refused operation changed the {DEVICE_KIND} set at the destination: {remaining}"
     )
 
 

--- a/tests/integration/test_infrahub_unkeyed_refusal_integration.py
+++ b/tests/integration/test_infrahub_unkeyed_refusal_integration.py
@@ -6,9 +6,15 @@ cannot prove is that nothing reached the server: a fixture holds no destination 
 This module closes that gap on the smallest possible fixture — one throwaway schema, one
 planned create, one count read back.
 
-Same posture as its siblings: a throwaway schema is loaded, everything it creates is deleted
-afterwards, and the module skips itself without a configured destination. Only the destination
-is needed; the operation is a hand-built plan record driven straight through
+**Everything this module touches lives on one branch it creates and deletes.** The sibling
+modules load their throwaway schema onto `main`, which makes two concurrent runs — or a run
+against an instance someone else is using — share a namespace: a `filters(kind=...)` teardown
+there removes objects the run does not own. Here the branch name carries a per-run uuid, the
+schema is loaded onto that branch alone, every read and write names it, and the branch is
+deleted afterwards, taking its schema and its objects with it. `main` is never written.
+
+The module skips itself without a configured destination. Only the destination is needed; the
+operation is a hand-built plan record driven straight through
 `InfrahubAdapter.apply_planned_operation`, so no source adapter is involved. Run with::
 
     INFRAHUB_ADDRESS=http://localhost:8000 \\
@@ -21,6 +27,7 @@ from __future__ import annotations
 import os
 import time
 import uuid
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -36,7 +43,6 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.integration
 
-DESTINATION_BRANCH = "main"
 SITE_KIND = "TestUnkeyedSite"
 DEVICE_KIND = "TestUnkeyedDevice"
 
@@ -83,35 +89,38 @@ def _env_or_skip() -> tuple[str, str]:
     return address, token
 
 
-def _await_schema_kinds(address: str, token: str, kinds: tuple[str, ...], timeout: float = 90.0) -> None:
-    """Block until the destination serves every one of `kinds`.
+def _await_schema_kinds(client: Any, branch: str, kinds: tuple[str, ...], timeout: float = 120.0) -> None:  # noqa: ANN401
+    """Block until the client can resolve every one of `kinds` on `branch`.
 
     `POST /api/schema/load` returns once the payload is accepted, not once the kinds it
-    declares are queryable, and a create issued in that window fails as a missing schema rather
-    than as the refusal under test.
+    declares are resolvable, and a create issued in that window fails as a missing schema
+    rather than as the refusal under test. The SDK's own `wait_until_converged` settles the
+    server side; the loop then re-fetches until the *client's* view agrees, which is the view
+    `client.create` actually reads. Both are needed when a second run is loading its own
+    branch's schema against the same instance at the same time.
     """
+    client.schema.wait_until_converged(branch=branch)
     deadline = time.monotonic() + timeout
     while True:
-        response = requests.get(
-            f"{address}/api/schema?branch={DESTINATION_BRANCH}",
-            headers={"X-INFRAHUB-KEY": token},
-            timeout=30,
-        )
-        response.raise_for_status()
-        missing = set(kinds) - {node["kind"] for node in response.json().get("nodes", [])}
+        missing = set(kinds) - set(client.schema.all(branch=branch, refresh=True))
         if not missing:
             return
         if time.monotonic() >= deadline:
-            msg = f"Destination did not serve {sorted(missing)} within {timeout:.0f}s of a successful schema load."
+            msg = f"Branch {branch!r} did not serve {sorted(missing)} within {timeout:.0f}s of a successful load."
             raise AssertionError(msg)
         time.sleep(1.0)
 
 
-def _make_client(address: str, token: str) -> Any:  # noqa: ANN401 — the SDK client is dynamically typed
-    """A sync Infrahub client, imported lazily so unit-only runs need no SDK extras."""
+def _make_client(address: str, token: str, branch: str = "main") -> Any:  # noqa: ANN401 — the SDK client is dynamic
+    """A sync Infrahub client scoped to `branch`, imported lazily for base installs.
+
+    The default branch is what the planned-write surface inherits: `apply_planned_operation`
+    names no branch of its own, so scoping the client is what keeps every write this run
+    issues inside the branch it owns.
+    """
     from infrahub_sdk import Config, InfrahubClientSync
 
-    return InfrahubClientSync(config=Config(address=address, api_token=token))
+    return InfrahubClientSync(config=Config(address=address, api_token=token, default_branch=branch))
 
 
 def _device_operation(device_name: str, site_name: str) -> PlannedOperation:
@@ -133,44 +142,72 @@ def _device_operation(device_name: str, site_name: str) -> PlannedOperation:
     )
 
 
-@pytest.fixture
-def live_unkeyed_fixture() -> Iterator[tuple[Any, InfrahubAdapter, str]]:
-    """Throwaway schema plus one site at the destination; torn down afterwards.
+@dataclass(frozen=True)
+class UnkeyedScope:
+    """One run's isolated destination scope."""
 
-    Yields `(client, adapter, site_name)`. No device is created: whether one can be is the
-    question under test.
+    client: Any
+    adapter: InfrahubAdapter
+    branch: str
+    site_name: str
+
+
+def _branch_exists(address: str, token: str, branch: str) -> bool:
+    """Whether the destination still lists `branch`."""
+    response = requests.post(
+        f"{address}/graphql",
+        headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
+        json={"query": "query { Branch { name } }"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    branches = response.json().get("data", {}).get("Branch") or []
+    return any(entry.get("name") == branch for entry in branches)
+
+
+@pytest.fixture
+def unkeyed_scope() -> Iterator[UnkeyedScope]:
+    """A branch this run owns, carrying the throwaway schema and one site.
+
+    The branch is the unit of isolation *and* of cleanup: deleting it removes the schema and
+    every object created against it, so no teardown has to enumerate objects by kind and
+    therefore none can remove another run's. `main` is never written.
     """
     address, token = _env_or_skip()
     suffix = uuid.uuid4().hex[:8]
-
-    schema_response = requests.post(
-        f"{address}/api/schema/load?branch={DESTINATION_BRANCH}",
-        headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
-        json={"schemas": [_SCHEMA]},
-        timeout=60,
-    )
-    schema_response.raise_for_status()
-    _await_schema_kinds(address, token, (SITE_KIND, DEVICE_KIND))
-
-    client = _make_client(address, token)
-    site_name = f"unkeyed-site-{suffix}"
-    site = client.create(kind=SITE_KIND, branch=DESTINATION_BRANCH, data={"name": site_name})
-    site.save()
+    branch = f"unkeyed-refusal-{suffix}"
+    # Created through a main-scoped client; every later call uses the branch-scoped one below.
+    _make_client(address, token).branch.create(branch_name=branch, sync_with_git=False)
+    client = _make_client(address, token, branch)
     try:
+        schema_response = requests.post(
+            f"{address}/api/schema/load?branch={branch}",
+            headers={"X-INFRAHUB-KEY": token, "Content-Type": "application/json"},
+            json={"schemas": [_SCHEMA]},
+            timeout=60,
+        )
+        schema_response.raise_for_status()
+        _await_schema_kinds(client, branch, (SITE_KIND, DEVICE_KIND))
+
+        site_name = f"unkeyed-site-{suffix}"
+        site = client.create(kind=SITE_KIND, branch=branch, data={"name": site_name})
+        site.save()
+
         adapter = InfrahubAdapter.__new__(InfrahubAdapter)
         adapter.client = client
-        adapter.schema = client.schema.all(branch=DESTINATION_BRANCH)
+        adapter.schema = client.schema.all(branch=branch)
         adapter.source_node = None
         adapter.owner_node = None
-        yield client, adapter, site_name
+        yield UnkeyedScope(client=client, adapter=adapter, branch=branch, site_name=site_name)
     finally:
-        for device in client.filters(kind=DEVICE_KIND, branch=DESTINATION_BRANCH, populate_store=False):
-            device.delete()
-        site.delete()
+        client.branch.delete(branch_name=branch)
+        assert not _branch_exists(address, token, branch), (
+            f"Branch {branch!r} survived teardown, so this run left destination state behind."
+        )
 
 
 def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destination(
-    live_unkeyed_fixture: tuple[Any, InfrahubAdapter, str],
+    unkeyed_scope: UnkeyedScope,
 ) -> None:
     """The refusal is proven against a live server, not against a recording transport.
 
@@ -180,21 +217,45 @@ def test_an_unkeyed_planned_operation_is_refused_without_touching_the_destinatio
     is a *duplicate* on re-apply: an unkeyed write that silently succeeded would show here as
     a count that climbed.
     """
-    client, adapter, site_name = live_unkeyed_fixture
-    before = client.count(kind=DEVICE_KIND, branch=DESTINATION_BRANCH)
+    scope = unkeyed_scope
+    before = scope.client.count(kind=DEVICE_KIND, branch=scope.branch)
 
     for attempt in range(2):
         with pytest.raises(UnkeyedWriteRefusedError) as refusal:
-            adapter.apply_planned_operation(
-                operation=_device_operation("unkeyed-device-a", site_name),
-                peers=adapter.new_peer_resolver(),
+            scope.adapter.apply_planned_operation(
+                operation=_device_operation("unkeyed-device-a", scope.site_name),
+                peers=scope.adapter.new_peer_resolver(),
             )
         assert DEVICE_KIND in str(refusal.value), f"The refusal must name the destination kind: {refusal.value}"
-        assert client.count(kind=DEVICE_KIND, branch=DESTINATION_BRANCH) == before, (
+        assert scope.client.count(kind=DEVICE_KIND, branch=scope.branch) == before, (
             f"Apply attempt {attempt + 1} changed the destination count for {DEVICE_KIND}, so the "
             "operation mutated the destination before the gate refused it."
         )
 
-    assert client.filters(kind=DEVICE_KIND, branch=DESTINATION_BRANCH, populate_store=False) == [], (
+    assert scope.client.filters(kind=DEVICE_KIND, branch=scope.branch, populate_store=False) == [], (
         f"A refused operation left an object of kind {DEVICE_KIND} at the destination."
+    )
+
+
+def test_the_run_writes_nothing_outside_the_branch_it_owns(unkeyed_scope: UnkeyedScope) -> None:
+    """Concurrency safety, asserted rather than described.
+
+    Two of these runs must be able to share one destination. That holds only if the schema and
+    the site this run created are invisible on `main`: a run that wrote there would both see
+    and delete another run's objects. Asserting the kind is absent from `main`'s schema is the
+    strongest form — it is not merely that no object exists, but that none could.
+    """
+    scope = unkeyed_scope
+    address, token = _env_or_skip()
+
+    response = requests.get(f"{address}/api/schema?branch=main", headers={"X-INFRAHUB-KEY": token}, timeout=30)
+    response.raise_for_status()
+    main_kinds = {node["kind"] for node in response.json().get("nodes", [])}
+
+    assert main_kinds & {SITE_KIND, DEVICE_KIND} == set(), (
+        f"The throwaway schema reached 'main' ({sorted(main_kinds & {SITE_KIND, DEVICE_KIND})}), so a "
+        "concurrent run would share this run's namespace."
+    )
+    assert scope.client.count(kind=SITE_KIND, branch=scope.branch) == 1, (
+        "The site this run created must be visible on its own branch, or the test above proves nothing."
     )

--- a/tests/integration/test_saved_plan_apply_integration.py
+++ b/tests/integration/test_saved_plan_apply_integration.py
@@ -1,16 +1,28 @@
-"""Phase H — the six criteria and half-criteria that need a running Infrahub. SUPERSEDED.
+"""Phase H — the criteria and half-criteria that need a running Infrahub, on a keyed slice.
 
-**This module is skipped at module level and is not live coverage of anything.** It was written
-and once run against a live destination, but its bounded slice qualifies through `InterfaceLag`
-and `InterfacePhysical`, whose destination human-friendly IDs cross a relationship. The
-fail-closed write contract refuses every rendered mutation carrying neither `id` nor `hfid`, so
-those two kinds are refused before they write and the seed step that must create a pre-existing
-`InterfaceLag` peer cannot complete. SC-008's relationship-crossing premise is therefore
-unsupported rather than unmet, and the earlier `7 passed, 1 error` result describes behaviour
-this repository no longer has. The keyed bundled qualification and the isolated unkeyed refusal
-cover this ground; the offline harness at `tests/plan/test_apply_conformance.py` asserts the
-mutation the SDK renders, including that refusal. Everything below is retained as the record of
-what the criteria asked for.
+**Re-derived for the fail-closed write contract.** The slice this module qualifies through is
+now all-direct: `BuiltinTag`, `LocationSite`, `LocationRack`, `OrganizationManufacturer`,
+`DcimPlatform`, `DcimDeviceType` are seeded, and `DcimDevice` is the kind under test. Every one
+of them declares `human_friendly_id: ['name__value']`, so every planned write here renders a key
+the client can form.
+
+The earlier slice qualified through `InterfaceLag` and `InterfacePhysical`, both
+`['device__name__value', 'name__value']`. A key that crosses a relationship cannot be rendered
+client-side, so the write surface refuses those kinds before they mutate and no supported slice
+can carry one. **SC-008's relationship-crossing peer premise is retired** — it required exactly
+such a kind to reach the destination — along with the nested `<rel>__<attr>__value` filter
+spelling it was the only live evidence for. The refusal itself is qualified directly by
+`tests/integration/test_infrahub_unkeyed_refusal_integration.py`; AD043's nested identity walk
+stays covered offline. Everything else the criteria asked for is preserved and runs live.
+
+**Expected result: six passed, one skipped.** The skip is SC-016's live half, and it is the
+AD092 precondition skip rather than a missing environment. It is now *structural* on a keyed
+slice: every kind in a supported slice is keyed all-direct on `name__value`, so the resolver
+filters it on exactly the component its uniqueness constraint pins, and the destination refuses
+a second matching object with `Violates uniqueness constraint` (HTTP 422). The skip message
+names every candidate kind, the filters it is queried with, and the constraint covering each.
+Nothing in that test is weakened: it runs in full against any schema whose referenced kinds
+leave a filtered component free.
 
 **Amended by AD090: "authored, not satisfied" was too weak a claim.** The first live run errored
 in fixture setup on every test here, because the fixture wrote its bounded configuration into a
@@ -33,64 +45,54 @@ Run them with a reachable destination and source::
 
     export INFRAHUB_ADDRESS="http://localhost:8000"
     export INFRAHUB_API_TOKEN="<token>"
-    export NETBOX_URL="https://demo.netbox.dev"
+    export NETBOX_URL="<netbox>"
     export NETBOX_TOKEN="<token>"
     uv run pytest -m integration tests/integration/test_saved_plan_apply_integration.py
 
-**These tests write to the destination.** SC-002 and SC-003 measure convergence, which is
-not observable without writing, so point them at a disposable Infrahub — the same posture
+The destination needs the pinned schema library loaded (see the NetBox tutorial). The source
+needs the deterministic seeded dataset: sites `site-a`/`site-b`/`site-c`, racks
+`rack-site-<x>-<n>`, devices `dev-01`…`dev-40`, tags `tag-01`…`tag-10`. `ADDED_FILTERS` bounds
+the run to `site-a`; the fixture raises a named setup error if that bounding stops matching.
+
+**These tests write to the destination and do not clean up after themselves.** SC-002 and
+SC-003 measure convergence, which is not observable without writing, so point them at a
+disposable Infrahub — the same posture
 `tests/integration/test_infrahub_node_to_diffsync_integration.py` already takes when it
 loads a throwaway schema and creates nodes against it.
 
-**Amended by AD091: the slice had to widen, because its own precondition refused it.** The
-earlier seven-entry slice ended at `DcimDevice`, and every kind `DcimDevice` references —
-`LocationRack`, `LocationSite`, `DcimDeviceType`, `DcimPlatform`, `BuiltinTag` — carries an
-**all-direct** destination human-friendly ID (`['name__value']`). So `_require_preexisting_peer`
-refused the fixture: with no relationship-crossing peer, SC-008's nested identity walk and
-PD-004's nested `<rel>__<attr>__value` filter spelling would have passed vacuously. The refusal
-was correct, and only live data could raise it, because which kinds have such a human-friendly ID
-is a fact about the **destination schema** and not about the configuration's `identifiers` lists —
-the same conflation AD091 corrects in the run's records. `InterfacePhysical` is the kind that
-supplies what was missing: two mapped kinds reference a kind whose destination human-friendly ID
-crosses a relationship — `DcimDevice.primary_address` → `IpamIPAddress` and
-`InterfacePhysical.bundle` → `InterfaceLag` — but `IpamIPAddress`'s plan identity
-(`identifiers: ["address", "vrf"]`) supplies no `ip_namespace` component at all, so no crossing
-filter can be formed for it and its own operations would be refused by
-`assert_convergence_key_is_supplied` first. `InterfaceLag`'s crossing component is
-`device__name__value`, its plan identity (`["device", "name"]`) supplies it, and it resolves
-against `DcimDevice` — already in the slice. `DcimDevice` and `InterfaceLag` therefore move into
-the seed. No assertion and no precondition below was weakened to get there.
+**One run per destination.** The fixture perturbs the destination with a per-run canary tag and
+then asserts the derived plan carries the create, update and delete those perturbations imply.
+A second run against the same instance sees the first run's canary still present, so its plan
+carries a *delete* of the old canary instead of the expected create, and every test here fails
+in setup naming the operation it wanted. That is destination state, not a defect: reset the
+instance (`invoke preview.down --volumes`, `preview.up`, reload the pinned schema library)
+between runs. Cleaning up inside the fixture is not equivalent — the plan is derived from the
+destination's state, so what must be fresh is the whole instance, not the objects this module
+happens to know it created.
 
 The fixture runs the qualified path (`examples/netbox_to_infrahub/config.yml`, NetBox →
-Infrahub) narrowed to ten of its schema-mapping entries, copied **verbatim** apart from the
-documented field removals (`DROPPED_FIELDS`) and the documented source-side bounding filter
-(`ADDED_FILTERS`): `BuiltinTag`, `LocationSite`, `LocationRack`, `OrganizationManufacturer`,
-`DcimPlatform`, `DcimDeviceType`, both `DcimDevice` entries, `InterfaceLag` and
-`InterfacePhysical`. The slice is the **reference closure** of `InterfacePhysical`, so no kind
-outside it is needed to resolve a peer, and it is the smallest closure that carries every
-shape this phase measures: a create with no references (`BuiltinTag`), an update
-(`LocationSite`), a relationship-bearing kind with a cardinality-one **and** a
-cardinality-many reference (`InterfacePhysical` — `device`, `bundle`; `DcimDevice` — `tags`),
-and — the one SC-008 turns on — a *referenced* kind whose **destination human-friendly ID
-crosses a relationship** (`InterfaceLag`, `['device__name__value', 'name__value']`), so a peer
-identity is a nested `{peer_kind, identity}` pair, the destination query that resolves it has
-to be spelled the nested way, and AD043's recursive resolution is exercised rather than
-declared.
+Infrahub) narrowed to the seven schema-mapping entries of the keyed slice, copied **verbatim**
+apart from the documented field removal (`DROPPED_FIELDS`) and the documented source-side
+bounding filter (`ADDED_FILTERS`): `BuiltinTag`, `LocationSite`, `LocationRack`,
+`OrganizationManufacturer`, `DcimPlatform`, `DcimDeviceType` and both `DcimDevice` entries. The
+slice is the **reference closure** of `DcimDevice`, so no kind outside it is needed to resolve a
+peer, and it carries every shape this phase can still measure: a create with no references
+(`BuiltinTag`), an update (`LocationSite`), and a reference-bearing kind with a cardinality-one
+**and** a cardinality-many reference (`DcimDevice` — `location`, `tags`).
 
 The plan under test is built in two phases, because three of its properties cannot be
 arranged after it exists:
 
-1. a **seed** run applies every kind except `InterfacePhysical`, so the devices, LAG
-   interfaces, racks, device types, platforms and tags a physical interface references already
-   exist at the destination *and no operation in the plan under test creates them* — the
-   pre-existing peers SC-008 requires, without which dependency-tier ordering fills the
+1. a **seed** run applies every kind except `DcimDevice`, so the racks, sites, device types,
+   platforms and tags a device references already exist at the destination *and no operation in
+   the plan under test creates them* — without which dependency-tier ordering fills the
    resolver's memo from the plan's own creates and the destination-query path under test never
    runs;
 2. the destination is then perturbed three ways — one unreferenced tag removed, one site's
    description changed, one tag created that the source does not have — so the plan under
    test carries a plain create, an update and a delete;
-3. the plan under test is derived over all ten entries, which adds the relationship-bearing
-   `InterfacePhysical` creates.
+3. the plan under test is derived over all seven entries, which adds the reference-bearing
+   `DcimDevice` creates.
 """
 
 from __future__ import annotations
@@ -121,16 +123,7 @@ if TYPE_CHECKING:
     from infrahub_sync.plan.models import PlannedOperation, RelationshipReference
     from infrahub_sync.plan.review import SavedPlan
 
-_SUPERSEDED_REASON = (
-    "Superseded by the fail-closed write contract: this module's slice qualifies through "
-    "InterfaceLag and InterfacePhysical, whose destination human-friendly IDs cross a "
-    "relationship, so neither can render a keyed mutation and both are refused before they "
-    "write. The seed step that must create a pre-existing InterfaceLag peer therefore cannot "
-    "run, and SC-008's relationship-crossing premise is unsupported rather than unmet. The "
-    "keyed bundled qualification and the isolated unkeyed refusal cover this ground instead."
-)
-
-pytestmark = [pytest.mark.integration, pytest.mark.skip(reason=_SUPERSEDED_REASON)]
+pytestmark = pytest.mark.integration
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUALIFIED_CONFIG = REPO_ROOT / "examples" / "netbox_to_infrahub" / "config.yml"
@@ -140,24 +133,27 @@ DESTINATION_BRANCH = "main"
 # The bounded slice of the qualified configuration, and the role each kind plays.
 TAG_KIND = "BuiltinTag"
 SITE_KIND = "LocationSite"
+RACK_KIND = "LocationRack"
 DEVICE_KIND = "DcimDevice"
-# The pre-existing peer whose destination human-friendly ID crosses a relationship (AD091).
-BUNDLE_KIND = "InterfaceLag"
-RELATIONSHIP_KIND = "InterfacePhysical"
 
-# Everything `InterfacePhysical` references, transitively. Seeded first, so every peer of an
-# interface pre-exists the plan under test and none of them is created by it (SC-008).
+# Every kind in the slice declares an all-direct destination human-friendly ID
+# (`['name__value']`), so every planned write here renders a key the client can form. The two
+# interface kinds the earlier slice carried — `InterfaceLag` and `InterfacePhysical`, both
+# `['device__name__value', 'name__value']` — cannot, and the write surface refuses them before
+# they mutate. `tests/integration/test_infrahub_unkeyed_refusal_integration.py` qualifies that
+# refusal directly; nothing here may depend on such a kind reaching the destination.
 SEED_KINDS = (
     TAG_KIND,
     SITE_KIND,
-    "LocationRack",
+    RACK_KIND,
     "OrganizationManufacturer",
     "DcimPlatform",
     "DcimDeviceType",
-    DEVICE_KIND,
-    BUNDLE_KIND,
 )
-KINDS_UNDER_TEST = (*SEED_KINDS, RELATIONSHIP_KIND)
+# `DcimDevice` is the kind under test: it is keyed, and it carries both a cardinality-one
+# reference whose peer identity nests (`location`) and a cardinality-many one (`tags`), so the
+# reference-resolution and replace-set paths are exercised by a supported kind.
+KINDS_UNDER_TEST = (*SEED_KINDS, DEVICE_KIND)
 
 # The first departure from copying the qualified configuration verbatim, and why. Every dropped
 # field references `IpamIPAddress` or `IpamVLAN`, whose own closures pull in `IpamVRF`,
@@ -168,47 +164,33 @@ KINDS_UNDER_TEST = (*SEED_KINDS, RELATIONSHIP_KIND)
 # untouched.
 DROPPED_FIELDS: Mapping[str, tuple[str, ...]] = {
     DEVICE_KIND: ("primary_address",),
-    RELATIONSHIP_KIND: ("ip_addresses",),
-    BUNDLE_KIND: ("ip_addresses", "untagged_vlan", "tagged_vlan"),
 }
 
 # The second departure, and why (AD091). It has two independent grounds, and the second is a
 # defect the first live run exposed rather than a matter of run time.
 #
-# **Ground one — size.** The qualified configuration maps 1727 physical interfaces on the NetBox
-# demo data, and the tests below apply the plan between one and six times each. Writing that
-# population twenty-odd times measures nothing these criteria do not already measure at one
-# device, and would put the live run into the hours. `BOUNDING_DEVICE` is chosen because two of
-# its physical interfaces are members of its one LAG interface, which is what makes the
-# relationship-crossing peer SC-008 needs exist at all.
+# **Ground one — size.** The source dataset carries 42 devices across three sites, and the tests
+# below apply the plan between one and six times each. Bounding to one site keeps the live run in
+# seconds while leaving every shape these criteria measure in scope.
 #
-# **Ground two — `LocationRack` is not convergent on the qualified path against this destination
-# schema, and that is a separate, now-recorded finding rather than something this fixture may
-# assert away.** Destination `LocationRack` declares `human_friendly_id: ['name__value']` and
-# `uniqueness_constraints: [['name__value']]` — keyed on the rack name **alone** — while the
-# configuration's identity for it is `identifiers: ["name", "site"]`. Thirteen NetBox demo racks
-# are named `Comms closet`, one per site, so thirteen distinct plan identities converge onto one
-# destination object whose `site` is whichever operation wrote last. Every re-derived plan then
-# reports a create *and* a delete for the same rack, and the churn cascades: `DcimDevice.location`
-# nests the rack identity, and `InterfaceLag` / `InterfacePhysical` nest the device identity, so
-# no kind in that chain can ever be seeded out of the plan. Note which way the mismatch runs:
-# FR-024's warning fires when the destination's key is **coarser than the plan can key on**
-# (`constraint <= identity` is what `warn_missing_convergence_key` tests), and here the constraint
-# *is* a subset of the identity, so both of its arms stay silent. Bounding both rack-bearing
-# entries to one site puts exactly one `Comms closet` in scope, which converges. The defect is not
-# fixed here and not hidden: it is recorded in the run's own records against this run's live
-# evidence, and none of the six criteria below is about it.
+# **Ground two — `LocationRack` is not convergent across sites on the qualified path, and that is
+# a separate recorded finding rather than something this fixture may assert away.** Destination
+# `LocationRack` declares `human_friendly_id: ['name__value']` — keyed on the rack name **alone**
+# — while the configuration's identity for it is `identifiers: ["name", "site"]`. Two racks that
+# share a name in different sites would converge onto one destination object whose `site` is
+# whichever operation wrote last. Note which way the mismatch runs: FR-024's warning fires when
+# the destination's key is **coarser than the plan can key on** (`constraint <= identity` is what
+# `warn_missing_convergence_key` tests), and here the constraint *is* a subset of the identity, so
+# both of its arms stay silent. Bounding to one site keeps the racks in scope distinctly named,
+# which converges. The defect is not fixed here and not hidden.
 #
 # Same species of documented departure as `DROPPED_FIELDS`, and asserted the same way: a filter
-# that stops matching leaves the plan with no relationship-bearing operation, which is a loud
-# setup error in `live_plan` naming the device.
-BOUNDING_DEVICE = "cisco1"
-BOUNDING_SITE = "dm-akron"
+# that stops matching leaves the plan with no operation for the kind under test, which is a loud
+# setup error in `live_plan`.
+BOUNDING_SITE = "site-a"
 ADDED_FILTERS: Mapping[str, tuple[dict[str, Any], ...]] = {
-    "LocationRack": ({"field": "site.slug", "operation": "==", "value": BOUNDING_SITE},),
+    RACK_KIND: ({"field": "site.slug", "operation": "==", "value": BOUNDING_SITE},),
     DEVICE_KIND: ({"field": "site.slug", "operation": "==", "value": BOUNDING_SITE},),
-    RELATIONSHIP_KIND: ({"field": "device.name", "operation": "==", "value": BOUNDING_DEVICE},),
-    BUNDLE_KIND: ({"field": "device.name", "operation": "==", "value": BOUNDING_DEVICE},),
 }
 
 # The environment both sides of the qualified path need. Missing any one of them skips.
@@ -617,9 +599,6 @@ class LivePlan:
     plan: SavedPlan
     client: Any
     schemas: Mapping[str, Any]
-    preexisting_peer_kind: str
-    preexisting_peer_identity: dict[str, Any]
-    preexisting_peer_filters: dict[str, Any]
 
 
 def _matching_node_ids(live: LivePlan, kind: str, identity: Mapping[str, Any]) -> list[str]:
@@ -842,12 +821,6 @@ def _require_operation(plan: SavedPlan, *, kind: str, action: str, name: str, ro
     raise LivePlanPreconditionError(msg)
 
 
-def _crosses_a_relationship(filters: Mapping[str, Any]) -> bool:
-    """Whether any filter kwarg is PD-004's nested `<rel>__<attr>__value` form."""
-    suffix = f"{_COMPONENT_SEPARATOR}{_VALUE_SUFFIX}"
-    return any(_COMPONENT_SEPARATOR in name.removesuffix(suffix) for name in filters)
-
-
 def _referenced_peers_absent_from_the_plan(
     plan: SavedPlan,
     operations: Sequence[PlannedOperation],
@@ -867,52 +840,26 @@ def _referenced_peers_absent_from_the_plan(
     ]
 
 
-def _require_preexisting_peer(
-    plan: SavedPlan,
-    operations: Sequence[PlannedOperation],
-    schemas: Mapping[str, Any],
-) -> dict[str, Any]:
+def _require_preexisting_peer(plan: SavedPlan, operations: Sequence[PlannedOperation]) -> tuple[str, dict[str, Any]]:
     """A referenced peer that pre-exists at the destination and that the plan does not create.
 
-    SC-008's load-bearing precondition. With every peer created by the same plan, tier
-    ordering fills the resolver's memo and the destination-query path — the requirement the
-    criterion exists to measure — never runs, so its absence is a setup error.
+    Load-bearing for the peer-resolution path: with every peer created by the same plan, tier
+    ordering fills the resolver's memo and the destination-query path never runs, so its
+    absence is a setup error rather than a failing assertion about the product.
 
-    Among those peers, the one returned is a peer whose **destination human-friendly ID
-    crosses a relationship** and whose plan identity supplies that crossing component. That
-    is the property that makes AD043's nested `{peer_kind, identity}` walk and PD-004's
-    nested `<rel>__<attr>__value` filter spelling actually run, and neither is decidable
-    offline. Which kinds have such a human-friendly ID is a fact about the destination
-    schema, so when none of the referenced kinds does, this is a setup error telling the
-    maintainer to widen `KINDS_UNDER_TEST` rather than a failing assertion about the product.
+    This no longer requires a peer whose destination human-friendly ID **crosses a
+    relationship**. That premise is retired: such a kind cannot render a keyed mutation, so
+    the write surface refuses it before it mutates, and no supported slice can carry one.
     """
     candidates = _referenced_peers_absent_from_the_plan(plan, operations)
     if not candidates:
         msg = (
             "Every peer the plan references is also created by the plan, so dependency-tier ordering fills the "
-            "resolver's memo and the destination-query path SC-008 measures is never exercised. The seed phase "
-            "was supposed to leave at least one referenced peer at the destination and out of the plan."
+            "resolver's memo and the destination-query path is never exercised. The seed phase was supposed to "
+            "leave at least one referenced peer at the destination and out of the plan."
         )
         raise LivePlanPreconditionError(msg)
-
-    inspected: dict[str, list[str]] = {}
-    for kind, identity in candidates:
-        inspected[kind] = _human_friendly_id(schemas, kind)
-        try:
-            filters = _identity_filters(schemas, kind, identity)
-        except LivePlanPreconditionError:
-            # This candidate supplies no scalar component at all; another may.
-            continue
-        if _crosses_a_relationship(filters):
-            return {"kind": kind, "identity": identity, "filters": filters}
-    msg = (
-        "No peer that pre-exists at the destination and is absent from the plan is queried through a "
-        f"relationship-crossing filter, so PD-004's nested `<rel>__<attr>__value` spelling and AD043's nested "
-        f"identity walk are not exercised. Referenced kinds and their destination human-friendly IDs: "
-        f"{inspected}. Widen KINDS_UNDER_TEST to a slice whose referenced kinds include one whose "
-        "human-friendly ID crosses a relationship."
-    )
-    raise LivePlanPreconditionError(msg)
+    return candidates[0]
 
 
 def _identity_key(identity: Mapping[str, Any]) -> str:
@@ -973,18 +920,29 @@ def live_plan(tmp_path_factory: pytest.TempPathFactory) -> Iterator[LivePlan]:
         _require_operation(
             plan, kind=TAG_KIND, action="delete", name=perturbations["delete_canary_name"], role="SC-007's live half"
         )
-        relationship_operations = [
-            operation for operation in plan.operations(kind=RELATIONSHIP_KIND) if operation.relationships
-        ]
-        if not relationship_operations:
+        # Non-vacuity: the kind under test must actually be in the plan, carrying both a
+        # cardinality-one reference whose peer identity nests and a cardinality-many one. A
+        # bounding filter that stops matching, or a mapping that drops a reference, would
+        # otherwise leave every assertion below true of an empty set.
+        device_operations = [operation for operation in plan.operations(kind=DEVICE_KIND) if operation.relationships]
+        if not device_operations:
             msg = (
-                f"The plan under test holds no relationship-bearing operation on {RELATIONSHIP_KIND!r}, so SC-008 and "
-                f"SC-003's third write class would measure nothing. The slice is bounded to the interfaces of "
-                f"{BOUNDING_DEVICE!r} (ADDED_FILTERS); if the qualified configuration or the source data no longer "
-                "carries that device, re-derive the bounding against them."
+                f"The plan under test holds no reference-bearing operation on {DEVICE_KIND!r}, so the "
+                f"reference-resolution and replace-set paths would measure nothing. The slice is bounded to "
+                f"site {BOUNDING_SITE!r} (ADDED_FILTERS); if the qualified configuration or the source data no "
+                "longer carries devices there, re-derive the bounding against them."
             )
             raise LivePlanPreconditionError(msg)
-        peer = _require_preexisting_peer(plan, relationship_operations, schemas)
+        cardinalities = {
+            reference.cardinality for operation in device_operations for reference in operation.relationships or ()
+        }
+        if cardinalities != {"one", "many"}:
+            msg = (
+                f"The {DEVICE_KIND!r} operations carry reference cardinalities {sorted(cardinalities)}, not both "
+                "'one' and 'many'. The cardinality-one path (peer resolution) and the cardinality-many path "
+                "(the replace-set flush) are different code, and one of them would go unmeasured."
+            )
+            raise LivePlanPreconditionError(msg)
 
         yield LivePlan(
             environment=environment,
@@ -995,9 +953,6 @@ def live_plan(tmp_path_factory: pytest.TempPathFactory) -> Iterator[LivePlan]:
             plan=plan,
             client=client,
             schemas=schemas,
-            preexisting_peer_kind=peer["kind"],
-            preexisting_peer_identity=peer["identity"],
-            preexisting_peer_filters=peer["filters"],
         )
     finally:
         monkeypatch.undo()
@@ -1226,46 +1181,44 @@ def test_the_write_class_conformance_matrix(live_plan: LivePlan, write_class: st
 # ---------------------------------------------------------------------------------------
 
 
-def test_relationship_peer_sets_match_the_plan(live_plan: LivePlan) -> None:
-    """SC-008: peer sets compared as unordered `(peer kind, peer identity)` pairs (AD043).
+def test_reference_peer_sets_match_the_plan(live_plan: LivePlan) -> None:
+    """Peer sets compared as unordered `(peer kind, peer identity)` pairs (AD043).
 
     Two things are asserted that a peer-set comparison alone would not reach:
 
     - the **destination-query path ran** for a peer the plan does not create. With every peer
       created by the same plan, dependency-tier ordering fills the resolver's memo and the
       query path never runs, so the comparison would pass while apply-time peer resolution is
-      broken. The fixture guarantees such a peer exists; here the query it forces is asserted
-      to have been issued.
-    - that query's **filter spelling**. The fixture picks a pre-existing peer whose
-      destination human-friendly ID crosses a relationship and whose plan identity supplies
-      that crossing component as a nested `{peer_kind, identity}` pair, so resolving it walks
-      AD043's nesting and asks the destination in PD-004's nested `<rel>__<attr>__value`
-      form — a claim no offline harness can settle.
+      broken. The seed phase guarantees such a peer exists; here the query it forces is
+      asserted to have been issued.
+    - the peer sets the destination actually holds afterwards.
+
+    **SC-008's relationship-crossing arm is retired.** It required a pre-existing peer whose
+    destination human-friendly ID crosses a relationship, so that resolving it exercised
+    PD-004's nested `<rel>__<attr>__value` filter spelling. Such a kind cannot render a keyed
+    mutation, so the write surface now refuses it before it mutates and no supported slice can
+    carry one. AD043's nested identity walk is still covered offline; what is no longer claimed
+    live is the nested filter spelling.
     """
-    operations = [
-        operation for operation in live_plan.plan.operations(kind=RELATIONSHIP_KIND) if operation.relationships
-    ]
-    assert operations, f"The plan holds no relationship-bearing {RELATIONSHIP_KIND} operation."
+    operations = [operation for operation in live_plan.plan.operations(kind=DEVICE_KIND) if operation.relationships]
+    assert operations, f"The plan holds no reference-bearing {DEVICE_KIND} operation."
+
+    peer_kind, peer_identity = _require_preexisting_peer(live_plan.plan, operations)
+    expected_filters = _identity_filters(live_plan.schemas, peer_kind, peer_identity)
 
     with _extraction_forbidden() as calls, _destination_queries_recorded(live_plan) as queries:
         _potenda_for_apply(live_plan).apply_plan(ownership=granted_ownership())
     assert calls == [], f"The apply path called {calls}, so the no-comparison-store precondition does not hold."
 
-    expected_filters = live_plan.preexisting_peer_filters
     matching = [
         query
         for query in queries
-        if query.get("kind") == live_plan.preexisting_peer_kind
-        and all(query.get(name) == value for name, value in expected_filters.items())
+        if query.get("kind") == peer_kind and all(query.get(name) == value for name, value in expected_filters.items())
     ]
     assert matching, (
-        f"No destination query resolved the pre-existing peer {live_plan.preexisting_peer_kind!r} "
-        f"{live_plan.preexisting_peer_identity!r} with {expected_filters}. The resolver answered it from its "
-        f"memo instead, so apply-time peer resolution was never exercised. Queries issued: {queries}"
-    )
-    assert _crosses_a_relationship(expected_filters), (
-        f"The pre-existing peer {live_plan.preexisting_peer_kind!r} is filtered by {sorted(expected_filters)}, none "
-        "of which crosses a relationship, so PD-004's nested filter spelling is not exercised."
+        f"No destination query resolved the pre-existing peer {peer_kind!r} {peer_identity!r} with "
+        f"{expected_filters}. The resolver answered it from its memo instead, so apply-time peer resolution was "
+        f"never exercised. Queries issued: {queries}"
     )
 
     observed = _observed_peer_sets(live_plan, operations)
@@ -1337,26 +1290,16 @@ def _ambiguous_peer_or_skip(live: LivePlan) -> tuple[str, dict[str, Any], dict[s
     those filters pin cannot hold a second matching object, and the destination answers the
     attempt with `Violates uniqueness constraint`, HTTP 422.
 
-    So every peer the plan references and does not create is checked against the schema — the
-    module fixture's chosen pre-existing peer first, so that where an ambiguity is admissible
-    for it the test measures exactly the peer T079 also resolves — and the first candidate
-    whose constraints leave a filtered component free is returned. When none does, that is
-    neither a missing environment nor a product defect but a verifiable, reproducible fact
-    about this schema, so it skips with the constraint that establishes it in the message.
-    The same skip pattern as `_env_or_skip`: a checked precondition, reported as a skip naming
-    what could not be established, rather than the setup error `LivePlanPreconditionError`
-    raises for a fixture that *should* have been satisfiable.
+    So every peer the plan references and does not create is checked against the schema, and
+    the first candidate whose constraints leave a filtered component free is returned. When
+    none does, that is neither a missing environment nor a product defect but a verifiable,
+    reproducible fact about this schema, so it skips with the constraint that establishes it in
+    the message. The same skip pattern as `_env_or_skip`: a checked precondition, reported as a
+    skip naming what could not be established, rather than the setup error
+    `LivePlanPreconditionError` raises for a fixture that *should* have been satisfiable.
     """
-    chosen = (live.preexisting_peer_kind, dict(live.preexisting_peer_identity))
     referencing = [operation for operation in live.plan.operations() if operation.relationships]
-    candidates = [
-        chosen,
-        *(
-            candidate
-            for candidate in _referenced_peers_absent_from_the_plan(live.plan, referencing)
-            if (candidate[0], _identity_key(candidate[1])) != (chosen[0], _identity_key(chosen[1]))
-        ),
-    ]
+    candidates = _referenced_peers_absent_from_the_plan(live.plan, referencing)
     refused: dict[str, str] = {}
     for kind, identity in candidates:
         try:

--- a/tests/integration/test_saved_plan_apply_integration.py
+++ b/tests/integration/test_saved_plan_apply_integration.py
@@ -1,18 +1,16 @@
-"""Phase H — the six criteria and half-criteria that need a running Infrahub.
+"""Phase H — the six criteria and half-criteria that need a running Infrahub. SUPERSEDED.
 
-**Authored, not satisfied (AD045b) — and now, for five of the six, satisfied (AD091).** No live
-Infrahub was reachable in the environment this feature was built in (AD007). One later was, and
-this module was run against it: **`7 passed, 1 error`**. SC-001, SC-002, SC-003, SC-008 and
-SC-007's live half **pass live**, which closes DBA-001, DBA-002, DBA-003, DBA-008 and DBA-007's
-live half. SC-016's live half does **not**: seeding a genuinely ambiguous peer needs a referenced
-kind whose uniqueness constraints do not cover the components the resolver filters on, and every
-kind the qualified configuration touches declares one that does — the destination answers the clone
-with `Violates uniqueness constraint 'device-name'`. That precondition is left exactly as written.
-Every test here stays `integration`-marked and skips itself when the destination environment is
-not configured, so a default `uv run pytest -q` still reports them as skips and the offline suite
-is unchanged. The offline conformance harness at `tests/plan/test_apply_conformance.py` narrowed
-the exposure by asserting the mutation the SDK renders; it never closed it, and nothing here was
-ever reportable as covered on its strength.
+**This module is skipped at module level and is not live coverage of anything.** It was written
+and once run against a live destination, but its bounded slice qualifies through `InterfaceLag`
+and `InterfacePhysical`, whose destination human-friendly IDs cross a relationship. The
+fail-closed write contract refuses every rendered mutation carrying neither `id` nor `hfid`, so
+those two kinds are refused before they write and the seed step that must create a pre-existing
+`InterfaceLag` peer cannot complete. SC-008's relationship-crossing premise is therefore
+unsupported rather than unmet, and the earlier `7 passed, 1 error` result describes behaviour
+this repository no longer has. The keyed bundled qualification and the isolated unkeyed refusal
+cover this ground; the offline harness at `tests/plan/test_apply_conformance.py` asserts the
+mutation the SDK renders, including that refusal. Everything below is retained as the record of
+what the criteria asked for.
 
 **Amended by AD090: "authored, not satisfied" was too weak a claim.** The first live run errored
 in fixture setup on every test here, because the fixture wrote its bounded configuration into a
@@ -123,7 +121,16 @@ if TYPE_CHECKING:
     from infrahub_sync.plan.models import PlannedOperation, RelationshipReference
     from infrahub_sync.plan.review import SavedPlan
 
-pytestmark = pytest.mark.integration
+_SUPERSEDED_REASON = (
+    "Superseded by the fail-closed write contract: this module's slice qualifies through "
+    "InterfaceLag and InterfacePhysical, whose destination human-friendly IDs cross a "
+    "relationship, so neither can render a keyed mutation and both are refused before they "
+    "write. The seed step that must create a pre-existing InterfaceLag peer therefore cannot "
+    "run, and SC-008's relationship-crossing premise is unsupported rather than unmet. The "
+    "keyed bundled qualification and the isolated unkeyed refusal cover this ground instead."
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.skip(reason=_SUPERSEDED_REASON)]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUALIFIED_CONFIG = REPO_ROOT / "examples" / "netbox_to_infrahub" / "config.yml"

--- a/tests/integration/test_saved_plan_apply_integration.py
+++ b/tests/integration/test_saved_plan_apply_integration.py
@@ -1103,11 +1103,10 @@ def test_applying_a_stored_plan_runs_no_extraction(live_plan: LivePlan) -> None:
 def test_re_applying_an_identical_plan_converges(live_plan: LivePlan) -> None:
     """SC-002: the same object, the same identity, no duplicate, for every kind in the plan.
 
-    This criterion **measures** convergence rather than asserting it holds (AD080): for a
-    destination kind whose convergence key crosses a relationship the render is unkeyed
-    today, and a duplicate here is the recorded AD066/AD067 limitation that
-    `tests/plan/test_apply_conformance.py` carries as a strict expected failure. A failure on
-    such a kind is this test doing its job. The assertion is not weakened for it.
+    A destination kind whose convergence key crosses a relationship cannot render keyed, and
+    its operation is now refused before it writes rather than duplicating. The apply therefore
+    stops at such a kind instead of converging past it, and this criterion measures the kinds
+    that do write. The assertion is not weakened for it.
     """
     writes = [operation for operation in live_plan.plan.operations() if operation.action != "delete"]
 

--- a/tests/plan/test_apply_conformance.py
+++ b/tests/plan/test_apply_conformance.py
@@ -7,10 +7,9 @@ the assembled `data`, because a relationship-crossing identity component is alre
 node-id string by then. So the harness runs a **real** `InfrahubNodeSync` built from the
 committed schema fixture with only the transport edge replaced; no server is contacted.
 
-Five assertions, because keyedness splits in two (AD067): an all-direct human-friendly-ID
-kind renders keyed; the relationship-crossing kind is the same assertion marked
-`xfail(strict=True)`, so the day the hole closes it xpasses and the limitation retires
-itself; the replace-set is issued for every cardinality-many relationship including
+Five assertions: an all-direct human-friendly-ID kind renders keyed; the
+relationship-crossing kind, which cannot render keyed client-side, is refused before its own
+mutation; the replace-set is issued for every cardinality-many relationship including
 `peers: []`, with no destination read; the flush names only the relationship fields
 being replaced (AD088); and applying the same operation twice renders byte-identical inputs.
 
@@ -35,6 +34,7 @@ from infrahub_sdk.schema import NodeSchemaAPI
 from infrahub_sdk.schema.main import BranchSchema
 
 from infrahub_sync.adapters.infrahub import InfrahubAdapter, PeerResolver
+from infrahub_sync.plan.errors import UnkeyedWriteRefusedError
 from infrahub_sync.plan.identity import canonical_identity, operation_id
 from infrahub_sync.plan.models import PlannedOperation, RelationshipReference
 
@@ -72,15 +72,6 @@ UNMAPPED_FIELD_MESSAGE = (
     "cardinality-many fields being replaced, never a re-render of the node. AD075 (the flush exists at all) "
     "and AD085 (the emptied peer set must survive it) depend on it too. Re-derive AD088 against the new SDK "
     "before changing this test."
-)
-
-XFAIL_REASON = (
-    "A human-friendly ID that crosses a relationship cannot render keyed today — the Material "
-    "risk row in plan.md. The plan carries no destination UUID (FR-012 forbids the load that "
-    "would supply one) so data['id'] is never set; the resolved relationship renders as "
-    "{'id': ...} with no __typename, so RelatedNodeSync.get() raises rather than consulting the "
-    "store, get_path_value catches that and returns None, and one None nulls the whole hfid. "
-    "Strict, so the day the write surface closes the hole this xpasses and fails the suite."
 )
 
 
@@ -162,7 +153,6 @@ def make_adapter(client: ConformanceClient) -> InfrahubAdapter:
     adapter.source_node = None
     adapter.owner_node = None
     adapter.schema = dict(SCHEMAS)
-    adapter._unkeyed_render_reported = set()
     return adapter
 
 
@@ -382,23 +372,21 @@ def test_an_all_direct_kind_renders_a_keyed_mutation(description: str, operation
 
 
 # ---------------------------------------------------------------------------------------
-# Assertion 2 — keyedness, the relationship-crossing kind (AD067)
+# Assertion 2 — the relationship-crossing kind is refused (AD066)
 # ---------------------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason=XFAIL_REASON)
-def test_a_relationship_crossing_kind_renders_a_keyed_mutation() -> None:
-    """The *same* assertion as above, on the kind that cannot satisfy it today."""
+def test_a_relationship_crossing_kind_is_refused_before_its_own_mutation() -> None:
+    """The kind that cannot render keyed is refused, not written unkeyed."""
     client, adapter, peers = seeded_adapter()
 
-    with record_rendered_inputs() as rendered:
+    with pytest.raises(UnkeyedWriteRefusedError):
         adapter.apply_planned_operation(operation=device_operation(), peers=peers)
 
-    assert client.mutation_names == [f"{DEVICE_KIND}Upsert"]
-    keyed = keys_of(rendered, DEVICE_KIND)
-    assert keyed
-    for keys in keyed:
-        assert "id" in keys or "hfid" in keys
+    assert client.mutations == [], (
+        "The refused operation makes zero mutation calls: the gate reads the rendered input "
+        "before the SDK write is issued."
+    )
 
 
 # ---------------------------------------------------------------------------------------

--- a/tests/service/test_compose_bootstrap.py
+++ b/tests/service/test_compose_bootstrap.py
@@ -301,10 +301,14 @@ def test_a_deployment_provider_exception_stays_behind_its_fixed_family(
     assert PROVIDER_CANARY not in caplog.text
 
 
-def test_a_prefect_context_exception_stays_behind_the_work_pool_family(
+def test_a_failure_running_the_pool_coroutine_stays_behind_the_work_pool_family(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Entering or leaving Prefect's client context is part of the provider boundary."""
+    """The loop `asyncio.run` owns is part of the provider boundary too.
+
+    The asynchronous context's own entry and exit are driven for real at the end of this
+    module; this case covers what the stub stands in for, the run call itself.
+    """
     _bootstrap_before_deployment(monkeypatch)
 
     def fail(coroutine: Coroutine[object, object, bool]) -> bool:
@@ -312,6 +316,55 @@ def test_a_prefect_context_exception_stays_behind_the_work_pool_family(
         raise RuntimeError(PROVIDER_CANARY)
 
     monkeypatch.setattr(bootstrap.asyncio, "run", fail)
+
+    with caplog.at_level("ERROR"):
+        result = bootstrap.main()
+
+    assert result == 1
+    assert "work-pool-unavailable" in caplog.text
+    assert PROVIDER_CANARY not in caplog.text
+
+
+class _FailsOnEntry:
+    """A real asynchronous context manager whose entry raises a provider exception.
+
+    Entering and leaving the Prefect client context are provider calls like any other: the
+    client is built from an endpoint and a credential, and both are rendered into the
+    exception text a failure carries.
+    """
+
+    async def __aenter__(self) -> _Pool:
+        raise RuntimeError(PROVIDER_CANARY)
+
+    async def __aexit__(self, *_details: object) -> None:
+        """Unreachable: entry never returns."""
+
+
+class _FailsOnExit:
+    """A real asynchronous context manager whose exit raises after a successful pool read."""
+
+    async def __aenter__(self) -> _Pool:
+        return _Pool(existing_type=PROCESS_POOL_TYPE)
+
+    async def __aexit__(self, *_details: object) -> None:
+        raise RuntimeError(PROVIDER_CANARY)
+
+
+def _bootstrap_before_the_work_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the steps before the pool, leaving `asyncio.run` and the context real."""
+    monkeypatch.setattr(bootstrap, "_bundled_package", _package)
+    monkeypatch.setattr(bootstrap.boto3, "client", lambda *_arguments, **_settings: _Bucket())
+    monkeypatch.setattr(bootstrap, "converge_bucket", lambda *_arguments: False)
+    monkeypatch.setattr(bootstrap, "_required", lambda _name: "present")
+
+
+@pytest.mark.parametrize("context", [_FailsOnEntry, _FailsOnExit], ids=["entering the context", "leaving it"])
+def test_a_real_client_context_failure_stays_behind_the_work_pool_family(
+    context: type, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The asynchronous context is driven for real, not stubbed at `asyncio.run`."""
+    _bootstrap_before_the_work_pool(monkeypatch)
+    monkeypatch.setattr(bootstrap, "get_client", context)
 
     with caplog.at_level("ERROR"):
         result = bootstrap.main()

--- a/tests/service/test_config_routes.py
+++ b/tests/service/test_config_routes.py
@@ -20,6 +20,7 @@ from infrahub_sync.configuration.models import ValidationFinding
 from infrahub_sync.product_store import configs as configs_service
 from infrahub_sync.product_store import local_product_projection
 from infrahub_sync.product_store.configs import ValidationReport
+from infrahub_sync.service import serve
 from infrahub_sync.service.app import create_app
 from infrahub_sync.service.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
 from infrahub_sync.service.config_routes import ConfigurationAPIError, ConfigurationRoutes
@@ -1098,8 +1099,11 @@ def test_create_app_keeps_run_and_configuration_dependencies_separate(tmp_path: 
     assert config_service.calls == ["list_configs"]
 
 
-def test_build_app_binds_one_projection_and_passes_configuration_dependency() -> None:
+def test_build_app_binds_one_projection_and_passes_configuration_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Runtime construction supplies one durable projection to both families."""
+    monkeypatch.setattr(serve, "collect_secret_values", tuple)
     received: list[object] = []
     route_dependency = object()
     projection_dependency = object()
@@ -1135,8 +1139,11 @@ def test_build_app_binds_one_projection_and_passes_configuration_dependency() ->
     assert received[-1] is route_dependency
 
 
-def test_build_app_composes_one_service_projection_for_runs_and_configurations() -> None:
+def test_build_app_composes_one_service_projection_for_runs_and_configurations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The deployed API has one environment-owned product projection."""
+    monkeypatch.setattr(serve, "collect_secret_values", tuple)
     projection = object()
     received: list[object] = []
 

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -61,6 +61,11 @@ NESTED_SECRET = "canary" + "n" * 58
 NESTED_BRANCHES = tuple(f"deep{letter * 55}" for letter in "xyz")
 NESTED_CREDENTIAL_PATH = ".".join((*NESTED_BRANCHES, NESTED_SECRET))
 
+# A declared adapter name longer than the finding text bound. The name is caller content and
+# reaches the missing-adapter message whole, so the bound cuts through it unless it is redacted
+# first. The grammar an adapter name must satisfy is `[a-z][a-z0-9_-]*`, with no length cap.
+ADAPTER_NAME_SECRET = "canary" + "m" * 294
+
 # Collected values whose shape a declared key cannot have. Each is exactly what
 # `collect_secret_values` collects — for the URL that is the userinfo rather than the whole
 # value — so a case here asserts the removal of a value the boundary really holds.
@@ -203,6 +208,22 @@ def _capabilities(*, allowed: tuple[str, ...], credential_paths: tuple[str, ...]
     return table
 
 
+def _named_source_package(adapter_name: str) -> dict[str, Any]:
+    """A valid package whose source role names `adapter_name`."""
+    package = _package(undeclared="canaryplain", credential_path="canarypath")
+    settings = package["configuration"]["source"]["settings"]
+    del settings["canaryplain"], settings["canarypath"]
+    package["configuration"]["source"]["name"] = adapter_name
+    return package
+
+
+def _with_source_adapter(adapter_name: str) -> dict[str, Any]:
+    """The builtin table plus a source adapter declared under `adapter_name`."""
+    table = dict(capabilities_module.BUILTIN_ADAPTER_CAPABILITIES)
+    table[adapter_name] = replace(table["netbox"], adapter_name=adapter_name)
+    return table
+
+
 def _install(monkeypatch: pytest.MonkeyPatch, table: dict[str, Any]) -> None:
     """Point the finding producer at one adapter declaration table."""
     monkeypatch.setattr(validation_module, "BUILTIN_ADAPTER_CAPABILITIES", table)
@@ -251,6 +272,7 @@ def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYNC_BOUND_TOKEN", BOUND_SECRET)
     monkeypatch.setenv("SYNC_LONG_TOKEN", LONG_SECRET)
     monkeypatch.setenv("SYNC_NESTED_TOKEN", NESTED_SECRET)
+    monkeypatch.setenv("SYNC_ADAPTER_TOKEN", ADAPTER_NAME_SECRET)
     monkeypatch.setenv("SYNC_UNICODE_TOKEN", SHAPED_SECRETS["unicode"])
     monkeypatch.setenv("SYNC_QUOTED_TOKEN", SHAPED_SECRETS["quoted"])
     monkeypatch.setenv("SYNC_ESCAPED_TOKEN", SHAPED_SECRETS["escaped"])
@@ -365,6 +387,30 @@ def test_the_stable_machine_fields_survive_redaction_byte_for_byte(
     assert [finding["severity"] for finding in report["findings"]] == [
         finding.severity for finding in pre_redaction.findings
     ]
+
+
+def test_a_withdrawn_adapter_declaration_never_exposes_an_adapter_name_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """Declaration drift reports the adapter name, and the message bound must not cut it.
+
+    Registering against a declared adapter and revalidating after that declaration is withdrawn
+    is the product's own current-declaration contract. The name is caller content, so a name
+    longer than the finding text bound leaves a prefix unless it is redacted before bounding.
+    """
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    _install(monkeypatch, _with_source_adapter(ADAPTER_NAME_SECRET))
+    registered = configs.register(package=_named_source_package(ADAPTER_NAME_SECRET), projection=projection)
+    _install(monkeypatch, dict(capabilities_module.BUILTIN_ADAPTER_CAPABILITIES))
+
+    report = _validate(monkeypatch, projection, registered.version)
+    body = json.dumps(report)
+
+    assert any(finding["code"] == "missing-adapter" for finding in report["findings"]), report
+    assert _longest_exposed_prefix(ADAPTER_NAME_SECRET, body) < MIN_SECRET_LENGTH, (
+        f"a prefix of the declared adapter name survived the message bound:\n{body}"
+    )
 
 
 def test_a_deep_declared_credential_path_never_exposes_a_secret_component_prefix(

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -1,9 +1,15 @@
 """A collected secret never reaches a serialized configuration validation finding.
 
-Diagnostics quote caller-declared keys, and the component bound cuts a key at 64 characters,
-so whole-value matching at a later boundary cannot find a longer secret. These cases drive the
-real HTTP surface — `build_app`, the router, and the serialized response — because that is the
-only place the producer's redaction and the boundary's redaction are both in force.
+Diagnostics quote caller-declared keys, and the length bounds cut one before a later
+whole-value match could find it. Every case drives the real router and the serialized response,
+because that is the only place the producer's redaction and the boundary's redaction are both
+in force.
+
+Two ways in, for two different reasons. A secret shaped like a declared name reaches the
+findings through the real producer, so those cases go through `build_app`. A secret that the
+declared-name grammar cannot express is injected as a `ValidationFinding` behind the route
+instead: the route's redaction of a report it did not produce is the thing under test, and each
+such case first asserts the value is really collected and really present before the boundary.
 """
 
 from __future__ import annotations
@@ -22,10 +28,16 @@ from fastapi.testclient import TestClient
 
 from infrahub_sync.configuration import capabilities as capabilities_module
 from infrahub_sync.configuration import validation as validation_module
-from infrahub_sync.execution import MIN_SECRET_LENGTH
+from infrahub_sync.configuration.models import ValidationFinding, safe_pointer_component
+from infrahub_sync.execution import MIN_SECRET_LENGTH, collect_secret_values
 from infrahub_sync.product_store import configs, local_product_projection
+from infrahub_sync.product_store.configs import ValidationReport
 from infrahub_sync.service import serve
-from infrahub_sync.service.auth import PRINCIPALS_ENV
+from infrahub_sync.service.app import create_app
+from infrahub_sync.service.auth import PRINCIPALS_ENV, EnvironmentPrincipalResolver
+from infrahub_sync.service.config_routes import ConfigurationRoutes
+from infrahub_sync.service.orchestration import Submission
+from infrahub_sync.service.service import RunService
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -42,8 +54,6 @@ SHORT_SECRET = "canary" + "a" * 4
 BOUND_SECRET = "canary" + "b" * 58
 LONG_SECRET = "canary" + "c" * 94
 
-# Shapes a declared key cannot have, collected from the environment all the same, so the
-# serialized response is asserted free of every collected value rather than of one shape.
 # A declared credential path deep enough that the pointer it builds passes the finding text
 # bound, with a secret as its last component. The bound then cuts through that component, and a
 # whole-value match at the final boundary cannot find the prefix left behind.
@@ -51,11 +61,14 @@ NESTED_SECRET = "canary" + "n" * 58
 NESTED_BRANCHES = tuple(f"deep{letter * 55}" for letter in "xyz")
 NESTED_CREDENTIAL_PATH = ".".join((*NESTED_BRANCHES, NESTED_SECRET))
 
-UNCOLLECTABLE_SHAPES = {
-    "SYNC_UNICODE_TOKEN": "cänary-sécret-" + "d" * 60,
-    "SYNC_QUOTED_TOKEN": "canary\"quoted'secret-" + "e" * 50,
-    "SYNC_ESCAPED_TOKEN": "canary/slash~tilde-" + "f" * 50,
-    "SYNC_USERINFO_URL": "https://canaryuser:canarypassword0002@example.invalid/api",
+# Collected values whose shape a declared key cannot have. Each is exactly what
+# `collect_secret_values` collects — for the URL that is the userinfo rather than the whole
+# value — so a case here asserts the removal of a value the boundary really holds.
+SHAPED_SECRETS = {
+    "unicode": "cänary-sécret-" + "d" * 60,
+    "quoted": "canary\"quoted'secret-" + "e" * 50,
+    "escaped": "canary/slash~tilde-" + "f" * 50,
+    "url-userinfo": "canaryuser:canarypassword0002",
 }
 
 
@@ -98,6 +111,74 @@ def _nested_package() -> dict[str, Any]:
         leaf = {branch: leaf}
     settings[NESTED_BRANCHES[0]] = leaf
     return package
+
+
+def _renderings(secret: str) -> set[str]:
+    """Every known rendering a boundary must remove: raw, pointer-escaped, JSON and repr."""
+    escaped = safe_pointer_component(secret)
+    return {secret, escaped, json.dumps(escaped, ensure_ascii=True)[1:-1], repr(secret)[1:-1]}
+
+
+def _injected_report(secret: str) -> ValidationReport:
+    """One report carrying `secret` where a producer would put caller content.
+
+    The pointer grammar refuses "/" and "~" outside an escape, so the location carries the
+    escaped form and the message carries the raw one — the two shapes a real finding has.
+    """
+    return ValidationReport(
+        config_id="injected",
+        registry_version=1,
+        package_checksum="c" * 64,
+        findings=(
+            ValidationFinding(
+                code="undeclared-setting",
+                severity="error",
+                location=f"/configuration/source/settings/{safe_pointer_component(secret)}",
+                message=f"setting {secret} is undeclared",
+            ),
+        ),
+        destination_schema_fingerprint=None,
+    )
+
+
+class _Orchestration:  # pylint: disable=too-few-public-methods
+    """The run service's collaborator, which no case here calls."""
+
+    async def submit(self, parameters: dict[str, object], *, idempotency_key: str) -> Submission:  # noqa: ARG002, PLR6301
+        return Submission(flow_run_id="unused", state="pending")
+
+
+def _validate_injected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, report: ValidationReport) -> dict[str, Any]:
+    """Serialize `report` through the real route, router and HTTP response.
+
+    Only the application service behind the route is replaced. The route's own secret set, its
+    redaction of the selected page, and the response model are the production ones.
+    """
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": BEARER, "administrator": True}}))
+    resolver = EnvironmentPrincipalResolver.from_environment()
+    secrets = tuple(dict.fromkeys((*collect_secret_values(), *resolver.secret_values)))
+    projection = local_product_projection(tmp_path)
+
+    class _Service:
+        ConfigsError = configs.ConfigsError
+        ConfigsRequestError = configs.ConfigsRequestError
+        ConfigsValidationError = configs.ConfigsValidationError
+        ConfigsNotFoundError = configs.ConfigsNotFoundError
+        ConfigsStorageError = configs.ConfigsStorageError
+        ConfigsInternalError = configs.ConfigsInternalError
+
+        @staticmethod
+        def validate(**_kwargs: object) -> ValidationReport:
+            return report
+
+    routes = ConfigurationRoutes(product_projection=projection, service=_Service(), secrets=secrets)
+    application = create_app(RunService(projection, _Orchestration(), secrets=secrets), resolver, routes)  # ty: ignore[invalid-argument-type]
+    response = TestClient(application).post(
+        f"/configs/{report.config_id}/versions/{report.registry_version}/validate",
+        headers={"Authorization": f"Bearer {BEARER}"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
 
 
 def _longest_exposed_prefix(secret: str, body: str) -> int:
@@ -170,8 +251,11 @@ def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYNC_BOUND_TOKEN", BOUND_SECRET)
     monkeypatch.setenv("SYNC_LONG_TOKEN", LONG_SECRET)
     monkeypatch.setenv("SYNC_NESTED_TOKEN", NESTED_SECRET)
-    for name, value in UNCOLLECTABLE_SHAPES.items():
-        monkeypatch.setenv(name, value)
+    monkeypatch.setenv("SYNC_UNICODE_TOKEN", SHAPED_SECRETS["unicode"])
+    monkeypatch.setenv("SYNC_QUOTED_TOKEN", SHAPED_SECRETS["quoted"])
+    monkeypatch.setenv("SYNC_ESCAPED_TOKEN", SHAPED_SECRETS["escaped"])
+    # Name-blind: the userinfo of any URL-shaped value is collected whatever the variable is called.
+    monkeypatch.setenv("SYNC_ENDPOINT", f"https://{SHAPED_SECRETS['url-userinfo']}@example.invalid/api")
 
 
 @pytest.mark.parametrize(
@@ -215,19 +299,31 @@ def test_both_reproduced_finding_families_are_reported_and_carry_no_secret(
         assert secret[:64] not in body
 
 
-def test_no_collected_value_of_any_shape_reaches_the_response(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+@pytest.mark.parametrize("shape", sorted(SHAPED_SECRETS), ids=sorted(SHAPED_SECRETS))
+def test_a_collected_value_of_any_shape_is_removed_from_the_serialized_findings(
+    shape: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
 ) -> None:
-    """Escaping, Unicode, quote and URL-userinfo shapes are absent in every rendering."""
+    """Escaping, Unicode, quote and URL-userinfo shapes leave the boundary in no rendering.
+
+    The declared-name grammar is `[a-z][a-z0-9_]*`, so none of these shapes can reach a finding
+    as a declared key. The finding is therefore injected: what is under test is the route's own
+    redaction of a report it did not produce. Two guards keep the case honest — the value is
+    asserted to be one the environment scan really collects, and the pre-redaction report is
+    asserted to carry the renderings the response is then asserted not to.
+    """
     _ = environment
-    projection = local_product_projection(tmp_path)
-    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+    secret = SHAPED_SECRETS[shape]
+    assert secret in collect_secret_values(), f"{secret!r} is not collected, so nothing would redact it"
 
-    body = json.dumps(_validate(monkeypatch, projection, version))
+    pre_redaction = _injected_report(secret)
+    serialized_before = json.dumps([finding.model_dump(mode="json") for finding in pre_redaction.findings])
+    exposed_before = {rendering for rendering in _renderings(secret) if rendering in serialized_before}
+    assert exposed_before, f"the injected report carries no rendering of {secret!r}, so the case is vacuous"
 
-    for value in UNCOLLECTABLE_SHAPES.values():
-        for rendering in (value, json.dumps(value)[1:-1], repr(value)[1:-1]):
-            assert rendering not in body, f"{rendering!r} reached the response:\n{body}"
+    body = json.dumps(_validate_injected(monkeypatch, tmp_path, pre_redaction))
+
+    for rendering in exposed_before:
+        assert rendering not in body, f"{rendering!r} survived the boundary:\n{body}"
 
 
 def test_two_secret_named_settings_stay_distinguishable_after_redaction(
@@ -247,22 +343,28 @@ def test_two_secret_named_settings_stay_distinguishable_after_redaction(
     assert all(location != SOURCE_SETTINGS for location in redacted)
 
 
-def test_the_stable_machine_fields_are_unchanged_by_redaction(
+def test_the_stable_machine_fields_survive_redaction_byte_for_byte(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
 ) -> None:
-    """A code, a severity and the report's own identifiers are never rewritten."""
+    """Every closed-vocabulary field leaves the boundary as the exact value that entered it.
+
+    Compared against the pre-redaction report rather than against a set of permitted values: an
+    environment holding a collected value equal to a code or a checksum would rewrite one of
+    these into something an allowed-set check still accepts.
+    """
     _ = environment
-    projection = local_product_projection(tmp_path)
-    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+    pre_redaction = _injected_report(SHAPED_SECRETS["quoted"])
 
-    report = _validate(monkeypatch, projection, version)
+    report = _validate_injected(monkeypatch, tmp_path, pre_redaction)
 
-    assert report["config_id"] == version.config_id
-    assert report["registry_version"] == version.registry_version
-    assert report["package_checksum"] == version.package_checksum
-    for finding in report["findings"]:
-        assert finding["severity"] in {"error", "warning"}
-        assert "*" not in finding["code"], f"a stable machine field was rewritten: {finding}"
+    assert report["config_id"] == pre_redaction.config_id
+    assert report["registry_version"] == pre_redaction.registry_version
+    assert report["package_checksum"] == pre_redaction.package_checksum
+    assert report["destination_schema_fingerprint"] == pre_redaction.destination_schema_fingerprint
+    assert [finding["code"] for finding in report["findings"]] == [finding.code for finding in pre_redaction.findings]
+    assert [finding["severity"] for finding in report["findings"]] == [
+        finding.severity for finding in pre_redaction.findings
+    ]
 
 
 def test_a_deep_declared_credential_path_never_exposes_a_secret_component_prefix(

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -67,6 +67,13 @@ NESTED_CREDENTIAL_PATH = ".".join((*NESTED_BRANCHES, NESTED_SECRET))
 # first. The grammar an adapter name must satisfy is `[a-z][a-z0-9_-]*`, with no length cap.
 ADAPTER_NAME_SECRET = "canary" + "m" * 294
 
+# A collected value whose last character is a space. `ValidationFinding` declares
+# `str_strip_whitespace`, so the model drops that space when it stores the message — and a
+# whole-value match at any later boundary then looks for a string the message no longer
+# contains. The value has to sit at the end of the message for the strip to reach it, which an
+# omission reason does.
+TRAILING_SPACE_SECRET = "canary-trailing-space-" + "t" * 50 + " "
+
 # Collected values whose shape a declared key cannot have. Each is exactly what
 # `collect_secret_values` collects — for the URL that is the userinfo rather than the whole
 # value — so a case here asserts the removal of a value the boundary really holds.
@@ -293,6 +300,7 @@ def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYNC_LONG_TOKEN", LONG_SECRET)
     monkeypatch.setenv("SYNC_NESTED_TOKEN", NESTED_SECRET)
     monkeypatch.setenv("SYNC_ADAPTER_TOKEN", ADAPTER_NAME_SECRET)
+    monkeypatch.setenv("SYNC_TRAILING_TOKEN", TRAILING_SPACE_SECRET)
     monkeypatch.setenv("SYNC_UNICODE_TOKEN", SHAPED_SECRETS["unicode"])
     monkeypatch.setenv("SYNC_QUOTED_TOKEN", SHAPED_SECRETS["quoted"])
     monkeypatch.setenv("SYNC_ESCAPED_TOKEN", SHAPED_SECRETS["escaped"])
@@ -478,6 +486,38 @@ def test_a_registered_adapter_name_never_reaches_a_finding_message_unredacted(
     assert any(finding["code"] == code for finding in report["findings"]), report
     assert _longest_exposed_prefix(ADAPTER_NAME_SECRET, body) < MIN_SECRET_LENGTH, (
         f"a prefix of the registered adapter name survived the message bound:\n{body}"
+    )
+
+
+def test_an_omission_reason_ending_in_whitespace_never_exposes_a_secret_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """Model normalization is a lossy transform, and it runs before whole-value redaction.
+
+    `ValidationFinding` declares `str_strip_whitespace`, so a message ending in a collected
+    value that itself ends in a space is stored one character shorter than the value. Every
+    later boundary matches whole values, so it finds nothing and the remaining characters
+    serialize. Redaction has to happen on the complete component, before the model sees it.
+    """
+    _ = environment
+    assert TRAILING_SPACE_SECRET in collect_secret_values(), (
+        "the trailing-space value is not collected, so nothing would redact it"
+    )
+
+    projection = local_product_projection(tmp_path)
+    package = _package(undeclared="canaryplain", credential_path="canarypath")
+    del package["configuration"]["source"]["settings"]["canaryplain"]
+    package["configuration"]["source"]["settings"]["canarypath"] = {"$credential": "netbox-token"}
+    package["omissions"] = [{"kind": "BuiltinTag", "reason": TRAILING_SPACE_SECRET}]
+    _install(monkeypatch, _capabilities(allowed=("canarypath",), credential_paths=("canarypath",)))
+    registered = configs.register(package=package, projection=projection)
+
+    report = _validate(monkeypatch, projection, registered.version)
+    body = json.dumps(report)
+
+    assert any(finding["code"] == "intentional-omission" for finding in report["findings"]), report
+    assert _longest_exposed_prefix(TRAILING_SPACE_SECRET, body) < MIN_SECRET_LENGTH, (
+        f"a prefix of the trailing-space secret survived model normalization:\n{body}"
     )
 
 

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -1,0 +1,234 @@
+"""A collected secret never reaches a serialized configuration validation finding.
+
+Diagnostics quote caller-declared keys, and the component bound cuts a key at 64 characters,
+so whole-value matching at a later boundary cannot find a longer secret. These cases drive the
+real HTTP surface — `build_app`, the router, and the serialized response — because that is the
+only place the producer's redaction and the boundary's redaction are both in force.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("prefect")
+
+from fastapi.testclient import TestClient
+
+from infrahub_sync.configuration import capabilities as capabilities_module
+from infrahub_sync.configuration import validation as validation_module
+from infrahub_sync.product_store import configs, local_product_projection
+from infrahub_sync.service import serve
+from infrahub_sync.service.auth import PRINCIPALS_ENV
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sync.product_store import ProductProjection
+    from infrahub_sync.product_store.models import ConfigurationVersion
+
+BEARER = "administrator-bearer-token-0001"
+SOURCE_SETTINGS = "/configuration/source/settings"
+
+# The declared setting name grammar is `[a-z][a-z0-9_]*`, so a secret only reaches these
+# findings as a key when it has that shape — which a hex or base32 token does.
+SHORT_SECRET = "canary" + "a" * 4
+BOUND_SECRET = "canary" + "b" * 58
+LONG_SECRET = "canary" + "c" * 94
+
+# Shapes a declared key cannot have, collected from the environment all the same, so the
+# serialized response is asserted free of every collected value rather than of one shape.
+UNCOLLECTABLE_SHAPES = {
+    "SYNC_UNICODE_TOKEN": "cänary-sécret-" + "d" * 60,
+    "SYNC_QUOTED_TOKEN": "canary\"quoted'secret-" + "e" * 50,
+    "SYNC_ESCAPED_TOKEN": "canary/slash~tilde-" + "f" * 50,
+    "SYNC_USERINFO_URL": "https://canaryuser:canarypassword0002@example.invalid/api",
+}
+
+
+def _package(*, undeclared: str, credential_path: str) -> dict[str, Any]:
+    """One valid package whose two secret-named settings are declared at registration."""
+    return copy.deepcopy(
+        {
+            "format_version": 1,
+            "configuration": {
+                "name": "secret-containment",
+                "source": {
+                    "name": "netbox",
+                    "settings": {
+                        "url": "https://demo.netbox.dev",
+                        "token": {"$credential": "netbox-token"},
+                        undeclared: "declared at registration",
+                        credential_path: {"$credential": "netbox-token"},
+                    },
+                },
+                "destination": {
+                    "name": "infrahub",
+                    "settings": {"url": "http://localhost:8000", "token": {"$credential": "infrahub-token"}},
+                },
+            },
+            "credentials": {
+                "netbox-token": {"provider": "env", "identifier": "NETBOX_TOKEN"},
+                "infrahub-token": {"provider": "env", "identifier": "INFRAHUB_API_TOKEN"},
+            },
+        }
+    )
+
+
+def _capabilities(*, allowed: tuple[str, ...], credential_paths: tuple[str, ...]) -> dict[str, Any]:
+    """The builtin table with netbox's source surface widened by the named settings."""
+    table = dict(capabilities_module.BUILTIN_ADAPTER_CAPABILITIES)
+    netbox = table["netbox"]
+    table["netbox"] = replace(
+        netbox,
+        allowed_settings=netbox.allowed_settings | set(allowed),
+        credential_setting_paths=(*netbox.credential_setting_paths, *credential_paths),
+    )
+    return table
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, table: dict[str, Any]) -> None:
+    """Point the finding producer at one adapter declaration table."""
+    monkeypatch.setattr(validation_module, "BUILTIN_ADAPTER_CAPABILITIES", table)
+
+
+def _register_then_narrow(
+    monkeypatch: pytest.MonkeyPatch,
+    projection: ProductProjection,
+    *,
+    undeclared: str,
+    credential_path: str,
+) -> ConfigurationVersion:
+    """Register while the declaration accepts both settings, then withdraw both from it.
+
+    Revalidating a persisted version against the *current* declaration is the product's own
+    contract, and it is the only way a registered package reports these two families.
+    """
+    _install(monkeypatch, _capabilities(allowed=(undeclared, credential_path), credential_paths=(credential_path,)))
+    registered = configs.register(
+        package=_package(undeclared=undeclared, credential_path=credential_path), projection=projection
+    )
+    _install(monkeypatch, _capabilities(allowed=(credential_path,), credential_paths=()))
+    return registered.version
+
+
+def _validate(
+    monkeypatch: pytest.MonkeyPatch, projection: ProductProjection, version: ConfigurationVersion
+) -> dict[str, Any]:
+    """Drive the real serialized validation response for the one registered version."""
+    monkeypatch.setenv(PRINCIPALS_ENV, json.dumps({"admin": {"token": BEARER, "administrator": True}}))
+    app = serve.build_app(projection_factory=lambda: projection)
+    response = TestClient(app).post(
+        f"/configs/{version.config_id}/versions/{version.registry_version}/validate",
+        headers={"Authorization": f"Bearer {BEARER}"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+@pytest.fixture
+def environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every canary in place before `build_app` collects them."""
+    monkeypatch.setenv("NETBOX_TOKEN", "netbox-token-value-0003")
+    monkeypatch.setenv("INFRAHUB_API_TOKEN", "infrahub-token-value-0004")
+    monkeypatch.setenv("SYNC_SHORT_TOKEN", SHORT_SECRET)
+    monkeypatch.setenv("SYNC_BOUND_TOKEN", BOUND_SECRET)
+    monkeypatch.setenv("SYNC_LONG_TOKEN", LONG_SECRET)
+    for name, value in UNCOLLECTABLE_SHAPES.items():
+        monkeypatch.setenv(name, value)
+
+
+@pytest.mark.parametrize(
+    ("description", "secret"),
+    [("shorter than the bound", SHORT_SECRET), ("exactly the bound", BOUND_SECRET), ("longer than it", LONG_SECRET)],
+)
+def test_a_secret_named_setting_is_absent_from_the_serialized_findings(
+    description: str,
+    secret: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    environment: None,
+) -> None:
+    """A declared key carrying a collected value never reaches the response, at any length."""
+    _ = description, environment
+    projection = local_product_projection(tmp_path)
+    version = _register_then_narrow(monkeypatch, projection, undeclared=secret, credential_path="canarypath")
+
+    body = json.dumps(_validate(monkeypatch, projection, version))
+
+    assert secret not in body, f"the whole secret reached the response:\n{body}"
+    assert secret[:64] not in body, f"a bounded prefix of the secret reached the response:\n{body}"
+
+
+def test_both_reproduced_finding_families_are_reported_and_carry_no_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """The two families the defect was reproduced in are still produced, and are safe."""
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+
+    report = _validate(monkeypatch, projection, version)
+    codes = {finding["code"] for finding in report["findings"]}
+    body = json.dumps(report)
+
+    assert "undeclared-setting" in codes, report
+    assert "credential-path-not-declared" in codes, report
+    for secret in (LONG_SECRET, BOUND_SECRET):
+        assert secret not in body
+        assert secret[:64] not in body
+
+
+def test_no_collected_value_of_any_shape_reaches_the_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """Escaping, Unicode, quote and URL-userinfo shapes are absent in every rendering."""
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+
+    body = json.dumps(_validate(monkeypatch, projection, version))
+
+    for value in UNCOLLECTABLE_SHAPES.values():
+        for rendering in (value, json.dumps(value)[1:-1], repr(value)[1:-1]):
+            assert rendering not in body, f"{rendering!r} reached the response:\n{body}"
+
+
+def test_two_secret_named_settings_stay_distinguishable_after_redaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """Redaction is lossy, so two pointers it maps together keep the existing location tag."""
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+
+    report = _validate(monkeypatch, projection, version)
+    redacted = [
+        finding["location"] for finding in report["findings"] if finding["location"].startswith(SOURCE_SETTINGS)
+    ]
+
+    assert len(redacted) == len(set(redacted)), f"two redacted pointers collapsed onto one: {redacted}"
+    assert all(location != SOURCE_SETTINGS for location in redacted)
+
+
+def test_the_stable_machine_fields_are_unchanged_by_redaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """A code, a severity and the report's own identifiers are never rewritten."""
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    version = _register_then_narrow(monkeypatch, projection, undeclared=LONG_SECRET, credential_path=BOUND_SECRET)
+
+    report = _validate(monkeypatch, projection, version)
+
+    assert report["config_id"] == version.config_id
+    assert report["registry_version"] == version.registry_version
+    assert report["package_checksum"] == version.package_checksum
+    for finding in report["findings"]:
+        assert finding["severity"] in {"error", "warning"}
+        assert "*" not in finding["code"], f"a stable machine field was rewritten: {finding}"

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -40,6 +40,7 @@ from infrahub_sync.service.orchestration import Submission
 from infrahub_sync.service.service import RunService
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from infrahub_sync.product_store import ProductProjection
@@ -217,11 +218,30 @@ def _named_source_package(adapter_name: str) -> dict[str, Any]:
     return package
 
 
-def _with_source_adapter(adapter_name: str) -> dict[str, Any]:
-    """The builtin table plus a source adapter declared under `adapter_name`."""
+def _with_source_adapter(adapter_name: str, overrides: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """The builtin table plus a source adapter declared under `adapter_name`.
+
+    `overrides` re-declare that adapter's surface, which is how each drift case below is
+    produced: the package registers against the declaration, then the declaration changes.
+    """
     table = dict(capabilities_module.BUILTIN_ADAPTER_CAPABILITIES)
-    table[adapter_name] = replace(table["netbox"], adapter_name=adapter_name)
+    table[adapter_name] = replace(table["netbox"], adapter_name=adapter_name, **(overrides or {}))
     return table
+
+
+def _raising_validator(_package: Any, _role: Any) -> Any:  # noqa: ANN401 — adapter validator contract
+    """An adapter-owned validator that fails, so its containment finding names the adapter."""
+    msg = "validator exploded"
+    raise RuntimeError(msg)
+
+
+# Each case: a declaration override applied *after* registration, keyed by the finding code the
+# resulting drift produces. All three quote the registered adapter name in their message.
+ADAPTER_NAME_DRIFT: dict[str, dict[str, Any]] = {
+    "adapter-role-mismatch": {"roles": frozenset({"destination"})},
+    "undeclared-setting": {"allowed_settings": frozenset({"token"})},
+    "adapter-validator-finding": {"validator": _raising_validator},
+}
 
 
 def _install(monkeypatch: pytest.MonkeyPatch, table: dict[str, Any]) -> None:
@@ -328,21 +348,41 @@ def test_a_collected_value_of_any_shape_is_removed_from_the_serialized_findings(
     """Escaping, Unicode, quote and URL-userinfo shapes leave the boundary in no rendering.
 
     The declared-name grammar is `[a-z][a-z0-9_]*`, so none of these shapes can reach a finding
-    as a declared key. The finding is therefore injected: what is under test is the route's own
-    redaction of a report it did not produce. Two guards keep the case honest — the value is
-    asserted to be one the environment scan really collects, and the pre-redaction report is
-    asserted to carry the renderings the response is then asserted not to.
+    as a declared *key*. They reach one as declared *free text*: an omission's `reason` is
+    caller-supplied, bounded only by length and printability, and the intentional-omission
+    producer renders it verbatim into a finding message. So this drives the real path — a
+    registered configuration, revalidated through `configs.validate`, serialized by the real
+    `ConfigurationRoutes` — rather than a report handed to the route ready-made.
+
+    Two guards keep the case honest per shape: the value is asserted to be one the environment
+    scan really collects, and the producer's own pre-redaction output is asserted to carry a
+    rendering of it before the response is asserted not to.
     """
     _ = environment
     secret = SHAPED_SECRETS[shape]
     assert secret in collect_secret_values(), f"{secret!r} is not collected, so nothing would redact it"
 
-    pre_redaction = _injected_report(secret)
+    projection = local_product_projection(tmp_path)
+    package = _package(undeclared="canaryplain", credential_path="canarypath")
+    del package["configuration"]["source"]["settings"]["canaryplain"]
+    package["configuration"]["source"]["settings"]["canarypath"] = {"$credential": "netbox-token"}
+    package["omissions"] = [{"kind": "BuiltinTag", "reason": f"Q-002 {secret}"}]
+    _install(monkeypatch, _capabilities(allowed=("canarypath",), credential_paths=("canarypath",)))
+    registered = configs.register(package=package, projection=projection)
+
+    # What the producer emits with no secrets supplied — the leak this boundary must remove.
+    pre_redaction = configs.validate(
+        config_id=registered.version.config_id,
+        registry_version=registered.version.registry_version,
+        projection=projection,
+    )
     serialized_before = json.dumps([finding.model_dump(mode="json") for finding in pre_redaction.findings])
     exposed_before = {rendering for rendering in _renderings(secret) if rendering in serialized_before}
-    assert exposed_before, f"the injected report carries no rendering of {secret!r}, so the case is vacuous"
+    assert exposed_before, (
+        f"the producer emitted no rendering of {secret!r}, so this case would pass vacuously:\n{serialized_before}"
+    )
 
-    body = json.dumps(_validate_injected(monkeypatch, tmp_path, pre_redaction))
+    body = json.dumps(_validate(monkeypatch, projection, registered.version))
 
     for rendering in exposed_before:
         assert rendering not in body, f"{rendering!r} survived the boundary:\n{body}"
@@ -410,6 +450,34 @@ def test_a_withdrawn_adapter_declaration_never_exposes_an_adapter_name_prefix(
     assert any(finding["code"] == "missing-adapter" for finding in report["findings"]), report
     assert _longest_exposed_prefix(ADAPTER_NAME_SECRET, body) < MIN_SECRET_LENGTH, (
         f"a prefix of the declared adapter name survived the message bound:\n{body}"
+    )
+
+
+@pytest.mark.parametrize("code", sorted(ADAPTER_NAME_DRIFT), ids=sorted(ADAPTER_NAME_DRIFT))
+def test_a_registered_adapter_name_never_reaches_a_finding_message_unredacted(
+    code: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    environment: None,
+) -> None:
+    """A declared adapter name is caller content wherever a finding quotes it.
+
+    Once a package registers against a declaration, the capability's own `adapter_name` *is*
+    the caller's string — the table is keyed by it. Every producer that quotes it therefore
+    quotes caller content, and a name longer than the finding text bound leaves a prefix.
+    """
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    _install(monkeypatch, _with_source_adapter(ADAPTER_NAME_SECRET))
+    registered = configs.register(package=_named_source_package(ADAPTER_NAME_SECRET), projection=projection)
+    _install(monkeypatch, _with_source_adapter(ADAPTER_NAME_SECRET, ADAPTER_NAME_DRIFT[code]))
+
+    report = _validate(monkeypatch, projection, registered.version)
+    body = json.dumps(report)
+
+    assert any(finding["code"] == code for finding in report["findings"]), report
+    assert _longest_exposed_prefix(ADAPTER_NAME_SECRET, body) < MIN_SECRET_LENGTH, (
+        f"a prefix of the registered adapter name survived the message bound:\n{body}"
     )
 
 

--- a/tests/service/test_validation_secret_containment.py
+++ b/tests/service/test_validation_secret_containment.py
@@ -22,6 +22,7 @@ from fastapi.testclient import TestClient
 
 from infrahub_sync.configuration import capabilities as capabilities_module
 from infrahub_sync.configuration import validation as validation_module
+from infrahub_sync.execution import MIN_SECRET_LENGTH
 from infrahub_sync.product_store import configs, local_product_projection
 from infrahub_sync.service import serve
 from infrahub_sync.service.auth import PRINCIPALS_ENV
@@ -43,6 +44,13 @@ LONG_SECRET = "canary" + "c" * 94
 
 # Shapes a declared key cannot have, collected from the environment all the same, so the
 # serialized response is asserted free of every collected value rather than of one shape.
+# A declared credential path deep enough that the pointer it builds passes the finding text
+# bound, with a secret as its last component. The bound then cuts through that component, and a
+# whole-value match at the final boundary cannot find the prefix left behind.
+NESTED_SECRET = "canary" + "n" * 58
+NESTED_BRANCHES = tuple(f"deep{letter * 55}" for letter in "xyz")
+NESTED_CREDENTIAL_PATH = ".".join((*NESTED_BRANCHES, NESTED_SECRET))
+
 UNCOLLECTABLE_SHAPES = {
     "SYNC_UNICODE_TOKEN": "cänary-sécret-" + "d" * 60,
     "SYNC_QUOTED_TOKEN": "canary\"quoted'secret-" + "e" * 50,
@@ -78,6 +86,28 @@ def _package(*, undeclared: str, credential_path: str) -> dict[str, Any]:
             },
         }
     )
+
+
+def _nested_package() -> dict[str, Any]:
+    """A valid package carrying a plain value at the deep path, so registration accepts it."""
+    package = _package(undeclared="canaryplain", credential_path="canarypath")
+    settings = package["configuration"]["source"]["settings"]
+    del settings["canaryplain"], settings["canarypath"]
+    leaf: dict[str, Any] = {NESTED_SECRET: "declared at registration"}
+    for branch in reversed(NESTED_BRANCHES[1:]):
+        leaf = {branch: leaf}
+    settings[NESTED_BRANCHES[0]] = leaf
+    return package
+
+
+def _longest_exposed_prefix(secret: str, body: str) -> int:
+    """The length of the longest leading run of `secret` that `body` still contains.
+
+    Redaction and the length bounds are both lossy, so "the whole value is absent" is too weak
+    a property: a bound that cuts through an unredacted component leaves a prefix, and whole-value
+    matching at any later boundary cannot find one. Zero means nothing of the value survived.
+    """
+    return next((cut for cut in range(len(secret), 0, -1) if secret[:cut] in body), 0)
 
 
 def _capabilities(*, allowed: tuple[str, ...], credential_paths: tuple[str, ...]) -> dict[str, Any]:
@@ -139,6 +169,7 @@ def environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYNC_SHORT_TOKEN", SHORT_SECRET)
     monkeypatch.setenv("SYNC_BOUND_TOKEN", BOUND_SECRET)
     monkeypatch.setenv("SYNC_LONG_TOKEN", LONG_SECRET)
+    monkeypatch.setenv("SYNC_NESTED_TOKEN", NESTED_SECRET)
     for name, value in UNCOLLECTABLE_SHAPES.items():
         monkeypatch.setenv(name, value)
 
@@ -232,3 +263,30 @@ def test_the_stable_machine_fields_are_unchanged_by_redaction(
     for finding in report["findings"]:
         assert finding["severity"] in {"error", "warning"}
         assert "*" not in finding["code"], f"a stable machine field was rewritten: {finding}"
+
+
+def test_a_deep_declared_credential_path_never_exposes_a_secret_component_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment: None
+) -> None:
+    """The pointer bound must never cut through an unredacted declared component.
+
+    The path is declared by the adapter capability rather than by the package, so it does not
+    reach the finding through the declared-content walk. It is bounded all the same, and a cut
+    through a secret component leaves a prefix no whole-value match can remove.
+    """
+    _ = environment
+    projection = local_product_projection(tmp_path)
+    _install(monkeypatch, _capabilities(allowed=(NESTED_BRANCHES[0],), credential_paths=()))
+    registered = configs.register(package=_nested_package(), projection=projection)
+    _install(
+        monkeypatch,
+        _capabilities(allowed=(NESTED_BRANCHES[0],), credential_paths=(NESTED_CREDENTIAL_PATH,)),
+    )
+
+    report = _validate(monkeypatch, projection, registered.version)
+    body = json.dumps(report)
+
+    assert any(finding["code"] == "inline-credential-value" for finding in report["findings"]), report
+    assert _longest_exposed_prefix(NESTED_SECRET, body) < MIN_SECRET_LENGTH, (
+        f"a prefix of the declared secret component survived the pointer bound:\n{body}"
+    )


### PR DESCRIPTION
## Problem

Saved-plan apply could warn and continue when the SDK rendered neither a usable `id` nor `hfid`, allowing an unkeyed Infrahub mutation. Validation diagnostics could also truncate caller-declared secrets before the final redaction boundary, exposing secret prefixes.

## Solution

- Refuse every planned create/update whose final SDK-rendered input has no usable `id` or `hfid`, immediately before `node.save()`.
- Redact declared secret components before diagnostic bounds, then apply final finding redaction at the HTTP boundary.
- Preserve sequential apply semantics: earlier keyed writes remain, the unkeyed operation fails, and later operations do not run.
- Add real bootstrap async-context regressions and live Infrahub/NetBox qualification for keyed saved-plan apply and isolated unkeyed refusal.

```text
before: unkeyed rendered write -> warning -> destination mutation
after:  unkeyed rendered write -> UnkeyedWriteRefusedError -> no mutation
```

## User-visible changes

Saved-plan apply now fails closed for kinds whose destination key cannot be rendered, including relationship-crossing human-friendly IDs and kinds with no human-friendly ID. Validation findings no longer expose prefixes of collected secrets when messages or locations are bounded.

## Verification

- `uv run invoke format`
- `uv run invoke lint`
- `uv run pytest -q` — 3967 passed, 161 skipped
- `uv run invoke check-310` — 3102 passed, 13 skipped, 144 deselected
- CLI help checks for the root, `configs`, and `runs` commands
- Live disposable fixtures:
  - keyed saved-plan apply: 6 passed, 1 optional schema-precondition skip; zero mandatory skips
  - isolated unkeyed refusal and nested-peer read: 3 passed
  - keyed replace-set and schema read: 3 passed
  - isolated-worker handoff: 3 passed
  - separate-sync guard: 4 passed
  - Preview smoke: 23 passed

The live NetBox source and Infrahub destination were disposable; their containers, volumes, networks, and temporary credential files were removed after verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saved-plan applies now refuse unkeyed writes before sending mutations, preventing partial unintended changes.
  * Validation diagnostics no longer expose declared secret values, including in configuration paths and omission messages.
  * Failed sequential applies record completed operations and stop subsequent writes.

* **Documentation**
  * Updated saved-plan and migration guidance to explain keyed destination requirements, unsupported shapes, sequential application, and partial-write records.
  * Added details on integration testing requirements and environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->