### PR TITLE
feat: use marketplace command to download schemas

### DIFF
--- a/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
+++ b/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
@@ -113,36 +113,17 @@ This is a production-grade Infrahub schema, not a copy of NetBox's data model. I
 
 :::
 
-This collection of schemas is still a work in progress; eventually it will be available through the marketplace. For now, download the files directly:
+The schemas are published on the [Infrahub Marketplace](https://marketplace.infrahub.app/collections/infrahub/traditional-infrastructure-sot) as the `infrahub/traditional-infrastructure-sot` collection. Download it with `infrahubctl`, which the project template already installs:
 
 ```bash
-BRANCH="bgi-schema-library-v2"
-DEST="schemas"
-BASE_URL="https://raw.githubusercontent.com/opsmill/schema-library/${BRANCH}"
-
-FILES=(
-  "base/dcim.yml"
-  "base/location.yml"
-  "base/ipam.yml"
-  "base/organization.yml"
-  "extensions/aggregate/aggregate.yml"
-  "extensions/cable/cable.yml"
-  "extensions/circuit/circuit.yml"
-  "extensions/compute/compute.yml"
-  "extensions/cluster/cluster.yml"
-  "extensions/hosting_cluster/hosting_cluster.yml"
-  "extensions/lag/lag.yml"
-  "extensions/location_site/location_site.yml"
-  "extensions/vlan/vlan.yml"
-  "extensions/qinq/qinq.yml"
-  "extensions/rack/rack.yml"
-  "extensions/vrf/vrf.yml"
-)
-
-for f in "${FILES[@]}"; do
-  curl -sSL --create-dirs -o "${DEST}/${f}" "${BASE_URL}/${f}"
-done
+uv run infrahubctl marketplace get infrahub/traditional-infrastructure-sot --collection
 ```
+
+The command writes the collection's 16 schema files into `schemas/traditional-infrastructure-sot/`. It reads from the marketplace only, so your Infrahub instance does not need to be reachable yet.
+
+:::success Verification
+Run `ls schemas/traditional-infrastructure-sot`. You should see files including `dcim.yml`, `location.yml`, `ipam.yml`, and `organization.yml`.
+:::
 
 Export the local Infrahub address and API token. Infrahub Sync will need them later to authenticate against your instance:
 
@@ -153,7 +134,7 @@ export INFRAHUB_API_TOKEN="06438eb2-8019-4776-878c-0941b1f1d1ec"
 
 This is the default admin token that the project's Docker Compose stack seeds automatically, and it matches the default already configured in `infrahubctl.toml`. Do not reuse it for an internet-facing or shared Infrahub instance.
 
-Then load the schema into Infrahub using the project's `load-schema` task:
+Then load the schema into Infrahub using the project's `load-schema` task, which walks the `schemas/` folder recursively and picks up everything you just downloaded:
 
 ```bash
 uv run invoke load-schema

--- a/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
+++ b/docs/docs/tutorials/netbox-demo-to-infrahub.mdx
@@ -88,7 +88,7 @@ You should see the Infrahub web interface with a navigation menu on the left sid
 1. Install the Python dependencies with uv:
 
 ```bash
-uv add "infrahub-sync==2.0.0" pynetbox
+uv add infrahub-sync pynetbox
 ```
 
 This installs the `infrahub-sync` command. `pynetbox` is required by the NetBox adapter.

--- a/examples/netbox_to_infrahub/config.yml
+++ b/examples/netbox_to_infrahub/config.yml
@@ -127,7 +127,7 @@ schema_mapping:
         reference: LocationSite
       - name: height
         mapping: u_height
-      - name: facility_id
+      - name: facility
         mapping: facility_id
       - name: status
         mapping: status.value
@@ -215,7 +215,7 @@ schema_mapping:
     fields:
       - name: name # /!\ Netbox allows duplicate device names within a virtual-chassis.
         mapping: name
-      - name: serial
+      - name: serial_number
         mapping: serial
       - name: description
         mapping: description
@@ -257,7 +257,7 @@ schema_mapping:
     fields:
       - name: name
         mapping: name
-      - name: serial
+      - name: serial_number
         mapping: serial
       - name: description
         mapping: description
@@ -614,7 +614,7 @@ schema_mapping:
         mapping: name
       - name: description
         mapping: description
-      - name: is_private
+      - name: private
         mapping: is_private
       - name: tags
         mapping: tags

--- a/examples/netbox_to_infrahub/infrahub/sync_adapter.py
+++ b/examples/netbox_to_infrahub/infrahub/sync_adapter.py
@@ -4,22 +4,25 @@ from infrahub_sync.plugin_loader import PluginLoader
 
 from .sync_models import (
     BuiltinTag,
-    ChoiceCircuitType,
-    ChoiceDeviceType,
-    CoreStandardGroup,
-    InfraCircuit,
-    InfraDevice,
-    InfraInterfaceL2L3,
-    InfraIPAddress,
-    InfraPrefix,
-    InfraProviderNetwork,
-    InfraRack,
-    InfraRouteTarget,
-    InfraVLAN,
-    InfraVRF,
-    LocationGeneric,
-    OrganizationGeneric,
-    RoleGeneric,
+    DcimCircuit,
+    DcimDevice,
+    DcimDeviceType,
+    DcimPlatform,
+    InterfaceLag,
+    InterfacePhysical,
+    InterfaceVirtual,
+    IpamAggregate,
+    IpamIPAddress,
+    IpamPrefix,
+    IpamRouteTarget,
+    IpamVLAN,
+    IpamVLANGroup,
+    IpamVRF,
+    LocationRack,
+    LocationSite,
+    OrganizationManufacturer,
+    OrganizationProvider,
+    OrganizationRIR,
 )
 
 # Load adapter class dynamically at runtime
@@ -33,20 +36,23 @@ _AdapterBaseClass = PluginLoader().resolve("infrahub")
 #  All modifications will be lost the next time you reexecute this command
 # -------------------------------------------------------
 class InfrahubSync(_AdapterBaseClass):
-    CoreStandardGroup = CoreStandardGroup
     BuiltinTag = BuiltinTag
-    ChoiceCircuitType = ChoiceCircuitType
-    ChoiceDeviceType = ChoiceDeviceType
-    InfraCircuit = InfraCircuit
-    InfraDevice = InfraDevice
-    InfraIPAddress = InfraIPAddress
-    InfraInterfaceL2L3 = InfraInterfaceL2L3
-    InfraPrefix = InfraPrefix
-    InfraProviderNetwork = InfraProviderNetwork
-    InfraRack = InfraRack
-    InfraRouteTarget = InfraRouteTarget
-    InfraVLAN = InfraVLAN
-    InfraVRF = InfraVRF
-    LocationGeneric = LocationGeneric
-    OrganizationGeneric = OrganizationGeneric
-    RoleGeneric = RoleGeneric
+    DcimCircuit = DcimCircuit
+    DcimDeviceType = DcimDeviceType
+    DcimPlatform = DcimPlatform
+    DcimDevice = DcimDevice
+    InterfacePhysical = InterfacePhysical
+    InterfaceVirtual = InterfaceVirtual
+    IpamPrefix = IpamPrefix
+    IpamIPAddress = IpamIPAddress
+    IpamAggregate = IpamAggregate
+    OrganizationRIR = OrganizationRIR
+    InterfaceLag = InterfaceLag
+    LocationSite = LocationSite
+    OrganizationManufacturer = OrganizationManufacturer
+    OrganizationProvider = OrganizationProvider
+    LocationRack = LocationRack
+    IpamVLAN = IpamVLAN
+    IpamVLANGroup = IpamVLANGroup
+    IpamVRF = IpamVRF
+    IpamRouteTarget = IpamRouteTarget

--- a/examples/netbox_to_infrahub/infrahub/sync_models.py
+++ b/examples/netbox_to_infrahub/infrahub/sync_models.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
 from infrahub_sync.plugin_loader import PluginLoader
-
 # Load model class dynamically at runtime (honor adapters_path, safe fallback)
 try:
-    _loader = PluginLoader.from_env_and_args(adapter_paths=[])
+
+    _loader = PluginLoader.from_env_and_args()
+
 
     _spec = "infrahub"
 
@@ -14,247 +15,269 @@ try:
 except Exception:
     # Fallback: use DiffSyncModel to avoid import-time failure
     from diffsync import DiffSyncModel as _FallbackModel
-
     _ModelBaseClass = _FallbackModel
-
 
 # -------------------------------------------------------
 # AUTO-GENERATED FILE, DO NOT MODIFY
 #  This file has been generated with the command `infrahub-sync generate`
 #  All modifications will be lost the next time you reexecute this command
 # -------------------------------------------------------
-class CoreStandardGroup(_ModelBaseClass):
-    _modelname = "CoreStandardGroup"
-    _identifiers = ("name",)
-    _attributes = ("description",)
-    description: str | None = None
-    name: str
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
 class BuiltinTag(_ModelBaseClass):
     _modelname = "BuiltinTag"
     _identifiers = ("name",)
     _attributes = ("description",)
-    name: str
     description: str | None = None
+    name: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
+class DcimCircuit(_ModelBaseClass):
+    _modelname = "DcimCircuit"
+    _identifiers = ("circuit_id",)
+    _attributes = ("provider", "description", "commit_rate", "status")
+    circuit_id: str
+    description: str | None = None
+    commit_rate: int | None = None
+    status: str | None = "active"
+    provider: str
 
-class ChoiceCircuitType(_ModelBaseClass):
-    _modelname = "ChoiceCircuitType"
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimDeviceType(_ModelBaseClass):
+    _modelname = "DcimDeviceType"
+    _identifiers = ("name", "manufacturer")
+    _attributes = ("part_number", "height", "full_depth", "weight")
+    name: str
+    part_number: str | None = None
+    height: int | None = 1
+    full_depth: bool | None = True
+    weight: int | None = None
+    manufacturer: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimPlatform(_ModelBaseClass):
+    _modelname = "DcimPlatform"
+    _identifiers = ("name",)
+    _attributes = ("manufacturer",)
+    name: str
+    manufacturer: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimDevice(_ModelBaseClass):
+    _modelname = "DcimDevice"
+    _identifiers = ("location", "name")
+    _attributes = ("tags", "primary_address", "platform", "device_type", "status", "description", "position", "serial_number", "rack_face")
+    status: str | None = "active"
+    name: str
+    description: str | None = None
+    position: int | None = None
+    serial_number: str | None = None
+    rack_face: str | None = "front"
+    tags: list[str] | None = []
+    primary_address: str | None = None
+    platform: str | None = None
+    device_type: str | None = None
+    location: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfacePhysical(_ModelBaseClass):
+    _modelname = "InterfacePhysical"
+    _identifiers = ("device", "name")
+    _attributes = ("bundle", "ip_addresses", "description", "mtu", "mac_address", "l2_mode")
+    name: str
+    description: str | None = None
+    mtu: int | None = 1500
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    bundle: str | None = None
+    device: str
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfaceVirtual(_ModelBaseClass):
+    _modelname = "InterfaceVirtual"
+    _identifiers = ("device", "name")
+    _attributes = ("untagged_vlan", "tagged_vlan", "ip_addresses", "description", "mac_address", "l2_mode")
+    name: str
+    description: str | None = None
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    device: str
+    untagged_vlan: str | None = None
+    tagged_vlan: list[str] | None = []
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamPrefix(_ModelBaseClass):
+    _modelname = "IpamPrefix"
+    _identifiers = ("prefix", "vrf")
+    _attributes = ("status", "description", "member_type")
+    status: str | None = "active"
+    description: str | None = None
+    member_type: str | None = "address"
+    prefix: str
+    vrf: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamIPAddress(_ModelBaseClass):
+    _modelname = "IpamIPAddress"
+    _identifiers = ("address", "vrf")
+    _attributes = ("description", "status")
+    description: str | None = None
+    status: str | None = "active"
+    address: str
+    vrf: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamAggregate(_ModelBaseClass):
+    _modelname = "IpamAggregate"
+    _identifiers = ("prefix",)
+    _attributes = ("rir", "description", "date_added")
+    description: str | None = None
+    date_added: str | None = None
+    prefix: str
+    rir: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class OrganizationRIR(_ModelBaseClass):
+    _modelname = "OrganizationRIR"
+    _identifiers = ("name",)
+    _attributes = ("tags", "private", "description")
+    private: bool | None = False
+    name: str
+    description: str | None = None
+    tags: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfaceLag(_ModelBaseClass):
+    _modelname = "InterfaceLag"
+    _identifiers = ("device", "name")
+    _attributes = ("untagged_vlan", "tagged_vlan", "ip_addresses", "description", "mac_address", "l2_mode", "bundle_number")
+    name: str
+    description: str | None = None
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    bundle_number: int
+    device: str
+    untagged_vlan: str | None = None
+    tagged_vlan: list[str] | None = []
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class LocationSite(_ModelBaseClass):
+    _modelname = "LocationSite"
+    _identifiers = ("name",)
+    _attributes = ("tags", "status", "facility", "physical_address", "timezone", "description")
+    status: str | None = "active"
+    facility: str | None = None
+    physical_address: str | None = None
+    timezone: str | None = None
+    name: str
+    description: str | None = None
+    tags: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class OrganizationManufacturer(_ModelBaseClass):
+    _modelname = "OrganizationManufacturer"
     _identifiers = ("name",)
     _attributes = ("tags", "description")
-    description: str | None = None
     name: str
-    tags: list[str] | None = []
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class ChoiceDeviceType(_ModelBaseClass):
-    _modelname = "ChoiceDeviceType"
-    _identifiers = ("name", "manufacturer")
-    _attributes = ("tags", "height", "full_depth", "part_number")
-    height: int | None = None
-    full_depth: bool | None = None
-    part_number: str | None = None
-    name: str
-    manufacturer: str
-    tags: list[str] | None = []
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraCircuit(_ModelBaseClass):
-    _modelname = "InfraCircuit"
-    _identifiers = ("circuit_id",)
-    _attributes = ("tags", "type", "provider", "vendor_id", "description")
-    circuit_id: str
-    vendor_id: str | None = None
     description: str | None = None
     tags: list[str] | None = []
-    type: str
-    provider: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraDevice(_ModelBaseClass):
-    _modelname = "InfraDevice"
-    _identifiers = ("location", "rack", "organization", "name")
-    _attributes = ("model", "role", "tags", "serial_number", "description", "asset_tag")
-    name: str | None = None
-    serial_number: str | None = None
-    description: str | None = None
-    asset_tag: str | None = None
-    model: str
-    rack: str | None = None
-    role: str | None = None
-    tags: list[str] | None = []
-    location: str
-    organization: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraIPAddress(_ModelBaseClass):
-    _modelname = "InfraIPAddress"
-    _identifiers = ("address", "vrf")
-    _attributes = ("organization", "description")
-    address: str
-    description: str | None = None
-    organization: str | None = None
-    vrf: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraInterfaceL2L3(_ModelBaseClass):
-    _modelname = "InfraInterfaceL2L3"
-    _identifiers = ("device", "name")
-    _attributes = ("tagged_vlan", "tags", "l2_mode", "mac_address", "description", "interface_type", "mgmt_only")
-    l2_mode: str | None = None
-    mac_address: str | None = None
-    description: str | None = None
-    interface_type: str | None = None
-    mgmt_only: bool | None = False
-    name: str
-    tagged_vlan: list[str] | None = []
-    untagged_vlan: str | None = None
-    tags: list[str] | None = []
-    device: str
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraPrefix(_ModelBaseClass):
-    _modelname = "InfraPrefix"
-    _identifiers = ("prefix", "vrf")
-    _attributes = ("role", "organization", "location", "description")
-    prefix: str
-    description: str | None = None
-    role: str | None = None
-    organization: str | None = None
-    location: str | None = None
-    vrf: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraProviderNetwork(_ModelBaseClass):
-    _modelname = "InfraProviderNetwork"
+class OrganizationProvider(_ModelBaseClass):
+    _modelname = "OrganizationProvider"
     _identifiers = ("name",)
-    _attributes = ("provider", "tags", "vendor_id", "description")
-    vendor_id: str | None = None
+    _attributes = ("tags", "description")
     name: str
     description: str | None = None
-    provider: str
     tags: list[str] | None = []
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraRack(_ModelBaseClass):
-    _modelname = "InfraRack"
-    _identifiers = ("name", "location")
-    _attributes = ("tags", "role", "asset_tag", "facility_id", "height", "serial_number")
-    asset_tag: str | None = None
-    facility_id: str | None = None
-    height: int | None = None
+class LocationRack(_ModelBaseClass):
+    _modelname = "LocationRack"
+    _identifiers = ("name", "site")
+    _attributes = ("tags", "facility", "status", "height", "serial_number", "asset_tag")
     name: str
+    facility: str | None = None
+    status: str | None = "active"
+    height: int | None = 42
     serial_number: str | None = None
+    asset_tag: str | None = None
+    site: str
     tags: list[str] | None = []
-    role: str | None = None
-    location: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
+class IpamVLAN(_ModelBaseClass):
+    _modelname = "IpamVLAN"
+    _identifiers = ("name", "vlan_id", "vlan_group")
+    _attributes = ("description", "status")
+    name: str
+    description: str | None = None
+    vlan_id: int
+    status: str | None = "active"
+    vlan_group: str
 
-class InfraRouteTarget(_ModelBaseClass):
-    _modelname = "InfraRouteTarget"
-    _identifiers = ("name", "organization")
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamVLANGroup(_ModelBaseClass):
+    _modelname = "IpamVLANGroup"
+    _identifiers = ("name",)
     _attributes = ("description",)
     name: str
     description: str | None = None
-    organization: str | None = None
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraVLAN(_ModelBaseClass):
-    _modelname = "InfraVLAN"
-    _identifiers = ("name", "vlan_id", "location", "vlan_group")
-    _attributes = ("organization", "description")
-    description: str | None = None
-    name: str
-    vlan_id: int
-    vlan_group: str | None = None
-    organization: str | None = None
-    location: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraVRF(_ModelBaseClass):
-    _modelname = "InfraVRF"
+class IpamVRF(_ModelBaseClass):
+    _modelname = "IpamVRF"
     _identifiers = ("name",)
-    _attributes = ("export_rt", "organization", "import_rt", "description", "vrf_rd")
-    description: str | None = None
+    _attributes = ("import_rt", "export_rt", "vrf_rd", "enforce_unique", "description")
+    name: str
     vrf_rd: str | None = None
-    name: str
-    export_rt: list[str] | None = []
-    organization: str | None = None
+    enforce_unique: bool | None = True
+    description: str | None = None
     import_rt: list[str] | None = []
+    export_rt: list[str] | None = []
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class LocationGeneric(_ModelBaseClass):
-    _modelname = "LocationGeneric"
-    _identifiers = ("name",)
-    _attributes = ("organization", "tags", "group", "description", "type")
-    description: str | None = None
-    type: str
-    name: str
-    organization: str | None = None
-    tags: list[str] | None = []
-    group: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class OrganizationGeneric(_ModelBaseClass):
-    _modelname = "OrganizationGeneric"
-    _identifiers = ("name",)
-    _attributes = ("group", "description")
-    description: str | None = None
-    name: str
-    group: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class RoleGeneric(_ModelBaseClass):
-    _modelname = "RoleGeneric"
+class IpamRouteTarget(_ModelBaseClass):
+    _modelname = "IpamRouteTarget"
     _identifiers = ("name",)
     _attributes = ("description",)
     name: str

--- a/examples/netbox_to_infrahub/netbox/sync_adapter.py
+++ b/examples/netbox_to_infrahub/netbox/sync_adapter.py
@@ -4,22 +4,25 @@ from infrahub_sync.plugin_loader import PluginLoader
 
 from .sync_models import (
     BuiltinTag,
-    ChoiceCircuitType,
-    ChoiceDeviceType,
-    CoreStandardGroup,
-    InfraCircuit,
-    InfraDevice,
-    InfraInterfaceL2L3,
-    InfraIPAddress,
-    InfraPrefix,
-    InfraProviderNetwork,
-    InfraRack,
-    InfraRouteTarget,
-    InfraVLAN,
-    InfraVRF,
-    LocationGeneric,
-    OrganizationGeneric,
-    RoleGeneric,
+    DcimCircuit,
+    DcimDevice,
+    DcimDeviceType,
+    DcimPlatform,
+    InterfaceLag,
+    InterfacePhysical,
+    InterfaceVirtual,
+    IpamAggregate,
+    IpamIPAddress,
+    IpamPrefix,
+    IpamRouteTarget,
+    IpamVLAN,
+    IpamVLANGroup,
+    IpamVRF,
+    LocationRack,
+    LocationSite,
+    OrganizationManufacturer,
+    OrganizationProvider,
+    OrganizationRIR,
 )
 
 # Load adapter class dynamically at runtime
@@ -33,20 +36,23 @@ _AdapterBaseClass = PluginLoader().resolve("netbox")
 #  All modifications will be lost the next time you reexecute this command
 # -------------------------------------------------------
 class NetboxSync(_AdapterBaseClass):
-    CoreStandardGroup = CoreStandardGroup
     BuiltinTag = BuiltinTag
-    ChoiceCircuitType = ChoiceCircuitType
-    ChoiceDeviceType = ChoiceDeviceType
-    InfraCircuit = InfraCircuit
-    InfraDevice = InfraDevice
-    InfraIPAddress = InfraIPAddress
-    InfraInterfaceL2L3 = InfraInterfaceL2L3
-    InfraPrefix = InfraPrefix
-    InfraProviderNetwork = InfraProviderNetwork
-    InfraRack = InfraRack
-    InfraRouteTarget = InfraRouteTarget
-    InfraVLAN = InfraVLAN
-    InfraVRF = InfraVRF
-    LocationGeneric = LocationGeneric
-    OrganizationGeneric = OrganizationGeneric
-    RoleGeneric = RoleGeneric
+    DcimCircuit = DcimCircuit
+    DcimDeviceType = DcimDeviceType
+    DcimPlatform = DcimPlatform
+    DcimDevice = DcimDevice
+    InterfacePhysical = InterfacePhysical
+    InterfaceVirtual = InterfaceVirtual
+    IpamPrefix = IpamPrefix
+    IpamIPAddress = IpamIPAddress
+    IpamAggregate = IpamAggregate
+    OrganizationRIR = OrganizationRIR
+    InterfaceLag = InterfaceLag
+    LocationSite = LocationSite
+    OrganizationManufacturer = OrganizationManufacturer
+    OrganizationProvider = OrganizationProvider
+    LocationRack = LocationRack
+    IpamVLAN = IpamVLAN
+    IpamVLANGroup = IpamVLANGroup
+    IpamVRF = IpamVRF
+    IpamRouteTarget = IpamRouteTarget

--- a/examples/netbox_to_infrahub/netbox/sync_models.py
+++ b/examples/netbox_to_infrahub/netbox/sync_models.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
 from infrahub_sync.plugin_loader import PluginLoader
-
 # Load model class dynamically at runtime (honor adapters_path, safe fallback)
 try:
-    _loader = PluginLoader.from_env_and_args(adapter_paths=[])
+
+    _loader = PluginLoader.from_env_and_args()
+
 
     _spec = "netbox"
 
@@ -14,247 +15,269 @@ try:
 except Exception:
     # Fallback: use DiffSyncModel to avoid import-time failure
     from diffsync import DiffSyncModel as _FallbackModel
-
     _ModelBaseClass = _FallbackModel
-
 
 # -------------------------------------------------------
 # AUTO-GENERATED FILE, DO NOT MODIFY
 #  This file has been generated with the command `infrahub-sync generate`
 #  All modifications will be lost the next time you reexecute this command
 # -------------------------------------------------------
-class CoreStandardGroup(_ModelBaseClass):
-    _modelname = "CoreStandardGroup"
-    _identifiers = ("name",)
-    _attributes = ("description",)
-    description: str | None = None
-    name: str
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
 class BuiltinTag(_ModelBaseClass):
     _modelname = "BuiltinTag"
     _identifiers = ("name",)
     _attributes = ("description",)
-    name: str
     description: str | None = None
+    name: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
+class DcimCircuit(_ModelBaseClass):
+    _modelname = "DcimCircuit"
+    _identifiers = ("circuit_id",)
+    _attributes = ("provider", "description", "commit_rate", "status")
+    circuit_id: str
+    description: str | None = None
+    commit_rate: int | None = None
+    status: str | None = "active"
+    provider: str
 
-class ChoiceCircuitType(_ModelBaseClass):
-    _modelname = "ChoiceCircuitType"
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimDeviceType(_ModelBaseClass):
+    _modelname = "DcimDeviceType"
+    _identifiers = ("name", "manufacturer")
+    _attributes = ("part_number", "height", "full_depth", "weight")
+    name: str
+    part_number: str | None = None
+    height: int | None = 1
+    full_depth: bool | None = True
+    weight: int | None = None
+    manufacturer: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimPlatform(_ModelBaseClass):
+    _modelname = "DcimPlatform"
+    _identifiers = ("name",)
+    _attributes = ("manufacturer",)
+    name: str
+    manufacturer: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class DcimDevice(_ModelBaseClass):
+    _modelname = "DcimDevice"
+    _identifiers = ("location", "name")
+    _attributes = ("tags", "primary_address", "platform", "device_type", "status", "description", "position", "serial_number", "rack_face")
+    status: str | None = "active"
+    name: str
+    description: str | None = None
+    position: int | None = None
+    serial_number: str | None = None
+    rack_face: str | None = "front"
+    tags: list[str] | None = []
+    primary_address: str | None = None
+    platform: str | None = None
+    device_type: str | None = None
+    location: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfacePhysical(_ModelBaseClass):
+    _modelname = "InterfacePhysical"
+    _identifiers = ("device", "name")
+    _attributes = ("bundle", "ip_addresses", "description", "mtu", "mac_address", "l2_mode")
+    name: str
+    description: str | None = None
+    mtu: int | None = 1500
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    bundle: str | None = None
+    device: str
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfaceVirtual(_ModelBaseClass):
+    _modelname = "InterfaceVirtual"
+    _identifiers = ("device", "name")
+    _attributes = ("untagged_vlan", "tagged_vlan", "ip_addresses", "description", "mac_address", "l2_mode")
+    name: str
+    description: str | None = None
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    device: str
+    untagged_vlan: str | None = None
+    tagged_vlan: list[str] | None = []
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamPrefix(_ModelBaseClass):
+    _modelname = "IpamPrefix"
+    _identifiers = ("prefix", "vrf")
+    _attributes = ("status", "description", "member_type")
+    status: str | None = "active"
+    description: str | None = None
+    member_type: str | None = "address"
+    prefix: str
+    vrf: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamIPAddress(_ModelBaseClass):
+    _modelname = "IpamIPAddress"
+    _identifiers = ("address", "vrf")
+    _attributes = ("description", "status")
+    description: str | None = None
+    status: str | None = "active"
+    address: str
+    vrf: str | None = None
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamAggregate(_ModelBaseClass):
+    _modelname = "IpamAggregate"
+    _identifiers = ("prefix",)
+    _attributes = ("rir", "description", "date_added")
+    description: str | None = None
+    date_added: str | None = None
+    prefix: str
+    rir: str
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class OrganizationRIR(_ModelBaseClass):
+    _modelname = "OrganizationRIR"
+    _identifiers = ("name",)
+    _attributes = ("tags", "private", "description")
+    private: bool | None = False
+    name: str
+    description: str | None = None
+    tags: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class InterfaceLag(_ModelBaseClass):
+    _modelname = "InterfaceLag"
+    _identifiers = ("device", "name")
+    _attributes = ("untagged_vlan", "tagged_vlan", "ip_addresses", "description", "mac_address", "l2_mode", "bundle_number")
+    name: str
+    description: str | None = None
+    mac_address: str | None = None
+    l2_mode: str | None = None
+    bundle_number: int
+    device: str
+    untagged_vlan: str | None = None
+    tagged_vlan: list[str] | None = []
+    ip_addresses: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class LocationSite(_ModelBaseClass):
+    _modelname = "LocationSite"
+    _identifiers = ("name",)
+    _attributes = ("tags", "status", "facility", "physical_address", "timezone", "description")
+    status: str | None = "active"
+    facility: str | None = None
+    physical_address: str | None = None
+    timezone: str | None = None
+    name: str
+    description: str | None = None
+    tags: list[str] | None = []
+
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class OrganizationManufacturer(_ModelBaseClass):
+    _modelname = "OrganizationManufacturer"
     _identifiers = ("name",)
     _attributes = ("tags", "description")
-    description: str | None = None
     name: str
-    tags: list[str] | None = []
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class ChoiceDeviceType(_ModelBaseClass):
-    _modelname = "ChoiceDeviceType"
-    _identifiers = ("name", "manufacturer")
-    _attributes = ("tags", "height", "full_depth", "part_number")
-    height: int | None = None
-    full_depth: bool | None = None
-    part_number: str | None = None
-    name: str
-    manufacturer: str
-    tags: list[str] | None = []
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraCircuit(_ModelBaseClass):
-    _modelname = "InfraCircuit"
-    _identifiers = ("circuit_id",)
-    _attributes = ("tags", "type", "provider", "vendor_id", "description")
-    circuit_id: str
-    vendor_id: str | None = None
     description: str | None = None
     tags: list[str] | None = []
-    type: str
-    provider: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraDevice(_ModelBaseClass):
-    _modelname = "InfraDevice"
-    _identifiers = ("location", "rack", "organization", "name")
-    _attributes = ("model", "role", "tags", "serial_number", "description", "asset_tag")
-    name: str | None = None
-    serial_number: str | None = None
-    description: str | None = None
-    asset_tag: str | None = None
-    model: str
-    rack: str | None = None
-    role: str | None = None
-    tags: list[str] | None = []
-    location: str
-    organization: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraIPAddress(_ModelBaseClass):
-    _modelname = "InfraIPAddress"
-    _identifiers = ("address", "vrf")
-    _attributes = ("organization", "description")
-    address: str
-    description: str | None = None
-    organization: str | None = None
-    vrf: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraInterfaceL2L3(_ModelBaseClass):
-    _modelname = "InfraInterfaceL2L3"
-    _identifiers = ("device", "name")
-    _attributes = ("tagged_vlan", "tags", "l2_mode", "mac_address", "description", "interface_type", "mgmt_only")
-    l2_mode: str | None = None
-    mac_address: str | None = None
-    description: str | None = None
-    interface_type: str | None = None
-    mgmt_only: bool | None = False
-    name: str
-    tagged_vlan: list[str] | None = []
-    untagged_vlan: str | None = None
-    tags: list[str] | None = []
-    device: str
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraPrefix(_ModelBaseClass):
-    _modelname = "InfraPrefix"
-    _identifiers = ("prefix", "vrf")
-    _attributes = ("role", "organization", "location", "description")
-    prefix: str
-    description: str | None = None
-    role: str | None = None
-    organization: str | None = None
-    location: str | None = None
-    vrf: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraProviderNetwork(_ModelBaseClass):
-    _modelname = "InfraProviderNetwork"
+class OrganizationProvider(_ModelBaseClass):
+    _modelname = "OrganizationProvider"
     _identifiers = ("name",)
-    _attributes = ("provider", "tags", "vendor_id", "description")
-    vendor_id: str | None = None
+    _attributes = ("tags", "description")
     name: str
     description: str | None = None
-    provider: str
     tags: list[str] | None = []
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraRack(_ModelBaseClass):
-    _modelname = "InfraRack"
-    _identifiers = ("name", "location")
-    _attributes = ("tags", "role", "asset_tag", "facility_id", "height", "serial_number")
-    asset_tag: str | None = None
-    facility_id: str | None = None
-    height: int | None = None
+class LocationRack(_ModelBaseClass):
+    _modelname = "LocationRack"
+    _identifiers = ("name", "site")
+    _attributes = ("tags", "facility", "status", "height", "serial_number", "asset_tag")
     name: str
+    facility: str | None = None
+    status: str | None = "active"
+    height: int | None = 42
     serial_number: str | None = None
+    asset_tag: str | None = None
+    site: str
     tags: list[str] | None = []
-    role: str | None = None
-    location: str
 
     local_id: str | None = None
     local_data: Any | None = None
 
+class IpamVLAN(_ModelBaseClass):
+    _modelname = "IpamVLAN"
+    _identifiers = ("name", "vlan_id", "vlan_group")
+    _attributes = ("description", "status")
+    name: str
+    description: str | None = None
+    vlan_id: int
+    status: str | None = "active"
+    vlan_group: str
 
-class InfraRouteTarget(_ModelBaseClass):
-    _modelname = "InfraRouteTarget"
-    _identifiers = ("name", "organization")
+    local_id: str | None = None
+    local_data: Any | None = None
+
+class IpamVLANGroup(_ModelBaseClass):
+    _modelname = "IpamVLANGroup"
+    _identifiers = ("name",)
     _attributes = ("description",)
     name: str
     description: str | None = None
-    organization: str | None = None
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class InfraVLAN(_ModelBaseClass):
-    _modelname = "InfraVLAN"
-    _identifiers = ("name", "vlan_id", "location", "vlan_group")
-    _attributes = ("organization", "description")
-    description: str | None = None
-    name: str
-    vlan_id: int
-    vlan_group: str | None = None
-    organization: str | None = None
-    location: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class InfraVRF(_ModelBaseClass):
-    _modelname = "InfraVRF"
+class IpamVRF(_ModelBaseClass):
+    _modelname = "IpamVRF"
     _identifiers = ("name",)
-    _attributes = ("export_rt", "organization", "import_rt", "description", "vrf_rd")
-    description: str | None = None
+    _attributes = ("import_rt", "export_rt", "vrf_rd", "enforce_unique", "description")
+    name: str
     vrf_rd: str | None = None
-    name: str
-    export_rt: list[str] | None = []
-    organization: str | None = None
+    enforce_unique: bool | None = True
+    description: str | None = None
     import_rt: list[str] | None = []
+    export_rt: list[str] | None = []
 
     local_id: str | None = None
     local_data: Any | None = None
 
-
-class LocationGeneric(_ModelBaseClass):
-    _modelname = "LocationGeneric"
-    _identifiers = ("name",)
-    _attributes = ("organization", "tags", "group", "description", "type")
-    description: str | None = None
-    type: str
-    name: str
-    organization: str | None = None
-    tags: list[str] | None = []
-    group: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class OrganizationGeneric(_ModelBaseClass):
-    _modelname = "OrganizationGeneric"
-    _identifiers = ("name",)
-    _attributes = ("group", "description")
-    description: str | None = None
-    name: str
-    group: str | None = None
-
-    local_id: str | None = None
-    local_data: Any | None = None
-
-
-class RoleGeneric(_ModelBaseClass):
-    _modelname = "RoleGeneric"
+class IpamRouteTarget(_ModelBaseClass):
+    _modelname = "IpamRouteTarget"
     _identifiers = ("name",)
     _attributes = ("description",)
     name: str


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the NetBox-to-Infrahub tutorial to retrieve the schema collection from the Infrahub Marketplace.
  - Added verification steps for the downloaded schema files.
  - Clarified that schema loading scans the schemas directory recursively.

- **Bug Fixes**
  - Corrected destination field names in the NetBox-to-Infrahub mapping configuration.
  - Updated the example synchronization models and mappings to align with the current schema, covering devices, interfaces, IPAM, locations, and organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->