### PR TITLE
chore: set private candidate version to 3.0.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-sync"
-version = "3.0.0a1"
+version = "3.0.0a2"
 description = "Infrahub-Sync is a versatile Python package that synchronizes data between a source and a destination system"
 authors = [{ name = "OpsMill", email = "info@opsmill.com" }]
 readme = "README.md"

--- a/tests/release/test_identity.py
+++ b/tests/release/test_identity.py
@@ -21,7 +21,7 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 # The selected V3 MVP identity. It appears here and in the package metadata; every
 # artifact name below is derived rather than written down a second time.
-VERSION = "3.0.0a1"
+VERSION = "3.0.0a2"
 
 COMMIT = "708a8fca4b3fe300ae33242ddcd791a181926eeb"
 # The two forms Git writes for a commit's own timestamp: a numeric offset, and
@@ -129,7 +129,7 @@ def test_the_declared_identity_is_read_from_the_installed_distribution() -> None
     assert (derived.revision, derived.created) == (COMMIT, COMMIT_TIME)
 
 
-@pytest.mark.parametrize("declared", ["2.0.1", "3.0.0", "v3.0.0a1", "3.0.0a2", " 3.0.0a1", ""])
+@pytest.mark.parametrize("declared", ["2.0.1", "3.0.0", "v3.0.0a2", "3.0.0a1", " 3.0.0a2", ""])
 def test_a_declared_version_that_contradicts_the_source_is_refused(declared: str) -> None:
     """An accepted mismatch would let the caller, not the source, name the artifacts."""
     with pytest.raises(release.ReleaseTaskError, match="is not the source's"):
@@ -224,9 +224,9 @@ def test_the_dry_run_accepts_the_distributions_the_identity_names(
 @pytest.mark.parametrize(
     "produced",
     [
-        ("infrahub_sync-3.0.0a2-py3-none-any.whl", "infrahub_sync-3.0.0a2.tar.gz"),
-        ("infrahub_sync-3.0.0a1-py3-none-any.whl",),
-        ("infrahub-sync-3.0.0a1-py3-none-any.whl", "infrahub_sync-3.0.0a1.tar.gz"),
+        ("infrahub_sync-3.0.0a1-py3-none-any.whl", "infrahub_sync-3.0.0a1.tar.gz"),
+        ("infrahub_sync-3.0.0a2-py3-none-any.whl",),
+        ("infrahub-sync-3.0.0a2-py3-none-any.whl", "infrahub_sync-3.0.0a2.tar.gz"),
     ],
 )
 def test_the_dry_run_refuses_a_distribution_the_identity_does_not_name(
@@ -235,7 +235,7 @@ def test_the_dry_run_refuses_a_distribution_the_identity_does_not_name(
     """A distribution named something else is one an upload would publish as this release."""
     _recorded(tmp_path, monkeypatch)
 
-    with pytest.raises(release.ReleaseTaskError, match=r"not the 3\.0\.0a1 distributions"):
+    with pytest.raises(release.ReleaseTaskError, match=r"not the 3\.0\.0a2 distributions"):
         release.build(StubContext(builds=produced))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ all = [
 
 [[package]]
 name = "infrahub-sync"
-version = "3.0.0a1"
+version = "3.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "diffsync" },


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Updated the package version to **3.0.0a2**.
- **Tests**
  - Updated release validation checks and expected package metadata to match version **3.0.0a2**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The private candidate metadata still identified the package as `3.0.0a1`. This updates the project declaration and synchronized root lock entry to `3.0.0a2`, and advances only the release-identity assertions coupled to the installed project version.

Before: `3.0.0a1`  
After: `3.0.0a2`

There is no runtime, dependency-graph, CLI, documentation, changelog, or build change.

## Verification

- `uv run invoke format`
- `uv run invoke lint`
- `uv run ruff check .`
- `uv run pytest -q tests/release/test_identity.py` — 43 passed
- `uv run pytest -q tests/service/test_compatibility.py` — 19 passed
- `uv lock --check`
- `uv run infrahub-sync --help`
- `uv run infrahub-sync configs --help`
- `uv run infrahub-sync runs --help`
- Release identity records `3.0.0a2` at exact commit `991d4e79a27b451f695cadd0a106b1707d7487d5`; a `3.0.0a1` request is refused.
- Fresh exact-head ship gate: PASS/PASS/PASS.

## Review notes

The lockfile differs only in the root package version. The identity rejection fixtures retain three separate defects: a complete wrong-version pair, a matching-version wheel-only set missing the sdist, and a matching-version wheel with the wrong distribution name.

No changelog fragment is consumed or added because this PR prepares the candidate metadata; release-note work remains separate.
