### PR TITLE
Wait through an identity refresh instead of refusing the submission

### DIFF
--- a/changelog/+worker-identity-refresh-wait.fixed.md
+++ b/changelog/+worker-identity-refresh-wait.fixed.md
@@ -1,0 +1,9 @@
+Fixed the service worker refusing a flow run that arrived while a routine identity
+heartbeat was in progress. Prefect has already proposed `Submitting` by the time the
+worker starts the child, so a refusal in that window marked the run `Crashed` for a worker
+replacement that never happened — a submission valid immediately before the heartbeat and
+valid immediately after it was rejected during it, with no wait and no recheck. A
+submission that meets a refresh now waits for it on the lock the refresh already holds,
+then revalidates against the identity the refresh left. Refusal is now reserved for an
+identity that really did change: no resolved record, a moved identity generation, or a
+child environment naming a different worker.

--- a/changelog/+worker-identity-refresh-wait.fixed.md
+++ b/changelog/+worker-identity-refresh-wait.fixed.md
@@ -7,3 +7,6 @@ submission that meets a refresh now waits for it on the lock the refresh already
 then revalidates against the identity the refresh left. Refusal is now reserved for an
 identity that really did change: no resolved record, a moved identity generation, or a
 child environment naming a different worker.
+
+The deployment's object store is now pulled from the publisher's Quay location,
+`quay.io/minio/minio`, at the same tag and digest it was already pinned to.

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -90,7 +90,7 @@ services:
 
   object-store:
     image: >-
-      minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
+      quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e
     labels: *instance-labels
     restart: unless-stopped
     command: ["server", "/data"]

--- a/development/docker-compose.preview.yml
+++ b/development/docker-compose.preview.yml
@@ -25,7 +25,7 @@ services:
       retries: 20
 
   sync-minio:
-    image: "minio/minio:RELEASE.2025-04-22T22-12-26Z"
+    image: "quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z"
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: "${PREVIEW_MINIO_ACCESS_KEY:-minioadmin}"

--- a/development/docker-compose.preview.yml
+++ b/development/docker-compose.preview.yml
@@ -39,7 +39,7 @@ services:
       retries: 20
 
   sync-minio-bootstrap:
-    image: "minio/mc:RELEASE.2025-04-16T18-13-26Z"
+    image: "quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z"
     depends_on:
       sync-minio:
         condition: service_healthy

--- a/infrahub_sync/service/worker.py
+++ b/infrahub_sync/service/worker.py
@@ -280,10 +280,15 @@ class ServiceProcessWorker(ProcessWorker):
     def _validate_child_identity(self, configuration: ProcessJobConfiguration) -> None:
         if not isinstance(configuration, ServiceProcessJobConfiguration):
             raise ServiceWorkerIdentityError(_IDENTITY_ERROR)
+        # Only identity facts belong here. The two refresh flags are lock state:
+        # `_identity_refresh_active` is set and cleared inside `_identity_lock`,
+        # so it is always false for this caller, and a non-zero
+        # `_identity_refresh_requests` says a heartbeat is queued -- which
+        # cannot change anything until we release, and says nothing about
+        # whether the identity we hold right now is the one we hold. Treating
+        # either as invalidating refused children whose identity was current.
         if (
-            self._identity_refresh_requests
-            or self._identity_refresh_active
-            or self.backend_id is None
+            self.backend_id is None
             or configuration._identity_generation != self._identity_generation
             or configuration.env.get("PREFECT__WORKER_ID") != str(self.backend_id)
         ):
@@ -295,9 +300,14 @@ class ServiceProcessWorker(ProcessWorker):
         configuration: ProcessJobConfiguration,
         task_status: TaskStatus[int] | None = None,
     ) -> ProcessWorkerResult:
-        """Start a child only while its prepared identity generation is current."""
-        if self._identity_refresh_requests or self._identity_refresh_active:
-            raise ServiceWorkerIdentityError(_IDENTITY_ERROR)
+        """Start a child once its prepared identity is confirmed still current."""
+        # Waiting is the deferral. A refresh owns `_identity_lock` for its whole
+        # window, so acquiring it holds this submission until the refresh has
+        # finished and then revalidates against whatever it left. Refusing here
+        # instead refused a submission that was valid immediately before and
+        # immediately after, with no wait and no revalidation -- and Prefect had
+        # already proposed Submitting, so the run was marked Crashed for a
+        # replacement that never happened.
         await self._identity_lock.acquire()
         effective_status: TaskStatus[int] = task_status if task_status is not None else anyio.TASK_STATUS_IGNORED
         lease = _IdentityLeaseTaskStatus(effective_status, self._identity_lock)

--- a/tests/service/test_service_worker.py
+++ b/tests/service/test_service_worker.py
@@ -277,9 +277,12 @@ async def test_polling_submission_refuses_when_refresh_changes_identity_to_none(
     await refresh_cleared_identity.wait()
     assert worker.backend_id is None
 
+    # Both releases precede the await: the submission now waits on the identity
+    # lock this paused refresh holds, so releasing the poll alone would leave the
+    # poll waiting on a refresh that is itself waiting to be released.
     release_poll.set()
-    results = await poll_task
     release_refresh.set()
+    results = await poll_task
     await refresh_task
 
     assert len(results) == 1

--- a/tests/service/test_service_worker_identity_recovery.py
+++ b/tests/service/test_service_worker_identity_recovery.py
@@ -6,18 +6,27 @@ even when it re-resolved the very same worker record, which crashed whatever
 submission was in flight; and a single unresolvable read raised out of the sync,
 which escaped Prefect's `critical_service_loop` and ended the worker process.
 
+A third shares it: a submission that arrived while a heartbeat was in progress
+was refused outright, with no wait and no recheck, even though the identity it
+carried was the one still installed once the heartbeat finished.
+
 Detection was never the problem — absent, stale and mismatched identity are all
 correctly refused. What these cases pin is the consequence: refuse to execute,
-stay alive, and resolve again on a later heartbeat.
+stay alive, resolve again on a later heartbeat, and wait through a refresh
+rather than fail inside it.
 
 Everything here runs against a real temporary Prefect server with the real
 client, a real work pool and the real worker. Nothing on the identity path is
-stubbed, because both defects were invisible to stubs: the previous suite
-asserted the refusals with a fake client and passed throughout.
+stubbed, because these defects were invisible to stubs: the previous suite
+asserted the refusals with a fake client and passed throughout. The only thing
+stood in for is the child process itself, so that reaching the start is
+observable without spawning one.
 """
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID, uuid4
 
@@ -121,6 +130,84 @@ def fail_reads_once(worker: ServiceProcessWorker) -> None:
         return cast("list[object]", await real(self))
 
     worker._read_worker_records = cast("Any", _read)  # type: ignore[method-assign]
+
+
+def pause_the_next_refresh(
+    worker: ServiceProcessWorker,
+    *,
+    reissue: UUID | None = None,
+) -> tuple[asyncio.Event, asyncio.Event]:
+    """Hold the next real refresh open while it owns the identity lock.
+
+    The pause is injected at the client boundary the refresh already reads
+    through, so what waits is the real `sync_with_backend` holding the real
+    lock. Nothing here assigns the private refresh flags: a test that sets them
+    by hand would prove only what it staged. `reissue` substitutes the
+    identifier on every record read afterwards, which is what a replacement
+    looks like to this worker.
+    """
+    real = ServiceProcessWorker._read_worker_records
+    holding = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _read(self: ServiceProcessWorker = worker) -> list[Any]:
+        if not holding.is_set():
+            holding.set()
+            await release.wait()
+        records = cast("list[Any]", await real(self))
+        if reissue is None:
+            return records
+        return [record.model_copy(update={"id": reissue}) for record in records]
+
+    worker._read_worker_records = cast("Any", _read)  # type: ignore[method-assign]
+    return holding, release
+
+
+class _StubRunner:
+    """Stand in for the child process, and count the starts that were reached."""
+
+    def __init__(self) -> None:
+        self.starts: list[dict[str, str | None]] = []
+
+    async def execute_flow_run(self, **kwargs: Any) -> SimpleNamespace:  # noqa: ANN401 - pinned Prefect runner shape.
+        self.starts.append(kwargs["env"])
+        kwargs["task_status"].started(42)
+        return SimpleNamespace(returncode=0, pid=42)
+
+
+def stub_child_start(worker: ServiceProcessWorker) -> _StubRunner:
+    """Keep the child unspawned, so a start is observable without running one."""
+    runner = _StubRunner()
+    worker._runner = cast("Any", runner)
+    return runner
+
+
+def a_flow_run() -> Any:  # noqa: ANN401 - Prefect reads only the identifier here.
+    """A flow run that carries what `ProcessWorker.run` actually reads."""
+    return SimpleNamespace(id=uuid4(), name="service-run", deployment_id=None, job_variables={})
+
+
+async def waiting_submission(
+    worker: ServiceProcessWorker,
+    configuration: ServiceProcessJobConfiguration,
+) -> asyncio.Task[Any]:
+    """Start a submission and return once it has reached the identity lock.
+
+    The event is set immediately before `run` is entered, so when this returns
+    the submission has run to its first suspension point. With the lock held by
+    a paused refresh that point is the acquire, which is what makes
+    `task.done()` a real question rather than a race: a submission that refused
+    without waiting has already finished by now.
+    """
+    entered = asyncio.Event()
+
+    async def _submit() -> Any:  # noqa: ANN401 - mirrors `run`'s Prefect result type.
+        entered.set()
+        return await worker.run(a_flow_run(), configuration)
+
+    task = asyncio.create_task(_submit())
+    await entered.wait()
+    return task
 
 
 async def test_a_heartbeat_that_resolves_the_same_record_keeps_a_submission_valid(
@@ -350,3 +437,207 @@ async def test_a_child_carrying_another_identity_is_refused(worker: ServiceProce
         foreign.env = {"PREFECT__WORKER_ID": str(uuid4())}
 
         assert not accepted(worker, foreign), "a child carrying another worker's identity was accepted"
+
+
+async def test_a_submission_that_meets_a_refresh_waits_through_it_and_starts(
+    worker: ServiceProcessWorker,
+) -> None:
+    """The repair. A submission valid before and after a refresh is valid during it.
+
+    The recorded failure is a refusal with no wait and no revalidation: Prefect
+    has already proposed `Submitting` by the time `run` is reached, so refusing
+    inside a window that changes nothing marks the run `Crashed` for a
+    replacement that never happened. `_submission_generation` already defers for
+    the identical condition, so the two policies disagreed and this is the one
+    that has to give.
+
+    `task.done()` before the release is the whole assertion: a submission that
+    refused instead of waiting has already finished at that point.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+        configuration = prepared(worker)
+        first = worker.backend_id
+
+        before = await worker.run(a_flow_run(), prepared(worker))
+
+        holding, release = pause_the_next_refresh(worker)
+        refresh = asyncio.create_task(worker.sync_with_backend())
+        await holding.wait()
+        during = await waiting_submission(worker, configuration)
+
+        assert not during.done(), "the submission refused inside the refresh instead of waiting for it"
+        assert len(runner.starts) == 1, "a child started while the refresh held the identity lock"
+
+        release.set()
+        result = await during
+        await refresh
+
+        after = await worker.run(a_flow_run(), prepared(worker))
+
+        assert worker.backend_id == first, "the refresh resolved a different record, so this proves nothing"
+        assert before.status_code == 0
+        assert result.status_code == 0, "the submission that waited did not start its child"
+        assert after.status_code == 0
+        assert len(runner.starts) == 3, "before, during and after did not each start exactly one child"
+
+
+async def test_a_replacement_during_the_wait_still_refuses_the_stale_submission(
+    worker: ServiceProcessWorker,
+) -> None:
+    """Waiting must not become forgiving. What waited is revalidated, not admitted.
+
+    The submission here waits through exactly the same window as the case
+    above; the only difference is that the record really is reissued, so the
+    generation the configuration was stamped with no longer matches and the
+    worker id it would hand the child names an identity this worker no longer
+    holds. Either surviving check is enough on its own.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+        stale = prepared(worker)
+        first = worker.backend_id
+        reissued = uuid4()
+
+        holding, release = pause_the_next_refresh(worker, reissue=reissued)
+        refresh = asyncio.create_task(worker.sync_with_backend())
+        await holding.wait()
+        submission = await waiting_submission(worker, stale)
+
+        assert not submission.done(), "the submission did not wait for the refresh"
+
+        release.set()
+        with pytest.raises(ServiceWorkerIdentityError):
+            await submission
+        await refresh
+
+        assert first is not None
+        assert worker.backend_id == reissued, "the reissued identifier was not installed"
+        assert worker.backend_id != first, "the identity did not change, so this proves nothing"
+        assert runner.starts == [], "a child was started for a superseded identity"
+
+
+async def test_refreshes_queued_behind_the_wait_do_not_admit_a_stale_submission(
+    worker: ServiceProcessWorker,
+) -> None:
+    """Several heartbeats can stack up behind one wait; the last one still decides.
+
+    A queued refresh is counted before it owns the lock, so the counter says
+    only that a heartbeat is pending. That is why it cannot be a validity term.
+    What has to hold instead is that every queued refresh completes before the
+    waiting submission is validated, so the identity it is checked against is
+    the one actually installed at the end.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+        stale = prepared(worker)
+        reissued = uuid4()
+
+        holding, release = pause_the_next_refresh(worker, reissue=reissued)
+        first = asyncio.create_task(worker.sync_with_backend())
+        await holding.wait()
+        queued = [asyncio.create_task(worker.sync_with_backend()) for _ in range(2)]
+        submission = await waiting_submission(worker, stale)
+
+        release.set()
+        with pytest.raises(ServiceWorkerIdentityError):
+            await submission
+        await asyncio.gather(first, *queued)
+
+        assert worker.backend_id == reissued
+        assert runner.starts == [], "a stale configuration was admitted while refreshes were queued"
+
+
+async def test_a_queued_refresh_alone_does_not_refuse_a_current_submission(
+    worker: ServiceProcessWorker,
+) -> None:
+    """A pending heartbeat is not a changed identity, and must not read as one.
+
+    This is the defect in its smallest form. The refreshes here all re-resolve
+    the same record, so nothing about the identity moves; only the pending
+    count does.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+        configuration = prepared(worker)
+        first = worker.backend_id
+
+        holding, release = pause_the_next_refresh(worker)
+        held = asyncio.create_task(worker.sync_with_backend())
+        await holding.wait()
+        queued = [asyncio.create_task(worker.sync_with_backend()) for _ in range(2)]
+        submission = await waiting_submission(worker, configuration)
+
+        release.set()
+        result = await submission
+        await asyncio.gather(held, *queued)
+
+        assert worker.backend_id == first, "the heartbeats resolved a different record"
+        assert result.status_code == 0
+        assert len(runner.starts) == 1, "the submission was refused for a heartbeat that changed nothing"
+
+
+async def test_a_submission_cancelled_while_waiting_leaves_no_lease_held(
+    worker: ServiceProcessWorker,
+) -> None:
+    """Waiting introduces a cancellation point, so the lock must survive one.
+
+    Prefect cancels submissions on shutdown. A cancelled wait that left the
+    identity lock held would deadlock every later submission and every later
+    heartbeat, which is a worse failure than the one being repaired. Asserted on
+    the lock and on a later submission rather than on the lease, so it is the
+    observable state that is pinned.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+
+        holding, release = pause_the_next_refresh(worker)
+        refresh = asyncio.create_task(worker.sync_with_backend())
+        await holding.wait()
+        submission = await waiting_submission(worker, prepared(worker))
+        submission.cancel()
+
+        release.set()
+        await refresh
+        with pytest.raises(asyncio.CancelledError):
+            await submission
+
+        assert not worker._identity_lock.locked(), "a cancelled wait left the identity lock held"
+        assert runner.starts == [], "a cancelled submission started a child"
+
+        result = await worker.run(a_flow_run(), prepared(worker))
+
+        assert result.status_code == 0, "a later submission could not proceed after the cancelled wait"
+        assert len(runner.starts) == 1
+
+
+async def test_no_child_is_started_before_the_identity_is_validated(
+    worker: ServiceProcessWorker,
+) -> None:
+    """Validation is a gate on starting a process, not a report made afterwards.
+
+    Stated as an event order rather than a return value: a refused submission
+    must leave the runner untouched, and the same runner must record exactly one
+    start once a configuration the worker really did prepare is submitted.
+    """
+    async with worker:
+        await worker.sync_with_backend()
+        runner = stub_child_start(worker)
+        foreign = worker.job_configuration()
+        foreign._identity_generation = worker._identity_generation
+        foreign.env = {"PREFECT__WORKER_ID": str(uuid4())}
+
+        with pytest.raises(ServiceWorkerIdentityError):
+            await worker.run(a_flow_run(), foreign)
+
+        assert runner.starts == [], "a child process was started for a configuration that was refused"
+
+        result = await worker.run(a_flow_run(), prepared(worker))
+
+        assert result.status_code == 0
+        assert len(runner.starts) == 1, "the accepted submission did not start exactly one child"

--- a/tests/service/test_service_worker_identity_recovery.py
+++ b/tests/service/test_service_worker_identity_recovery.py
@@ -210,6 +210,27 @@ async def waiting_submission(
     return task
 
 
+async def queued_refresh(worker: ServiceProcessWorker) -> asyncio.Task[None]:
+    """Start a refresh and return once it is counted and waiting for the lock.
+
+    Ordering here decides what a test proves, so it is established rather than
+    assumed: `sync_with_backend` increments the pending count before it asks for
+    the lock, and `Event.set` does not yield, so when this returns the refresh
+    has been counted and has parked at the acquire behind whoever is already
+    queued. Relying on the order `create_task` happens to schedule in would
+    leave the same test passing for the wrong reason.
+    """
+    entered = asyncio.Event()
+
+    async def _refresh() -> None:
+        entered.set()
+        await worker.sync_with_backend()
+
+    task = asyncio.create_task(_refresh())
+    await entered.wait()
+    return task
+
+
 async def test_a_heartbeat_that_resolves_the_same_record_keeps_a_submission_valid(
     worker: ServiceProcessWorker,
 ) -> None:
@@ -526,9 +547,9 @@ async def test_refreshes_queued_behind_the_wait_do_not_admit_a_stale_submission(
 
     A queued refresh is counted before it owns the lock, so the counter says
     only that a heartbeat is pending. That is why it cannot be a validity term.
-    What has to hold instead is that every queued refresh completes before the
-    waiting submission is validated, so the identity it is checked against is
-    the one actually installed at the end.
+    What has to hold instead is that the identity the waiting submission is
+    checked against is the one installed by the refreshes that finished ahead of
+    it.
     """
     async with worker:
         await worker.sync_with_backend()
@@ -556,9 +577,16 @@ async def test_a_queued_refresh_alone_does_not_refuse_a_current_submission(
 ) -> None:
     """A pending heartbeat is not a changed identity, and must not read as one.
 
-    This is the defect in its smallest form. The refreshes here all re-resolve
-    the same record, so nothing about the identity moves; only the pending
-    count does.
+    This is the defect in its smallest form, and the one case that discriminates
+    the pending count as a validity term. The submission is parked at the lock
+    *before* the other refreshes are queued, so the lock hands it over while
+    those refreshes are counted and still waiting: it is validated with the
+    count non-zero and the identity unchanged. Queue them ahead of it instead
+    and each one decrements as it releases, so the count is back to zero by the
+    time validation runs and the test passes either way.
+
+    The refreshes all re-resolve the same record, so nothing about the identity
+    moves; only the pending count does.
     """
     async with worker:
         await worker.sync_with_backend()
@@ -569,8 +597,13 @@ async def test_a_queued_refresh_alone_does_not_refuse_a_current_submission(
         holding, release = pause_the_next_refresh(worker)
         held = asyncio.create_task(worker.sync_with_backend())
         await holding.wait()
-        queued = [asyncio.create_task(worker.sync_with_backend()) for _ in range(2)]
         submission = await waiting_submission(worker, configuration)
+        queued = [await queued_refresh(worker) for _ in range(2)]
+
+        # Read-only, and the premise of the case: the refresh holding the lock
+        # plus the two queued behind the submission. Staging this by hand would
+        # prove only what was staged, so it is asserted, not assigned.
+        assert worker._identity_refresh_requests >= 3, "the queued refreshes were not counted before the handover"
 
         release.set()
         result = await submission


### PR DESCRIPTION
## Problem

The service worker refused a flow run that arrived while a routine identity heartbeat was in
progress. Prefect has already proposed `Submitting` by the time the worker starts the child, so a
refusal in that window marked the run `Crashed` for a worker replacement that never happened. A
submission valid immediately before the heartbeat, and valid immediately after it, was rejected
*during* it — with no wait and no recheck.

`sync_with_backend` raises `_identity_refresh_requests` before it takes `_identity_lock` and lowers it
after releasing, and sets `_identity_refresh_active` inside the lock. `run()` refused on either flag
before acquiring, so every heartbeat opened a window in which an already-selected submission was
hard-failed.

## What changed

Two edits in `infrahub_sync/service/worker.py`; every other added line is a comment.

1. **`run()` waits instead of refusing.** The pre-lock raise is removed, so the call falls through to
   the pre-existing `await self._identity_lock.acquire()`. A refresh owns that lock for its whole
   window, so acquiring it holds the submission until the refresh has finished, and the existing
   `_validate_child_identity` call then revalidates against whatever the refresh left. Everything
   after the acquire is unchanged, including the identity lease and its `finally` release.
2. **`_validate_child_identity` checks identity, not lock state.** The two refresh-flag terms are
   removed. `_identity_refresh_active` is set and cleared inside the lock by its only writer, so it is
   always false for that caller; a non-zero `_identity_refresh_requests` only means a heartbeat is
   *queued*, which cannot change anything until we release and says nothing about whether the identity
   we hold is current. Refusal is now reserved for an identity that really did change: no resolved
   record, a moved identity generation, or a child environment naming a different worker.

`_submission_generation()` keeps both flag terms, so polling still defers while a refresh is queued
or active. The two policies now agree instead of disagreeing.

No timeout, retry, sleep, new lock, event, task, thread, configuration key, or abstraction is
introduced. The wait is cancellable: a cancel while awaiting the lock never acquires it, so no lease
is held and nothing leaks.

## Scope

Four files: `infrahub_sync/service/worker.py`, `tests/service/test_service_worker_identity_recovery.py`,
`tests/service/test_service_worker.py`, and one changelog fragment. `product_store/store.py`,
`service/service.py` and `service/liveness.py` are byte-identical to the base — that establishes the
**scope** of the diff. It is not a claim that no downstream behaviour can be affected; the
behavioural argument is the one above, and the tests below are what check it.

## Evidence mapping

| Obligation | Status |
| --- | --- |
| Changed-surface tests | `test_service_worker_identity_recovery.py` (17) + `test_service_worker.py` (14) = **31 passed**. Neither file carries an opt-in marker, so the hosted `tests` job executes all 31 on 3.10–3.13. |
| RED-first | 4 of the 6 new tests fail against the unmodified base worker. |
| Discriminating mutations | Restoring the request-count term fails exactly the queued-refresh test; restoring the pre-lock raise fails 4 tests; neutering the identity checks fails 8, including two pre-existing polling refusals; deleting the lease release hangs the suite. |
| `invoke format` / `invoke lint` | clean / **exit 0**, all legs. `ty`: 21 diagnostics, all pre-existing, none in the changed files. |
| CLI sanity | `--help`, `configs --help`, `runs --help` → exit 0 at this head **and** at the exact base. |
| **Full suite** | **NOT run locally** — it needs a shared Compose harness claim this unit does not hold. Covered by the hosted `tests` jobs on this PR, not by a local run. |
| **Real PostgreSQL (mandatory)** | **PASSED at this exact head.** Real PostgreSQL is a mandatory gate for this job in implementation and whole-diff review, and a skipped mandatory case is a failed gate — independently of whether any PG-backed test touches the changed lines. `test_apply_guard_integration.py` + `test_managed_write_guard_integration.py` → **15 collected, 15 passed, 0 skipped**. All 15 depend on a `dsn` fixture that skips unless a real `psycopg.connect` probe succeeds, and the bodies hold real advisory locks with subprocesses connecting through the database URL, so a pass is not possible without a live server. Fixture: fresh, uniquely named, unit-owned container with its own volume and network, a dynamically assigned loopback port, credentials in a `0600` file outside the repository and never printed; torn down afterwards with only owned resources removed and no prune. **Unchanged-layer regression evidence, not a worker-interleaving discriminator**: none of these files imports `infrahub_sync.service.worker`, so they cannot reach `run()` or `_validate_child_identity` and are not offered as if they could. |
| Real Prefect server (**not** PostgreSQL) | `test_service_prefect_idempotency.py` → **1 collected, 1 passed, 0 skipped**, exercising `PrefectOrchestration.submit` idempotency against a real temporary Prefect API server (`prefect_test_harness`, its own SQLite under a scoped `PREFECT_HOME`). It has **no DSN and no PostgreSQL dependency**, so it is listed separately and is **not** part of the PostgreSQL receipt. Also unchanged-layer regression evidence. |
The hosted `tests` job runs `-m "not integration"`, so its green is not integration coverage. The
mandatory real-PostgreSQL obligation is satisfied by the separate isolated run recorded above, not by
that job and not by treating its exclusions as coverage.

## What is proven, and what is not

**Proven deterministically, in-process against a real temporary Prefect server:** the forced
heartbeat interleaving. The tests park a submission on the lock held by a *real* paused
`sync_with_backend`, queue further heartbeats behind it, and assert that the submission waits, is
validated with the refresh count non-zero, and starts — and that a genuinely reissued record is still
refused with no child started. Synchronisation is named `asyncio.Event`s throughout; nothing sleeps,
and no test assigns the private flags.

**Not proven here — the real replacement lifecycle.** This change is qualified at the worker boundary
only, with the record identifier substituted at the client read seam. A real replacement worker with
a real child process is exercised solely by the hosted `image`/Compose job. That job does not *force*
the interleaving, so a green run is evidence that the real lifecycle works with the repair present —
**not** proof that the race is fixed. Those are separate claims and this PR does not merge them.

**One term is deliberately unpinned.** Restoring `_identity_refresh_active` alone to the validator
changes no test outcome, because no reachable state makes it differ for the locked caller. It is
unreachable dead code rather than untested behaviour, and pinning it would require assigning a private
flag, which the tests avoid on purpose.

One evidentiary limitation, recorded rather than glossed: pytest prints no commit, so the receipts
above corroborate the unit's own worktree but not the SHA directly. Every code path they exercise is
byte-identical from the base through this head — the unit's commits touch only `worker.py`, two test
modules and a changelog fragment — so any head on this branch yields the same receipt.

Local acceptance is complete, including the mandatory real-PostgreSQL run recorded above. The full
suite and the replacement-lifecycle qualification remain **pending on this PR's own hosted gates**.

## Registry location (folded into this PR)

Two commits on top of the behavioral fix move the MinIO images to the publisher's Quay location,
because `minio/minio` and `minio/mc` were both refused for anonymous pulls on Docker Hub while
library controls succeeded — this branch's `image` job failed on `pull access denied for
minio/minio`. That is a repository-specific anonymous refusal observed at probe time, not a claim
about publisher intent or permanence.

`b245de6..86d95e7` is **3 files, +6/-3**, with zero Python bytes changed:

- `deploy/compose/compose.yaml` — object store, `quay.io/` prefix only; tag and manifest-list digest
  `a1ea29fa…015e` byte-identical, so this is the same image content by digest.
- `development/docker-compose.preview.yml` — `sync-minio` and `sync-minio-bootstrap`, `quay.io/`
  prefix only, tags byte-identical. Both lines were tag-only and **no digest was added**, so no
  byte-identity claim is made for either preview line.
- `changelog/+worker-identity-refresh-wait.fixed.md` — one clause covering the deployment's object
  store. No `mc` clause: the preview file is the developer path, not the shipped bundle.

**Correction to the `86d95e7` commit message.** It remarks that the publisher's documentation for
`minio/mc` names Docker Hub only. That is README-scoped and understates the publisher record: MinIO's
release build pushes `quay.io/minio/mc:${release}` in the same buildx invocation as its Docker Hub
tags ([docker-buildx.sh](https://github.com/minio/mc/blob/master/docker-buildx.sh#L27-L39)), and
MinIO's own Helm chart defaults `mcImage.repository` to `quay.io/minio/mc`
([values.yaml](https://github.com/minio/minio/blob/master/helm/minio/values.yaml#L26-L28)). The
commit cannot be amended, so the correction is recorded here. It runs in the safe direction: the
message claims less publisher support than exists and asserts nothing about image content.

Validation: `yamllint` exit 0; `invoke lint` passed with the same 21 pre-existing `ty` diagnostics.
The Python suites were not re-run because no Python bytes changed and no suite opens either YAML
file. The N=3 behavioral ship receipt stays bound to `b245de6`; the registry extension carries a
bounded single-reviewer check at `86d95e7`, which is not a second N=3 judgment. The `mc` line is not
exercised by the hosted `image`/Compose gate — that fixture starts only `infrahub-server` and
`task-worker` — so its validation is the next `invoke preview.up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Flow submissions arriving during a worker identity refresh now wait for the refresh to complete and are revalidated before starting.
  - Valid submissions are no longer incorrectly marked as crashed during routine identity heartbeats.
  - Submissions are still refused when the worker identity genuinely changes or becomes invalid.
  - Cancellation while waiting for identity validation now completes cleanly.

- **Infrastructure**
  - Deployment configurations now pull the pinned object-store image from Quay.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->